### PR TITLE
[Rename] Book Stitch → Book Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD024 -->
 
-All notable changes to Book Stitch will be documented in this file.
+All notable changes to Book Sync will be documented in this file.
 
 ## [1.0.4] - 2026-03-03
 
@@ -58,7 +58,7 @@ All notable changes to Book Stitch will be documented in this file.
 
 ### Initial Release
 
-Book Stitch is a self-hosted sync engine that links audiobook listening positions to matching spots in ebooks. It transcribes a segment of the audiobook audio, fuzzy-matches it against the EPUB text, and builds an alignment map. Once built, converting between a timestamp and a page position is instant.
+Book Sync is a self-hosted sync engine that links audiobook listening positions to matching spots in ebooks. It transcribes a segment of the audiobook audio, fuzzy-matches it against the EPUB text, and builds an alignment map. Once built, converting between a timestamp and a page position is instant.
 
 Forked from [abs-kosync-bridge](https://github.com/JadeTech-Solutions/abs-kosync-bridge) and rebuilt with a new architecture, simplified feature set, and fresh identity.
 
@@ -87,7 +87,7 @@ All integrations are optional. Use as few or as many as you want.
 - **Web dashboard** — Book grid with cover art, per-service progress, out-of-sync warnings, search/filter, and quick actions (sync now, mark complete, edit mapping, delete).
 - **Settings UI** — All configuration managed from the web interface. Multi-library ABS picker, per-service toggles, sync tuning. Settings persist in the database; environment variables are only needed for initial bootstrapping.
 - **Split-port security** — Run the KoSync API on a separate port from the admin dashboard. Expose the sync endpoint to the internet while keeping the dashboard on your LAN.
-- **Write suppression** — Centralized write tracker prevents feedback loops across all clients. If Book Stitch just pushed a position to a service, the echo that comes back is silently dropped.
+- **Write suppression** — Centralized write tracker prevents feedback loops across all clients. If Book Sync just pushed a position to a service, the echo that comes back is silently dropped.
 - **Auto-suggestions** — Discovers unmapped books with activity and fuzzy-matches them to potential ebook counterparts for user approval.
 - **Batch matching** — Link multiple books at once from a queue interface.
 - **Telegram notifications** — Forward log events to a Telegram chat at a configurable severity threshold.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2025 cporcellijr (original abs-kosync-bridge)
-Copyright (c) 2026 serabi (Book Stitch fork)
+Copyright (c) 2026 serabi (Book Sync fork)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,4 +1,4 @@
-# Quick Start Guide - Book Stitch
+# Quick Start Guide - Book Sync
 
 ## Goal
 Get your reading progress syncing across your self-hosted services, and track your reading history. Optionally syncs your reading progress with Hardcover.app.
@@ -7,7 +7,7 @@ Get your reading progress syncing across your self-hosted services, and track yo
 
 ## Step 1: Choose Your Services
 
-Book Stitch syncs progress between any combination of these services:
+Book Sync syncs progress between any combination of these services:
 
 | Service | Type | What It Does |
 |---------|------|-------------|
@@ -29,8 +29,8 @@ You need **at least two services** to sync between. Common setups:
 There is no published Docker image yet — you'll build from source:
 
 ```bash
-git clone https://github.com/serabi/book-stitch.git
-cd book-stitch
+git clone https://github.com/serabi/book-sync.git
+cd book-sync
 ```
 
 ---
@@ -41,11 +41,11 @@ Copy this template. All service credentials (API keys, URLs, passwords) are conf
 
 ```yaml
 services:
-  book-stitch:
+  book-sync:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: book-stitch
+    container_name: book-sync
     restart: unless-stopped
     environment:
       - TZ=America/New_York
@@ -100,7 +100,7 @@ Press `Ctrl+C` to exit logs.
 
 Open your browser to: **http://localhost:4477**
 
-You should see the Book Stitch dashboard.
+You should see the Book Sync dashboard.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Book Stitch
+# Book Sync
 
 <div align="center">
 
-<img src="static/icon.png" alt="Book Stitch" width="128">
+<img src="static/icon.png" alt="Book Sync" width="128">
 
 **Sync your audiobooks with your ebooks across your various self-hosted services.**
 
-[![License](https://img.shields.io/github/license/serabi/book-stitch?cacheSeconds=3600)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/serabi/book-stitch)](https://github.com/serabi/book-stitch/releases)
-[![Snyk Security](https://snyk.io/test/github/serabi/book-stitch/badge.svg)](https://snyk.io/test/github/serabi/book-stitch)
-[![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/serabi/book-stitch?labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![License](https://img.shields.io/github/license/serabi/book-sync?cacheSeconds=3600)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/serabi/book-sync)](https://github.com/serabi/book-sync/releases)
+[![Snyk Security](https://snyk.io/test/github/serabi/book-sync/badge.svg)](https://snyk.io/test/github/serabi/book-sync)
+[![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/serabi/book-sync?labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 </div>
 
@@ -19,9 +19,9 @@
 
 If you listen to audiobooks on a regular basis on [Audiobookshelf](https://www.audiobookshelf.org/) or [Storyteller](https://storyteller-platform.gitlab.io/storyteller/) during the day and then pick up the same book via KoReader or Kobo before bed, you know how frustrating it can be to find your place in the book. 
 
-The goal of Book Stitch is to help "stitch" your books together in order to let you resume reading where you left off, no matter which app you use. It's a self-hosted, Docker based sync engine that links your audiobook position to the matching spot in the ebook (and vice versa), then pushes that position to every app you use. It works by transcribing a segment of the audiobook audio and fuzzy-matching it against the EPUB text. Once that alignment map is built, converting between a timestamp and a page position simply takes a sync. 
+The goal of Book Sync is to keep your books in sync across multiple platforms so that you can resume reading where you left off, no matter which app you use. It's a self-hosted, Docker based sync engine that links your audiobook position to the matching spot in the ebook (and vice versa), then pushes that position to every app you use. It works by transcribing a segment of the audiobook audio and fuzzy-matching it against the EPUB text. Once that alignment map is built, converting between a timestamp and a page position simply takes a sync. 
 
-Major kudos and credit goes to [abs-kosync-bridge](https://github.com/cporcellijr/abs-kosync-bridge) for being the inspiration and original jumping-off point for this project. A big thing I love about the open source community is the ability for us to contribute to projects, fork projects, and give back to the community through those efforts. In the spirit of open source, I'm sharing Book Stitch in case anyone else finds it useful, and I'm open to suggestions and contributions.  
+Major kudos and credit goes to [abs-kosync-bridge](https://github.com/cporcellijr/abs-kosync-bridge) for being the inspiration and original jumping-off point for this project. A big thing I love about the open source community is the ability for us to contribute to projects, fork projects, and give back to the community through those efforts. In the spirit of open source, I'm sharing Book Sync in case anyone else finds it useful, and I'm open to suggestions and contributions.  
 
 ### Supported platforms
 
@@ -42,9 +42,9 @@ You can use as few or as many of the above services as you want. None are requir
 
 ```yaml
 services:
-  book-stitch:
+  book-sync:
     build: .
-    container_name: book_stitch
+    container_name: book_sync
     restart: unless-stopped
     environment:
       - TZ=America/New_York
@@ -65,21 +65,21 @@ Start the container, open `http://your-server:4477`, and configure everything fr
 
 ## How it works
 
-Book Stitch runs three sync layers simultaneously, from fastest to slowest:
+Book Sync runs three sync layers simultaneously, from fastest to slowest:
 
-1. **Instant sync** — Listens to Audiobookshelf's Socket.IO stream and KOReader's KoSync updates in real time. When you pause an audiobook or push an update from KoReader via KoSync, Book Stitch picks up the change within seconds.
+1. **Instant sync** — Listens to Audiobookshelf's Socket.IO stream and KOReader's KoSync updates in real time. When you pause an audiobook or push an update from KoReader via KoSync, Book Sync picks up the change within seconds.
 
 2. **Per-client polling** — Lightweight checks against individual services (Storyteller, Booklore) at their own intervals. Only triggers a sync when the position has actually changed.
 
 3. **Scheduled full sync** — A background sweep every few minutes that catches anything the other layers missed.
 
-When a position change is detected, Book Stitch converts it to every other format (timestamp to percentage, percentage to EPUB position, etc.) and pushes updates to all connected clients. A write-tracker prevents feedback loops — if Book Stitch just pushed a position to a client, it ignores the echo that comes back.
+When a position change is detected, Book Sync converts it to every other format (timestamp to percentage, percentage to EPUB position, etc.) and pushes updates to all connected clients. A write-tracker prevents feedback loops — if Book Sync just pushed a position to a client, it ignores the echo that comes back.
 
 ---
 
 ## The alignment process
 
-The first time you link an audiobook to its EPUB, Book Stitch needs to build an alignment map. Here's what happens:
+The first time you link an audiobook to its EPUB, Book Sync needs to build an alignment map. Here's what happens:
 
 1. A segment of the audiobook is transcribed using [Whisper](https://github.com/openai/whisper) (local/part of the Docker container), [Deepgram](https://deepgram.com/) (cloud), or [Whisper.cpp](https://github.com/ggerganov/whisper.cpp) (external server).
 2. The transcript is fuzzy-matched against the EPUB text to find corresponding positions.
@@ -91,7 +91,7 @@ You can use a local Whisper model (runs on CPU or NVIDIA GPU) or offload to a cl
 
 ## Split-port mode
 
-Book Stitch can expose the KoSync API on a separate port from the admin dashboard. This keeps the sync endpoint available to your e-reader over the internet while the dashboard stays on your local network.
+Book Sync can expose the KoSync API on a separate port from the admin dashboard. This keeps the sync endpoint available to your e-reader over the internet while the dashboard stays on your local network.
 
 **Important:** Port 4477 (the dashboard) must stay on your LAN. Only the `KOSYNC_PORT` can be exposed via a reverse proxy as it does have an authentication layer built in.
 
@@ -119,7 +119,7 @@ The **LAN Address** field shows `http://<server-ip>:<KOSYNC_PORT>` automatically
 
 1. Set `KOSYNC_PORT` in your Docker environment
 2. Configure your reverse proxy to forward `https://your-domain` to port `KOSYNC_PORT`
-3. In Book Stitch settings, enter the public URL
+3. In Book Sync settings, enter the public URL
 4. In KOReader: Settings > Cloud storage > Progress sync > Custom server > enter your public URL
 
 ### Security features
@@ -130,10 +130,10 @@ The sync endpoint includes rate limiting, input validation, and MD5-hashed authe
 
 ## Ebook sources
 
-Book Stitch needs access to your EPUB files for alignment. Three options, in order of simplicity:
+Book Sync needs access to your EPUB files for alignment. Three options, in order of simplicity:
 
 - **Mount a volume** — Point `/books` at your EPUB directory. Simplest approach.
-- **Booklore** — Book Stitch fetches EPUBs through the Booklore API. No volume mount needed.
+- **Booklore** — Book Sync fetches EPUBs through the Booklore API. No volume mount needed.
 - **Calibre-Web Automated (CWA)** — Same idea, fetches EPUBs through CWA's API.
 
 ---
@@ -146,9 +146,9 @@ _Docker image coming soon_
 Clone the repository and build the image:
 
 ```bash
-git clone https://github.com/serabi/book-stitch.git
-cd book-stitch
-docker build -t book-stitch .
+git clone https://github.com/serabi/book-sync.git
+cd book-sync
+docker build -t book-sync .
 ```
 
 Copy the example compose file and edit it for your setup:
@@ -166,7 +166,7 @@ The dashboard will be available at `http://localhost:4477`. All service configur
 To enable NVIDIA GPU acceleration for Whisper transcription, pass the `INSTALL_GPU` build arg. This adds ~800MB to the image for the CUDA libraries.
 
 ```bash
-docker build --build-arg INSTALL_GPU=true -t book-stitch .
+docker build --build-arg INSTALL_GPU=true -t book-sync .
 ```
 
 You'll also need to uncomment the `deploy.resources` section in your `docker-compose.yml` to expose the GPU to the container. See the example compose file for details.
@@ -176,7 +176,7 @@ You'll also need to uncomment the `deploy.resources` section in your `docker-com
 The build accepts an `APP_VERSION` arg that controls the version displayed in the dashboard. Defaults to `dev` if not set.
 
 ```bash
-docker build --build-arg APP_VERSION=1.0.0 -t book-stitch .
+docker build --build-arg APP_VERSION=1.0.0 -t book-sync .
 ```
 
 ### Local development
@@ -203,7 +203,7 @@ package installed in the image) and `ffmpeg`. Use the included wrapper script:
 ./run-tests.sh -k "test_sync_cycle"               # filter by name
 ```
 
-If the `book-stitch` container is running, tests execute there via `docker exec`
+If the `book-sync` container is running, tests execute there via `docker exec`
 (fastest). Otherwise the script falls back to `docker compose -f docker-compose.test.yml run --rm test`.
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Book Stitch — TODO
+# Book Sync — TODO
 
 ## Code Cleanup
 - [x] Remove last 5 emojis from codebase

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,4 @@
-# Book Stitch - Example Docker Compose Configuration
+# Book Sync - Example Docker Compose Configuration
 #
 # All settings are configured via the web dashboard at http://localhost:4477/settings
 # No environment variables are required beyond TZ.
@@ -6,12 +6,12 @@
 # See README.md for detailed configuration instructions.
 
 services:
-  book-stitch:
+  book-sync:
     build: .
     # args:
     #   # Set to "true" to download NVIDIA CUDA libraries (adds ~800MB to image)
     #   INSTALL_GPU: "false"
-    container_name: book_stitch
+    container_name: book_sync
     restart: unless-stopped
 
     environment:

--- a/migrations/SQLALCHEMY_MIGRATION.md
+++ b/migrations/SQLALCHEMY_MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## ✅ Migration Completed Successfully
 
-The Book Stitch application has been successfully migrated from JSON file storage to SQLAlchemy ORM with SQLite backend while maintaining full backward compatibility.
+The Book Sync application has been successfully migrated from JSON file storage to SQLAlchemy ORM with SQLite backend while maintaining full backward compatibility.
 
 ## 🏗️ Architecture Changes
 

--- a/migrations/UNIFIED_DATABASE_ARCHITECTURE.md
+++ b/migrations/UNIFIED_DATABASE_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## ✅ Simplified Database Architecture
 
-The Book Stitch application now has a **unified database service** that works exclusively with SQLAlchemy models, eliminating dictionary conversions and providing cleaner, type-safe code.
+The Book Sync application now has a **unified database service** that works exclusively with SQLAlchemy models, eliminating dictionary conversions and providing cleaner, type-safe code.
 
 ## 🏗️ Architecture Overview
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONTAINER_NAME="book-stitch"
+CONTAINER_NAME="book-sync"
 COMPOSE_TEST_FILE="docker-compose.test.yml"
 
-# Check if the book-stitch container is running
+# Check if the book-sync container is running
 if docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q true; then
     echo "==> Running tests in existing '$CONTAINER_NAME' container..."
 

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -11,7 +11,7 @@ mkdir -p "$BACKUP_DIR"
 
 # Timestamp for the backup
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-BACKUP_FILE="${BACKUP_DIR}/book_stitch_${TIMESTAMP}.db"
+BACKUP_FILE="${BACKUP_DIR}/book_sync_${TIMESTAMP}.db"
 
 # Check if database exists
 if [ -f "${DATA_DIR}/${DB_FILE}" ]; then

--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -504,13 +504,13 @@ class ABSClient:
             "deviceInfo": {
                 "id": "abs-kosync-bot",
                 "deviceId": "abs-kosync-bot",
-                "clientName": "Book-Stitch",
+                "clientName": "Book-Sync",
                 "clientVersion": "1.0",
-                "manufacturer": "Book Stitch",
+                "manufacturer": "Book Sync",
                 "model": "Bridge",
                 "sdkVersion": "1.0"
             },
-            "mediaPlayer": "Book-Stitch",
+            "mediaPlayer": "Book-Sync",
             "supportedMimeTypes": ["audio/mpeg", "audio/mp4"],
             "forceDirectPlay": True,
             "forceTranscode": False

--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -40,7 +40,7 @@ class HardcoverClient:
         self.headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.token}",
-            "User-Agent": "Book-Stitch/1.0",
+            "User-Agent": "Book-Sync/1.0",
         }
 
     def is_configured(self):

--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -547,7 +547,7 @@ def kosync_put_progress():
         # Debounce sync trigger — wait until the reader stops turning pages
         # Skip if the update came from the sync bot itself (prevents sync→PUT→sync loop)
         # Skip if instant sync is globally disabled.
-        is_internal = device and device.lower() in ('abs-sync-bot', 'book-stitch')
+        is_internal = device and device.lower() in ('abs-sync-bot', 'book-stitch', 'book-sync')
         instant_sync_enabled = os.environ.get('INSTANT_SYNC_ENABLED', 'true').lower() != 'false'
         if linked_book.status == 'active' and _manager and not is_internal and instant_sync_enabled:
             logger.debug(f"KOSync PUT: Progress event recorded for '{linked_book.abs_title}'")
@@ -746,8 +746,8 @@ def _respond_from_book_states(doc_id, book):
         best_doc = max(docs_with_progress, key=lambda d: float(d.percentage))
         logger.info(f"KOSync: Resolved {doc_id[:8]}... to '{book.abs_title}' via sibling hash {best_doc.document_hash[:8]}... ({float(best_doc.percentage):.2%})")
         return jsonify({
-            "device": best_doc.device or "book-stitch",
-            "device_id": best_doc.device_id or "book-stitch",
+            "device": best_doc.device or "book-sync",
+            "device_id": best_doc.device_id or "book-sync",
             "document": doc_id,
             "percentage": float(best_doc.percentage),
             "progress": best_doc.progress or "",
@@ -761,8 +761,8 @@ def _respond_from_book_states(doc_id, book):
     latest_state = kosync_state or max(states, key=lambda s: s.last_updated if s.last_updated else 0)
 
     return jsonify({
-        "device": "book-stitch",
-        "device_id": "book-stitch",
+        "device": "book-sync",
+        "device_id": "book-sync",
         "document": doc_id,
         "percentage": float(latest_state.percentage) if latest_state.percentage else 0,
         "progress": (latest_state.xpath or latest_state.cfi) if hasattr(latest_state, 'xpath') else "",

--- a/src/blueprints/__init__.py
+++ b/src/blueprints/__init__.py
@@ -1,4 +1,4 @@
-"""Flask Blueprints for Book Stitch web server."""
+"""Flask Blueprints for Book Sync web server."""
 
 
 def register_blueprints(app):

--- a/src/blueprints/helpers.py
+++ b/src/blueprints/helpers.py
@@ -1,4 +1,4 @@
-"""Shared helper functions for Book Stitch blueprints.
+"""Shared helper functions for Book Sync blueprints.
 
 All functions access shared state via flask.current_app.config rather than
 module-level globals, which allows them to work from any blueprint.

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -1,5 +1,5 @@
 """
-Unified SQLAlchemy database service for Book Stitch.
+Unified SQLAlchemy database service for Book Sync.
 Direct model-based interface without dictionary conversions.
 """
 

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,5 +1,5 @@
 """
-SQLAlchemy ORM models for Book Stitch database.
+SQLAlchemy ORM models for Book Sync database.
 """
 
 from datetime import datetime

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Dependency Injection Container for Book Stitch.
+Dependency Injection Container for Book Sync.
 Using python-dependency-injector library for proper DI functionality.
 """
 

--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1,5 +1,5 @@
 """
-Ebook Utilities for Book Stitch
+Ebook Utilities for Book Sync
 """
 import glob
 import hashlib

--- a/src/utils/transcriber.py
+++ b/src/utils/transcriber.py
@@ -1,5 +1,5 @@
 """
-Audio Transcriber for Book Stitch
+Audio Transcriber for Book Sync
 
 UPDATED VERSION with:
 - WAV normalization fix for ctranslate2/faster-whisper codec compatibility

--- a/src/version.py
+++ b/src/version.py
@@ -22,7 +22,7 @@ def get_update_status():
 
     try:
         r = requests.get(
-            "https://api.github.com/repos/serabi/book-stitch/releases/latest",
+            "https://api.github.com/repos/serabi/book-sync/releases/latest",
             timeout=5,
             headers={"Accept": "application/vnd.github+json"}
         )

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ cleanup() {
 # Set up signal handlers for graceful shutdown
 trap cleanup SIGTERM SIGINT
 
-echo "Starting Book Stitch (Integrated Mode)..."
+echo "Starting Book Sync (Integrated Mode)..."
 echo ""
 
 echo "Running Database Migrations..."

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Base Reset & Typography */
+/* Book Sync - Base Reset & Typography */
 
 * {
   box-sizing: border-box;

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Shared Components: Buttons, Forms, Cards, Badges, Modals */
+/* Book Sync - Shared Components: Buttons, Forms, Cards, Badges, Modals */
 
 /* ═══════════════════════════════════════════
    BUTTONS

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Dashboard (index.html) specific styles */
+/* Book Sync - Dashboard (index.html) specific styles */
 
 /* Sort direction toggle */
 .sort-direction {

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Layout: Navbar, Container, Grid */
+/* Book Sync - Layout: Navbar, Container, Grid */
 
 /* ─── Top Navigation Bar ─── */
 .top-nav {

--- a/static/css/logs.css
+++ b/static/css/logs.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Logs page specific styles */
+/* Book Sync - Logs page specific styles */
 
 /* Override container for logs */
 .container {

--- a/static/css/match.css
+++ b/static/css/match.css
@@ -1,4 +1,4 @@
-/* Book Stitch - Match + Batch Match page specific styles */
+/* Book Sync - Match + Batch Match page specific styles */
 
 /* Override container width for match pages */
 .container {

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -1,4 +1,4 @@
-/* Book Stitch — Settings: Sidebar-Tab Layout */
+/* Book Sync — Settings: Sidebar-Tab Layout */
 
 /* ─── Layout Override ─── */
 .container {

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -1,6 +1,6 @@
-/* Book Stitch Design System - Color Tokens & Variables */
+/* Book Sync Design System - Color Tokens & Variables */
 :root {
-  /* Primary palette (from Book Stitch design system) */
+  /* Primary palette (from Book Sync design system) */
   --color-primary: #6B21A8;
   --color-primary-hover: #7C3AED;
   --color-primary-light: rgba(124, 58, 237, 0.15);

--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Batch Match - Book Stitch</title>
+    <title>Batch Match - Book Sync</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/variables.css">

--- a/templates/index.html
+++ b/templates/index.html
@@ -289,7 +289,7 @@
     </div>
     {% endmacro %}
 
-    <title>Book Stitch</title>
+    <title>Book Sync</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">
@@ -618,7 +618,7 @@
                 });
 
                 // Persist choice
-                localStorage.setItem('book_stitch_filter', filterValue);
+                localStorage.setItem('book_sync_filter', filterValue);
             }
 
             function updateKoSyncHash(event) {
@@ -660,8 +660,8 @@
             let lastSort = null;
 
             // Load saved preferences
-            const savedSort = localStorage.getItem('book_stitch_sort') || 'title';
-            const savedSortState = localStorage.getItem('book_stitch_sort_state');
+            const savedSort = localStorage.getItem('book_sync_sort') || 'title';
+            const savedSortState = localStorage.getItem('book_sync_sort_state');
 
             if (savedSort) {
                 sortSelect.value = savedSort;
@@ -750,8 +750,8 @@
                 sortCards(allBooksGrid, sortBy, direction);
 
                 // Save preferences
-                localStorage.setItem('book_stitch_sort', sortBy);
-                localStorage.setItem('book_stitch_sort_state', JSON.stringify(sortState));
+                localStorage.setItem('book_sync_sort', sortBy);
+                localStorage.setItem('book_sync_sort_state', JSON.stringify(sortState));
             }
 
             function updateSortIndicator(direction) {
@@ -787,7 +787,7 @@
             // Filter Logic initialization
             if (filterSelect) {
                 filterSelect.addEventListener('change', filterBooks);
-                const savedFilter = localStorage.getItem('book_stitch_filter') || 'all';
+                const savedFilter = localStorage.getItem('book_sync_filter') || 'all';
                 filterSelect.value = savedFilter;
                 // Apply filter initially
                 filterBooks();
@@ -951,7 +951,7 @@
                 {% endif %}
             </span>
             {% if update_available %}
-            <a href="https://github.com/serabi/book-stitch/releases/latest" target="_blank"
+            <a href="https://github.com/serabi/book-sync/releases/latest" target="_blank"
                 style="font-size: 11px; color: #7C3AED; text-decoration: none; background: rgba(124,58,237,0.15); border: 1px solid rgba(124,58,237,0.3); border-radius: 4px; padding: 3px 8px; white-space: nowrap; transition: all 0.2s; font-weight: 600;"
                 onmouseover="this.style.background='rgba(124,58,237,0.25)'"
                 onmouseout="this.style.background='rgba(124,58,237,0.15)'">

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Logs - Book Stitch</title>
+    <title>Logs - Book Sync</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">

--- a/templates/match.html
+++ b/templates/match.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Add Book - Book Stitch</title>
+    <title>Add Book - Book Sync</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/variables.css">

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,8 +1,8 @@
 <header class="top-nav">
     <div class="nav-brand">
         <a href="/" class="brand-link">
-            <img src="/static/icon.png" alt="Book Stitch" class="app-icon" width="36" height="36">
-            <h1>Book Stitch</h1>
+            <img src="/static/icon.png" alt="Book Sync" class="app-icon" width="36" height="36">
+            <h1>Book Sync</h1>
         </a>
     </div>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-menu" aria-expanded="false">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Settings - Book Stitch</title>
+    <title>Settings - Book Sync</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">
@@ -418,7 +418,7 @@
 
                             <div class="info-box full-width" style="border-left: 3px solid var(--color-kosync); background: rgba(124, 58, 237, 0.06);">
                                 <strong>Security Note</strong>
-                                <p style="margin: 6px 0 0;">Book Stitch's web dashboard has no built-in authentication. Only expose the KOSync sync endpoint to the internet &mdash; it uses password-based authentication. Use split-port mode or a reverse proxy that restricts access to the <code>/syncs/</code> and <code>/healthcheck</code> paths only.</p>
+                                <p style="margin: 6px 0 0;">Book Sync's web dashboard has no built-in authentication. Only expose the KOSync sync endpoint to the internet &mdash; it uses password-based authentication. Use split-port mode or a reverse proxy that restricts access to the <code>/syncs/</code> and <code>/healthcheck</code> paths only.</p>
                             </div>
 
                             <div class="section-divider"></div>
@@ -482,7 +482,7 @@
                             <h3><span class="accent-dot" style="background: var(--color-kosync);"></span> Sync Engine Source</h3>
                         </div>
                         <div class="sub-section-body">
-                            <p class="help-text full-width" style="margin-bottom: 12px;">Controls where Book Stitch's sync engine reads KoSync data from.</p>
+                            <p class="help-text full-width" style="margin-bottom: 12px;">Controls where Book Sync's sync engine reads KoSync data from.</p>
 
                             <div class="full-width" style="display: flex; flex-direction: column; gap: 12px;">
                                 <label class="radio-card" style="display: flex; align-items: flex-start; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; cursor: pointer;">

--- a/tests/test_syncmanager_paths.py
+++ b/tests/test_syncmanager_paths.py
@@ -16,7 +16,7 @@ def test_syncmanager_di_paths():
     print("[TEST] Testing SyncManager paths from DI container...")
 
     # Create temporary directories for testing
-    temp_base_dir = tempfile.mkdtemp(prefix="book_stitch_test_")
+    temp_base_dir = tempfile.mkdtemp(prefix="book_sync_test_")
     temp_data_dir = os.path.join(temp_base_dir, "data")
     temp_books_dir = os.path.join(temp_base_dir, "books")
 


### PR DESCRIPTION
## Summary
- Renames all references from "Book Stitch" to "Book Sync" across 37 files
- Updates HTML titles, navbar, CSS headers, Python docstrings, API identifiers (clientName, manufacturer, mediaPlayer, User-Agent), Docker config, shell scripts, documentation, localStorage keys, and GitHub URLs
- Keeps `book-stitch` in the KoSync `is_internal` check for backward compatibility with existing database entries

## Test plan
- [ ] Verify the navbar displays "Book Sync"
- [ ] Verify all page titles show "Book Sync"
- [ ] Verify `run-tests.sh` references the correct container name `book-sync`
- [ ] Verify docker-compose.example.yml uses `book-sync` service/container names
- [ ] Verify KoSync device names report as `book-sync` in new sync entries
- [ ] Verify old `book-stitch` device entries are still recognized as internal (no sync loops)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new database fields for enhanced ebook metadata storage

* **Bug Fixes**
  * Fixed WAV normalization for audio codec compatibility

* **Updates**
  * Updated project branding across the application interface
  * Migrated user preference storage system
  * Updated version checking mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->