### PR TITLE
Add caching and fix N+1 queries for dashboard performance

### DIFF
--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -14,6 +14,10 @@ class ABSClient:
         # Configuration is now dynamic via properties (no caching)
         self.session = requests.Session()
         self.timeout = 30
+        # TTL cache for get_all_audiobooks() — avoids 1+N ABS requests on every dashboard load
+        self._audiobooks_cache = None
+        self._audiobooks_cache_time = 0
+        self._AUDIOBOOKS_CACHE_TTL = 300  # 5 minutes
 
     @property
     def base_url(self):
@@ -80,20 +84,41 @@ class ABSClient:
 
     def get_all_audiobooks(self):
         if not self.is_configured(): return []
+
+        # Return cached result if still fresh
+        now = time.time()
+        if self._audiobooks_cache is not None and (now - self._audiobooks_cache_time) < self._AUDIOBOOKS_CACHE_TTL:
+            return self._audiobooks_cache
+
         self._update_session_headers()
         lib_url = f"{self.base_url}/api/libraries"
         try:
             r = self.session.get(lib_url, timeout=self.timeout)
-            if r.status_code != 200: return []
+            if r.status_code != 200:
+                # Return stale cache on failure instead of empty list
+                if self._audiobooks_cache is not None:
+                    logger.warning("ABS library fetch failed, returning stale cache")
+                    return self._audiobooks_cache
+                return []
             libraries = r.json().get('libraries', [])
             all_audiobooks = []
             for lib in libraries:
                 r_items = self.get_audiobooks_for_lib(lib['id'])
                 all_audiobooks.extend(r_items)
+            self._audiobooks_cache = all_audiobooks
+            self._audiobooks_cache_time = time.time()
             return all_audiobooks
         except Exception as e:
             logger.error(f"Exception fetching audiobooks: {e}")
+            if self._audiobooks_cache is not None:
+                logger.warning("Returning stale audiobooks cache after exception")
+                return self._audiobooks_cache
             return []
+
+    def invalidate_audiobooks_cache(self):
+        """Clear the audiobooks cache so the next call fetches fresh data."""
+        self._audiobooks_cache = None
+        self._audiobooks_cache_time = 0
 
     def get_audiobooks_for_lib(self, lib: str):
         if not self.is_configured(): return []

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -20,10 +20,15 @@ def api_status():
     database_service = get_database_service()
     books = database_service.get_all_books()
 
+    # Bulk-fetch all states to avoid N+1 queries (one per book)
+    all_states = database_service.get_all_states()
+    states_by_book = {}
+    for state in all_states:
+        states_by_book.setdefault(state.abs_id, []).append(state)
+
     mappings = []
     for book in books:
-        states = database_service.get_states_for_book(book.abs_id)
-        state_by_client = {state.client_name: state for state in states}
+        state_by_client = {state.client_name: state for state in states_by_book.get(book.abs_id, [])}
 
         mapping = {
             'abs_id': book.abs_id,

--- a/src/blueprints/covers.py
+++ b/src/blueprints/covers.py
@@ -21,7 +21,9 @@ def serve_cover(filename):
     # 1. Check if file exists
     cover_path = COVERS_DIR / filename
     if cover_path.exists():
-        return send_from_directory(COVERS_DIR, filename)
+        resp = send_from_directory(COVERS_DIR, filename)
+        resp.headers['Cache-Control'] = 'public, max-age=86400, immutable'
+        return resp
 
     # 2. Try to extract
     database_service = get_database_service()
@@ -34,7 +36,9 @@ def serve_cover(filename):
             full_book_path = parser.resolve_book_path(book.ebook_filename)
 
             if parser.extract_cover(full_book_path, cover_path):
-                return send_from_directory(COVERS_DIR, filename)
+                resp = send_from_directory(COVERS_DIR, filename)
+                resp.headers['Cache-Control'] = 'public, max-age=86400, immutable'
+                return resp
         except Exception as e:
             logger.debug(f"Lazy cover extraction failed: {e}")
 
@@ -55,7 +59,9 @@ def proxy_cover(abs_id):
 
         req = requests.get(url, stream=True, timeout=10)
         if req.status_code == 200:
-            return Response(req.iter_content(chunk_size=1024), content_type=req.headers.get('content-type', 'image/jpeg'))
+            resp = Response(req.iter_content(chunk_size=1024), content_type=req.headers.get('content-type', 'image/jpeg'))
+            resp.headers['Cache-Control'] = 'public, max-age=86400, immutable'
+            return resp
         else:
             return "Cover not found", 404
     except Exception as e:
@@ -83,7 +89,9 @@ def proxy_booklore_cover(source_tag, book_id):
         url = f"{bl_client.base_url}/api/v1/books/{book_id}/cover"
         req = requests.get(url, headers={"Authorization": f"Bearer {token}"}, stream=True, timeout=10)
         if req.status_code == 200:
-            return Response(req.iter_content(chunk_size=1024), content_type=req.headers.get('content-type', 'image/jpeg'))
+            resp = Response(req.iter_content(chunk_size=1024), content_type=req.headers.get('content-type', 'image/jpeg'))
+            resp.headers['Cache-Control'] = 'public, max-age=86400, immutable'
+            return resp
         else:
             return "Cover not found", 404
     except Exception as e:

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -308,7 +308,7 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         )
 
         self.mock_database_service.get_all_books.return_value = [test_book]
-        self.mock_database_service.get_states_for_book.return_value = []
+        self.mock_database_service.get_all_states.return_value = []
 
         # Make HTTP request
         response = self.client.get('/api/status')


### PR DESCRIPTION
## Summary
- **ABS audiobook caching**: 5-minute TTL cache on `get_all_audiobooks()` to avoid 1+N ABS API requests on every dashboard load. Returns stale cache on failure instead of empty list.
- **N+1 query fix**: `/api/status` now bulk-fetches all sync states in one query instead of one per book.
- **Cover cache headers**: All cover endpoints return `Cache-Control: public, max-age=86400, immutable` so browsers cache images for 24 hours.

## Test plan
- [ ] Load dashboard — verify audiobook list loads correctly and subsequent loads are faster
- [ ] Confirm `/api/status` returns correct state data for all books
- [ ] Check browser devtools: cover image responses should have `Cache-Control` header
- [ ] Second page load should serve covers from browser cache (304 or disk cache)
- [ ] Run `pytest tests/test_webserver.py` — updated mock matches new bulk-fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Audiobooks list now cached for 5 minutes to accelerate repeated requests
  * Cover images include browser caching headers (1-day expiry) for faster repeat loads
  * Database queries optimized when fetching book states

* **Bug Fixes**
  * Failed library fetches now serve previously cached audiobooks instead of errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->