### PR TITLE
Rename: Book Sync → PageKeeper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Book Sync is a self-hosted, Docker-based sync engine that keeps audiobook and ebook reading positions in sync across multiple platforms (Audiobookshelf, KOReader via KoSync, Storyteller, Booklore, and Hardcover). It works by transcribing audiobook audio and fuzzy-matching the transcript against EPUB text to build an alignment map, then converting positions between formats and pushing updates to all connected clients.
+PageKeeper is a self-hosted, Docker-based reading companion that tracks what you read and keeps your position in sync across multiple platforms (Audiobookshelf, KOReader via KoSync, Storyteller, Booklore, and Hardcover). It works by transcribing audiobook audio and fuzzy-matching the transcript against EPUB text to build an alignment map, then converting positions between formats and pushing updates to all connected clients.
 
 The application is a Python/Flask web server with a web dashboard on port 4477, a background sync engine, and an optional split KoSync API port.
 
@@ -33,7 +33,7 @@ Always run tests via `./run-tests.sh` — never bare `pytest`. The test suite re
 ./run-tests.sh -k "test_name" -v            # filtered + verbose
 ```
 
-If the `book-sync` container is running, tests execute there via `docker exec` (fastest). Otherwise the script falls back to `docker compose -f docker-compose.test.yml run --rm test`.
+If the `pagekeeper` container is running, tests execute there via `docker exec` (fastest). Otherwise the script falls back to `docker compose -f docker-compose.test.yml run --rm test`.
 
 ## Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD024 -->
 
-All notable changes to Book Sync will be documented in this file.
+All notable changes to PageKeeper will be documented in this file.
 
 ## [1.0.6] - 2026-03-05
 
@@ -10,7 +10,7 @@ All notable changes to Book Sync will be documented in this file.
 
 - **Diagnostic test buttons** — Each service section on the Settings page now has a "Test" button that verifies connectivity and authentication in one click. Covers Audiobookshelf, Storyteller, Booklore, CWA, Hardcover, and Telegram. Returns human-readable error messages (e.g., "Authentication failed — check your username and password") instead of raw HTTP status codes.
 - **Storyteller native alignment** — Alignment maps can now be built directly from Storyteller's word-level timing data (`wordTimeline`), bypassing Whisper transcription entirely. Mount Storyteller's processing directory and set the Assets Directory in Settings. New alignment priority chain: Storyteller native → SMIL → Whisper.
-- **Socket-driven suggestion discovery** — When an unmapped audiobook is detected via ABS Socket.IO events, Book Sync automatically queues a suggestion search in the background. Thread-safe with lock + in-flight set to prevent duplicate work.
+- **Socket-driven suggestion discovery** — When an unmapped audiobook is detected via ABS Socket.IO events, PageKeeper automatically queues a suggestion search in the background. Thread-safe with lock + in-flight set to prevent duplicate work.
 - **Reverse suggestions** — Books with reading progress in Storyteller or Booklore now trigger searches for matching audiobooks in Audiobookshelf, surfacing pairing candidates in both directions.
 - **Storyteller as suggestion source** — Storyteller is now searched alongside Booklore and CWA when discovering ebook matches for audiobook suggestions.
 - **Pairing suggestions page** — Dedicated `/suggestions` page with card grid, cover images, match candidates with source labels, filter/search, and Dismiss/Link/Never Ask actions.
@@ -108,7 +108,7 @@ All notable changes to Book Sync will be documented in this file.
 
 ### Initial Release
 
-Book Sync is a self-hosted sync engine that links audiobook listening positions to matching spots in ebooks. It transcribes a segment of the audiobook audio, fuzzy-matches it against the EPUB text, and builds an alignment map. Once built, converting between a timestamp and a page position is instant.
+PageKeeper is a self-hosted sync engine that links audiobook listening positions to matching spots in ebooks. It transcribes a segment of the audiobook audio, fuzzy-matches it against the EPUB text, and builds an alignment map. Once built, converting between a timestamp and a page position is instant.
 
 Forked from [abs-kosync-bridge](https://github.com/JadeTech-Solutions/abs-kosync-bridge) and rebuilt with a new architecture, simplified feature set, and fresh identity.
 
@@ -137,7 +137,7 @@ All integrations are optional. Use as few or as many as you want.
 - **Web dashboard** — Book grid with cover art, per-service progress, out-of-sync warnings, search/filter, and quick actions (sync now, mark complete, edit mapping, delete).
 - **Settings UI** — All configuration managed from the web interface. Multi-library ABS picker, per-service toggles, sync tuning. Settings persist in the database; environment variables are only needed for initial bootstrapping.
 - **Split-port security** — Run the KoSync API on a separate port from the admin dashboard. Expose the sync endpoint to the internet while keeping the dashboard on your LAN.
-- **Write suppression** — Centralized write tracker prevents feedback loops across all clients. If Book Sync just pushed a position to a service, the echo that comes back is silently dropped.
+- **Write suppression** — Centralized write tracker prevents feedback loops across all clients. If PageKeeper just pushed a position to a service, the echo that comes back is silently dropped.
 - **Auto-suggestions** — Discovers unmapped books with activity and fuzzy-matches them to potential ebook counterparts for user approval.
 - **Batch matching** — Link multiple books at once from a queue interface.
 - **Telegram notifications** — Forward log events to a Telegram chat at a configurable severity threshold.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2025 cporcellijr (original abs-kosync-bridge)
-Copyright (c) 2026 serabi (Book Sync fork)
+Copyright (c) 2026 serabi (PageKeeper fork)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,4 +1,4 @@
-# Quick Start Guide - Book Sync
+# Quick Start Guide - PageKeeper
 
 ## Goal
 Get your reading progress syncing across your self-hosted services, and track your reading history. Optionally syncs your reading progress with Hardcover.app.
@@ -7,7 +7,7 @@ Get your reading progress syncing across your self-hosted services, and track yo
 
 ## Step 1: Choose Your Services
 
-Book Sync syncs progress between any combination of these services:
+PageKeeper syncs progress between any combination of these services:
 
 | Service | Type | What It Does |
 |---------|------|-------------|
@@ -29,8 +29,8 @@ You need **at least two services** to sync between. Common setups:
 There is no published Docker image yet — you'll build from source:
 
 ```bash
-git clone https://github.com/serabi/book-sync.git
-cd book-sync
+git clone https://github.com/serabi/pagekeeper.git
+cd pagekeeper
 ```
 
 ---
@@ -41,11 +41,11 @@ Copy this template. All service credentials (API keys, URLs, passwords) are conf
 
 ```yaml
 services:
-  book-sync:
+  pagekeeper:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: book-sync
+    container_name: pagekeeper
     restart: unless-stopped
     environment:
       - TZ=America/New_York
@@ -100,7 +100,7 @@ Press `Ctrl+C` to exit logs.
 
 Open your browser to: **http://localhost:4477**
 
-You should see the Book Sync dashboard.
+You should see the PageKeeper dashboard.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Book Sync
+# PageKeeper
 
 <div align="center">
 
-<img src="static/icon.png" alt="Book Sync" width="128">
+<img src="static/icon.png" alt="PageKeeper" width="128">
 
-**Sync your audiobooks with your ebooks across your various self-hosted services.**
+**Keep your place across every book, every app, every format.**
 
 [![License](https://img.shields.io/github/license/serabi/book-sync?cacheSeconds=3600)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/serabi/book-sync)](https://github.com/serabi/book-sync/releases)
@@ -15,13 +15,17 @@
 
 ---
 
-## What is this?
+## What is PageKeeper?
 
-If you listen to audiobooks on a regular basis on [Audiobookshelf](https://www.audiobookshelf.org/) or [Storyteller](https://storyteller-platform.gitlab.io/storyteller/) during the day and then pick up the same book via KoReader or Kobo before bed, you know how frustrating it can be to find your place in the book. 
+PageKeeper is a self-hosted reading companion that tracks what you read and keeps your place across platforms. Whether you listen to an audiobook during your commute on [Audiobookshelf](https://www.audiobookshelf.org/) and pick up the same book on your e-reader before bed, or just want a single place to see your reading progress across services — PageKeeper handles it.
 
-The goal of Book Sync is to keep your books in sync across multiple platforms so that you can resume reading where you left off, no matter which app you use. It's a self-hosted, Docker based sync engine that links your audiobook position to the matching spot in the ebook (and vice versa), then pushes that position to every app you use. It works by transcribing a segment of the audiobook audio and fuzzy-matching it against the EPUB text. Once that alignment map is built, converting between a timestamp and a page position simply takes a sync. 
+At its core, PageKeeper is a **reading tracker**: it knows which books you're reading, how far along you are, when you started and finished, and keeps a journal of your progress. On top of that, it can **sync your position** between audiobook and ebook platforms by building an alignment map between the audio and the text. Once that map is built, jumping between formats is seamless.
 
-Major kudos and credit goes to [abs-kosync-bridge](https://github.com/cporcellijr/abs-kosync-bridge) for being the inspiration and original jumping-off point for this project. A big thing I love about the open source community is the ability for us to contribute to projects, fork projects, and give back to the community through those efforts. In the spirit of open source, I'm sharing Book Sync in case anyone else finds it useful, and I'm open to suggestions and contributions.  
+### Origin story
+
+This project started as a fork of [abs-kosync-bridge](https://github.com/cporcellijr/abs-kosync-bridge), a clever tool that synced Audiobookshelf positions to KOReader via the KoSync protocol. Major kudos to [cporcellijr](https://github.com/cporcellijr) for the original idea and implementation.
+
+Over time, the scope grew well beyond that bridge: multi-platform sync, reading tracking, auto-completion, suggestion discovery, alignment from multiple sources, and a full web dashboard. At this point it's essentially a new application, but the spirit of open source that made it possible is the same. If you find PageKeeper useful, contributions and suggestions are always welcome.
 
 ### Supported platforms
 
@@ -33,7 +37,7 @@ Major kudos and credit goes to [abs-kosync-bridge](https://github.com/cporcellij
 | [Booklore](https://github.com/booklore) | Ebook library and shelf manager |
 | [Hardcover](https://hardcover.app/) | Book tracking service (write-only) |
 
-You can use as few or as many of the above services as you want. None are required to use the app. 
+You can use as few or as many of the above services as you want. None are required to use the app.
 
 
 ---
@@ -42,9 +46,9 @@ You can use as few or as many of the above services as you want. None are requir
 
 ```yaml
 services:
-  book-sync:
+  pagekeeper:
     build: .
-    container_name: book_sync
+    container_name: pagekeeper
     restart: unless-stopped
     environment:
       - TZ=America/New_York
@@ -65,23 +69,23 @@ Start the container, open `http://your-server:4477`, and configure everything fr
 
 ## How it works
 
-Book Sync runs three sync layers simultaneously, from fastest to slowest:
+PageKeeper runs three sync layers simultaneously, from fastest to slowest:
 
-1. **Instant sync** — Listens to Audiobookshelf's Socket.IO stream and KOReader's KoSync updates in real time. When you pause an audiobook or push an update from KoReader via KoSync, Book Sync picks up the change within seconds.
+1. **Instant sync** — Listens to Audiobookshelf's Socket.IO stream and KOReader's KoSync updates in real time. When you pause an audiobook or push an update from KoReader via KoSync, PageKeeper picks up the change within seconds.
 
 2. **Per-client polling** — Lightweight checks against individual services (Storyteller, Booklore) at their own intervals. Only triggers a sync when the position has actually changed.
 
 3. **Scheduled full sync** — A background sweep every few minutes that catches anything the other layers missed.
 
-When a position change is detected, Book Sync converts it to every other format (timestamp to percentage, percentage to EPUB position, etc.) and pushes updates to all connected clients. A write-tracker prevents feedback loops — if Book Sync just pushed a position to a client, it ignores the echo that comes back.
+When a position change is detected, PageKeeper converts it to every other format (timestamp to percentage, percentage to EPUB position, etc.) and pushes updates to all connected clients. A write-tracker prevents feedback loops — if PageKeeper just pushed a position to a client, it ignores the echo that comes back.
 
 ---
 
 ## The alignment process
 
-The first time you link an audiobook to its EPUB, Book Sync needs to build an alignment map — a lookup table that converts between audio timestamps and ebook character positions. It tries three sources in priority order:
+The first time you link an audiobook to its EPUB, PageKeeper needs to build an alignment map — a lookup table that converts between audio timestamps and ebook character positions. It tries three sources in priority order:
 
-1. **Storyteller native** — If the book is linked to Storyteller and you've mounted the Storyteller data directory, Book Sync reads Storyteller's word-level timing data (`wordTimeline`) directly. No transcription needed — fastest option.
+1. **Storyteller native** — If the book is linked to Storyteller and you've mounted the Storyteller data directory, PageKeeper reads Storyteller's word-level timing data (`wordTimeline`) directly. No transcription needed — fastest option.
 2. **SMIL** — If the EPUB contains embedded SMIL timing data (common in publisher-produced audiobooks), it's extracted and used for alignment. Also fast.
 3. **Whisper** — Falls back to transcribing a segment of the audiobook audio using [Whisper](https://github.com/openai/whisper) (local), [Deepgram](https://deepgram.com/) (cloud), or [Whisper.cpp](https://github.com/ggerganov/whisper.cpp) (external server), then fuzzy-matching the transcript against the EPUB text.
 
@@ -96,13 +100,13 @@ volumes:
   - /path/to/storyteller/processing:/storyteller-data:ro
 ```
 
-Then in Settings → Audiobooks → Storyteller, set **Assets Directory** to `/storyteller-data`.
+Then in Settings > Audiobooks > Storyteller, set **Assets Directory** to `/storyteller-data`.
 
 ---
 
 ## Split-port mode
 
-Book Sync can expose the KoSync API on a separate port from the admin dashboard. This keeps the sync endpoint available to your e-reader over the internet while the dashboard stays on your local network.
+PageKeeper can expose the KoSync API on a separate port from the admin dashboard. This keeps the sync endpoint available to your e-reader over the internet while the dashboard stays on your local network.
 
 **Important:** Port 4477 (the dashboard) must stay on your LAN. Only the `KOSYNC_PORT` can be exposed via a reverse proxy as it does have an authentication layer built in.
 
@@ -113,7 +117,7 @@ environment:
   - KOSYNC_PORT=5758
 ports:
   - "4477:4477"   # Dashboard — LAN only, do NOT forward
-  - "5758:5758"   # Sync API — has authentication 
+  - "5758:5758"   # Sync API — has authentication
 ```
 
 ### TLS requirement
@@ -130,7 +134,7 @@ The **LAN Address** field shows `http://<server-ip>:<KOSYNC_PORT>` automatically
 
 1. Set `KOSYNC_PORT` in your Docker environment
 2. Configure your reverse proxy to forward `https://your-domain` to port `KOSYNC_PORT`
-3. In Book Sync settings, enter the public URL
+3. In PageKeeper settings, enter the public URL
 4. In KOReader: Settings > Cloud storage > Progress sync > Custom server > enter your public URL
 
 ### Exposed paths
@@ -156,24 +160,24 @@ The sync endpoint includes rate limiting, input validation, and MD5-hashed authe
 
 ## Ebook sources
 
-Book Sync needs access to your EPUB files for alignment. Three options, in order of simplicity:
+PageKeeper needs access to your EPUB files for alignment. Three options, in order of simplicity:
 
 - **Mount a volume** — Point `/books` at your EPUB directory. Simplest approach.
-- **Booklore** — Book Sync fetches EPUBs through the Booklore API. No volume mount needed.
+- **Booklore** — PageKeeper fetches EPUBs through the Booklore API. No volume mount needed.
 - **Calibre-Web Automated (CWA)** — Same idea, fetches EPUBs through CWA's API.
 
 ---
 
 ## Pairing suggestions
 
-When Book Sync detects an audiobook you're actively listening to in Audiobookshelf, it can automatically search your ebook services (Booklore, Calibre-Web Automated, Storyteller) for a matching title and suggest a pairing. This works in two directions:
+When PageKeeper detects an audiobook you're actively listening to in Audiobookshelf, it can automatically search your ebook services (Booklore, Calibre-Web Automated, Storyteller) for a matching title and suggest a pairing. This works in two directions:
 
 - **Forward:** Audiobooks with progress in ABS trigger searches across your ebook sources.
 - **Reverse:** Books with progress in Storyteller or Booklore trigger searches for matching audiobooks in ABS.
 
 Suggestions appear on the **Suggestions** page (`/suggestions`), where you can link, dismiss, or permanently ignore them. Real-time discovery also happens via Socket.IO — when you start playing an unmapped audiobook, a suggestion is queued automatically.
 
-Enable suggestions in **Settings → General → Pairing Suggestions**.
+Enable suggestions in **Settings > General > Pairing Suggestions**.
 
 ---
 
@@ -193,7 +197,7 @@ Clone the repository and build the image:
 ```bash
 git clone https://github.com/serabi/book-sync.git
 cd book-sync
-docker build -t book-sync .
+docker build -t pagekeeper .
 ```
 
 Copy the example compose file and edit it for your setup:
@@ -211,7 +215,7 @@ The dashboard will be available at `http://localhost:4477`. All service configur
 To enable NVIDIA GPU acceleration for Whisper transcription, pass the `INSTALL_GPU` build arg. This adds ~800MB to the image for the CUDA libraries.
 
 ```bash
-docker build --build-arg INSTALL_GPU=true -t book-sync .
+docker build --build-arg INSTALL_GPU=true -t pagekeeper .
 ```
 
 You'll also need to uncomment the `deploy.resources` section in your `docker-compose.yml` to expose the GPU to the container. See the example compose file for details.
@@ -221,7 +225,7 @@ You'll also need to uncomment the `deploy.resources` section in your `docker-com
 The build accepts an `APP_VERSION` arg that controls the version displayed in the dashboard. Defaults to `dev` if not set.
 
 ```bash
-docker build --build-arg APP_VERSION=1.0.0 -t book-sync .
+docker build --build-arg APP_VERSION=1.0.0 -t pagekeeper .
 ```
 
 ### Local development
@@ -248,7 +252,7 @@ package installed in the image) and `ffmpeg`. Use the included wrapper script:
 ./run-tests.sh -k "test_sync_cycle"               # filter by name
 ```
 
-If the `book-sync` container is running, tests execute there via `docker exec`
+If the `pagekeeper` container is running, tests execute there via `docker exec`
 (fastest). Otherwise the script falls back to `docker compose -f docker-compose.test.yml run --rm test`.
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Book Sync — TODO
+# PageKeeper — TODO
 
 ## Code Cleanup
 - [x] Remove last 5 emojis from codebase

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,4 @@
-# Book Sync - Example Docker Compose Configuration
+# PageKeeper - Example Docker Compose Configuration
 #
 # All settings are configured via the web dashboard at http://localhost:4477/settings
 # No environment variables are required beyond TZ.
@@ -6,12 +6,12 @@
 # See README.md for detailed configuration instructions.
 
 services:
-  book-sync:
+  pagekeeper:
     build: .
     # args:
     #   # Set to "true" to download NVIDIA CUDA libraries (adds ~800MB to image)
     #   INSTALL_GPU: "false"
-    container_name: book_sync
+    container_name: pagekeeper
     restart: unless-stopped
 
     environment:

--- a/future-plans/2026-03 - reading tracker plan.md
+++ b/future-plans/2026-03 - reading tracker plan.md
@@ -2,11 +2,11 @@
 
 ## Context
 
-Book Sync is currently a sync engine — it moves reading progress between platforms but doesn't own the reading experience itself. The goal is to evolve it into a **local-first reading tracker** where all reading data (status, dates, journals, goals, stats) lives in SQLite, with Hardcover as an optional bidirectional sync target for users who want social features.
+PageKeeper is currently a sync engine — it moves reading progress between platforms but doesn't own the reading experience itself. The goal is to evolve it into a **local-first reading tracker** where all reading data (status, dates, journals, goals, stats) lives in SQLite, with Hardcover as an optional bidirectional sync target for users who want social features.
 
 **Why local-first:** Self-hosters value data privacy. A reading tracker that requires an external service contradicts the self-hosting ethos. By making everything work locally and treating Hardcover as optional, we serve both privacy-focused users and Hardcover users with a single architecture.
 
-**Scope:** Only synced books (books already managed by Book Sync) get reading tracking. No standalone book import/discovery.
+**Scope:** Only synced books (books already managed by PageKeeper) get reading tracking. No standalone book import/discovery.
 
 **Key insight:** `Book.status` already stores reading states (`active`=reading, `paused`, `dnf`, `completed`) alongside sync states (`processing`, `failed_*`). The foundation is there — we need to formalize it with dates, journals, and a dedicated UI.
 

--- a/future-plans/booklore-audio-sync.md
+++ b/future-plans/booklore-audio-sync.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Booklore recently added native audiobook support with a full player, streaming API, and progress tracking. Book Sync already integrates with Booklore for **ebook** progress, but the audiobook half is unimplemented — `BookloreSyncClient.get_supported_sync_types()` returns `{'audiobook', 'ebook'}` but only the ebook path has code behind it.
+Booklore recently added native audiobook support with a full player, streaming API, and progress tracking. PageKeeper already integrates with Booklore for **ebook** progress, but the audiobook half is unimplemented — `BookloreSyncClient.get_supported_sync_types()` returns `{'audiobook', 'ebook'}` but only the ebook path has code behind it.
 
 This plan adds Booklore audiobook progress sync so that listening in Booklore's audiobook player stays in sync with ABS, KOReader, Storyteller, etc. — using the same alignment-map cross-format pipeline that already works for ABS audiobooks.
 
@@ -80,7 +80,7 @@ Discovered from Booklore source code (Spring Boot + Angular):
 
 **New private methods:**
 
-- **`_find_booklore_audiobook(book)`** — matches a Book Sync book to a Booklore book record:
+- **`_find_booklore_audiobook(book)`** — matches a PageKeeper book to a Booklore book record:
   - Strategy A: `find_book_by_filename(book.ebook_filename)` — works when Booklore has both epub and audiobook under same book ID
   - Strategy B (fallback): `search_books(book.abs_title)` — accept only unambiguous single match; filter for audio file types if multiple results
 
@@ -244,7 +244,7 @@ Between V1 and V3, these quality-of-life improvements:
 
 - **`booklore_book_id` column** on `books` table (Alembic migration) — O(1) lookup after first match, avoids repeated title search
 - **`fileProgress` write variant** — uses `bookFileId` for newer Booklore versions
-- **Manual book linking UI** — dropdown on book detail page to explicitly link Booklore book ID to Book Sync entry
+- **Manual book linking UI** — dropdown on book detail page to explicitly link Booklore book ID to PageKeeper entry
 - **Bulk audiobook progress prefetch** — enrich `_refresh_book_cache()` with audiobook progress data to avoid per-book API calls
 
 ---

--- a/migrations/SQLALCHEMY_MIGRATION.md
+++ b/migrations/SQLALCHEMY_MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## ✅ Migration Completed Successfully
 
-The Book Sync application has been successfully migrated from JSON file storage to SQLAlchemy ORM with SQLite backend while maintaining full backward compatibility.
+The PageKeeper application has been successfully migrated from JSON file storage to SQLAlchemy ORM with SQLite backend while maintaining full backward compatibility.
 
 ## 🏗️ Architecture Changes
 

--- a/migrations/UNIFIED_DATABASE_ARCHITECTURE.md
+++ b/migrations/UNIFIED_DATABASE_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## ✅ Simplified Database Architecture
 
-The Book Sync application now has a **unified database service** that works exclusively with SQLAlchemy models, eliminating dictionary conversions and providing cleaner, type-safe code.
+The PageKeeper application now has a **unified database service** that works exclusively with SQLAlchemy models, eliminating dictionary conversions and providing cleaner, type-safe code.
 
 ## 🏗️ Architecture Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "abs-kosync-stitch"
+name = "pagekeeper"
 requires-python = ">=3.11"
 
 [tool.ruff]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONTAINER_NAME="book-sync"
+CONTAINER_NAME="pagekeeper"
 COMPOSE_TEST_FILE="docker-compose.test.yml"
 
-# Check if the book-sync container is running
+# Check if the pagekeeper container is running
 if docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q true; then
     echo "==> Running tests in existing '$CONTAINER_NAME' container..."
 

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -11,7 +11,7 @@ mkdir -p "$BACKUP_DIR"
 
 # Timestamp for the backup
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-BACKUP_FILE="${BACKUP_DIR}/book_sync_${TIMESTAMP}.db"
+BACKUP_FILE="${BACKUP_DIR}/pagekeeper_${TIMESTAMP}.db"
 
 # Check if database exists
 if [ -f "${DATA_DIR}/${DB_FILE}" ]; then

--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -504,13 +504,13 @@ class ABSClient:
             "deviceInfo": {
                 "id": "abs-kosync-bot",
                 "deviceId": "abs-kosync-bot",
-                "clientName": "Book-Sync",
+                "clientName": "PageKeeper",
                 "clientVersion": "1.0",
-                "manufacturer": "Book Sync",
+                "manufacturer": "PageKeeper",
                 "model": "Bridge",
                 "sdkVersion": "1.0"
             },
-            "mediaPlayer": "Book-Sync",
+            "mediaPlayer": "PageKeeper",
             "supportedMimeTypes": ["audio/mpeg", "audio/mp4"],
             "forceDirectPlay": True,
             "forceTranscode": False

--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -40,7 +40,7 @@ class HardcoverClient:
         self.headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.token}",
-            "User-Agent": "Book-Sync/1.0",
+            "User-Agent": "PageKeeper/1.0",
         }
 
     def is_configured(self):

--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -548,7 +548,7 @@ def kosync_put_progress():
         # Debounce sync trigger — wait until the reader stops turning pages
         # Skip if the update came from the sync bot itself (prevents sync→PUT→sync loop)
         # Skip if instant sync is globally disabled.
-        is_internal = device and device.lower() in ('abs-sync-bot', 'book-stitch', 'book-sync')
+        is_internal = device and device.lower() in ('abs-sync-bot', 'book-stitch', 'book-sync', 'pagekeeper')
         instant_sync_enabled = os.environ.get('INSTANT_SYNC_ENABLED', 'true').lower() != 'false'
         if linked_book.status == 'active' and _manager and not is_internal and instant_sync_enabled:
             logger.debug(f"KOSync PUT: Progress event recorded for '{linked_book.abs_title}'")
@@ -758,8 +758,8 @@ def _respond_from_book_states(doc_id, book):
         best_doc = max(docs_with_progress, key=lambda d: float(d.percentage))
         logger.info(f"KOSync: Resolved {doc_id[:8]}... to '{book.abs_title}' via sibling hash {best_doc.document_hash[:8]}... ({float(best_doc.percentage):.2%})")
         return jsonify({
-            "device": best_doc.device or "book-sync",
-            "device_id": best_doc.device_id or "book-sync",
+            "device": best_doc.device or "pagekeeper",
+            "device_id": best_doc.device_id or "pagekeeper",
             "document": doc_id,
             "percentage": float(best_doc.percentage),
             "progress": best_doc.progress or "",
@@ -773,8 +773,8 @@ def _respond_from_book_states(doc_id, book):
     latest_state = kosync_state or max(states, key=lambda s: s.last_updated if s.last_updated else 0)
 
     return jsonify({
-        "device": "book-sync",
-        "device_id": "book-sync",
+        "device": "pagekeeper",
+        "device_id": "pagekeeper",
         "document": doc_id,
         "percentage": float(latest_state.percentage) if latest_state.percentage else 0,
         "progress": (latest_state.xpath or latest_state.cfi) if hasattr(latest_state, 'xpath') else "",

--- a/src/blueprints/__init__.py
+++ b/src/blueprints/__init__.py
@@ -1,4 +1,4 @@
-"""Flask Blueprints for Book Sync web server."""
+"""Flask Blueprints for PageKeeper web server."""
 
 
 def register_blueprints(app):

--- a/src/blueprints/helpers.py
+++ b/src/blueprints/helpers.py
@@ -1,4 +1,4 @@
-"""Shared helper functions for Book Sync blueprints.
+"""Shared helper functions for PageKeeper blueprints.
 
 All functions access shared state via flask.current_app.config rather than
 module-level globals, which allows them to work from any blueprint.

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -1,5 +1,5 @@
 """
-Unified SQLAlchemy database service for Book Sync.
+Unified SQLAlchemy database service for PageKeeper.
 Direct model-based interface without dictionary conversions.
 """
 

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,5 +1,5 @@
 """
-SQLAlchemy ORM models for Book Sync database.
+SQLAlchemy ORM models for PageKeeper database.
 """
 
 from datetime import datetime

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Dependency Injection Container for Book Sync.
+Dependency Injection Container for PageKeeper.
 Using python-dependency-injector library for proper DI functionality.
 """
 

--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -1,5 +1,5 @@
 """
-Ebook Utilities for Book Sync
+Ebook Utilities for PageKeeper
 """
 import glob
 import hashlib

--- a/src/utils/transcriber.py
+++ b/src/utils/transcriber.py
@@ -1,5 +1,5 @@
 """
-Audio Transcriber for Book Sync
+Audio Transcriber for PageKeeper
 
 UPDATED VERSION with:
 - WAV normalization fix for ctranslate2/faster-whisper codec compatibility

--- a/src/version.py
+++ b/src/version.py
@@ -22,7 +22,7 @@ def get_update_status():
 
     try:
         r = requests.get(
-            "https://api.github.com/repos/serabi/book-sync/releases/latest",
+            "https://api.github.com/repos/serabi/pagekeeper/releases/latest",
             timeout=5,
             headers={"Accept": "application/vnd.github+json"}
         )

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ cleanup() {
 # Set up signal handlers for graceful shutdown
 trap cleanup SIGTERM SIGINT
 
-echo "Starting Book Sync (Integrated Mode)..."
+echo "Starting PageKeeper (Integrated Mode)..."
 echo ""
 
 echo "Running Database Migrations..."

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,4 +1,4 @@
-/* Book Sync - Base Reset & Typography */
+/* PageKeeper - Base Reset & Typography */
 
 * {
   box-sizing: border-box;

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -1,4 +1,4 @@
-/* Book Sync - Shared Components: Buttons, Forms, Cards, Badges, Modals */
+/* PageKeeper - Shared Components: Buttons, Forms, Cards, Badges, Modals */
 
 /* ═══════════════════════════════════════════
    BUTTONS

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,4 +1,4 @@
-/* Book Sync - Dashboard (index.html) specific styles */
+/* PageKeeper - Dashboard (index.html) specific styles */
 
 /* Sort direction toggle */
 .sort-direction {

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -1,4 +1,4 @@
-/* Book Sync - Layout: Navbar, Container, Grid */
+/* PageKeeper - Layout: Navbar, Container, Grid */
 
 /* ─── Top Navigation Bar ─── */
 .top-nav {

--- a/static/css/logs.css
+++ b/static/css/logs.css
@@ -1,4 +1,4 @@
-/* Book Sync - Logs page specific styles */
+/* PageKeeper - Logs page specific styles */
 
 /* Override container for logs */
 .container {

--- a/static/css/match.css
+++ b/static/css/match.css
@@ -1,4 +1,4 @@
-/* Book Sync - Match + Batch Match page specific styles */
+/* PageKeeper - Match + Batch Match page specific styles */
 
 /* Override container width for match pages */
 .container {

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -1,4 +1,4 @@
-/* Book Sync — Settings: Sidebar-Tab Layout */
+/* PageKeeper — Settings: Sidebar-Tab Layout */
 
 /* ─── Layout Override ─── */
 .container {

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -1,6 +1,6 @@
-/* Book Sync Design System - Color Tokens & Variables */
+/* PageKeeper Design System - Color Tokens & Variables */
 :root {
-  /* Primary palette (from Book Sync design system) */
+  /* Primary palette (from PageKeeper design system) */
   --color-primary: #6B21A8;
   --color-primary-hover: #7C3AED;
   --color-primary-light: rgba(124, 58, 237, 0.15);

--- a/templates/batch_match.html
+++ b/templates/batch_match.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Batch Match - Book Sync</title>
+    <title>Batch Match - PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/variables.css">

--- a/templates/index.html
+++ b/templates/index.html
@@ -310,7 +310,7 @@
     </div>
     {% endmacro %}
 
-    <title>Book Sync</title>
+    <title>PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">
@@ -577,6 +577,15 @@
             const allBooksGrid = document.getElementById('all-books-grid');
             const sortSelect = document.getElementById('sort-select');
             const filterSelect = document.getElementById('filter-select');
+
+            // One-time migration: read new key, fall back to legacy key, migrate forward
+            function migrateLocalStorage(newKey, legacyKey) {
+                let val = localStorage.getItem(newKey);
+                if (val !== null) return val;
+                val = localStorage.getItem(legacyKey);
+                if (val !== null) localStorage.setItem(newKey, val);
+                return val;
+            }
             const directionBtn = document.getElementById('sort-direction');
             const dashboardSearch = document.getElementById('dashboard-search');
 
@@ -654,7 +663,7 @@
                 });
 
                 // Persist choice
-                localStorage.setItem('book_sync_filter', filterValue);
+                localStorage.setItem('pagekeeper_filter', filterValue);
             }
 
             function updateKoSyncHash(event) {
@@ -696,8 +705,8 @@
             let lastSort = null;
 
             // Load saved preferences
-            const savedSort = localStorage.getItem('book_sync_sort') || 'title';
-            const savedSortState = localStorage.getItem('book_sync_sort_state');
+            const savedSort = migrateLocalStorage('pagekeeper_sort', 'book_sync_sort') || 'title';
+            const savedSortState = migrateLocalStorage('pagekeeper_sort_state', 'book_sync_sort_state');
 
             if (savedSort) {
                 sortSelect.value = savedSort;
@@ -787,8 +796,8 @@
                 sortCards(allBooksGrid, sortBy, direction);
 
                 // Save preferences
-                localStorage.setItem('book_sync_sort', sortBy);
-                localStorage.setItem('book_sync_sort_state', JSON.stringify(sortState));
+                localStorage.setItem('pagekeeper_sort', sortBy);
+                localStorage.setItem('pagekeeper_sort_state', JSON.stringify(sortState));
             }
 
             function updateSortIndicator(direction) {
@@ -824,7 +833,7 @@
             // Filter Logic initialization
             if (filterSelect) {
                 filterSelect.addEventListener('change', filterBooks);
-                const savedFilter = localStorage.getItem('book_sync_filter') || 'all';
+                const savedFilter = migrateLocalStorage('pagekeeper_filter', 'book_sync_filter') || 'all';
                 filterSelect.value = savedFilter;
                 // Apply filter initially
                 filterBooks();

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Logs - Book Sync</title>
+    <title>Logs - PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">

--- a/templates/match.html
+++ b/templates/match.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Add Book - Book Sync</title>
+    <title>Add Book - PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/variables.css">

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,8 +1,8 @@
 <header class="top-nav">
     <div class="nav-brand">
         <a href="/" class="brand-link">
-            <img src="/static/icon.png" alt="Book Sync" class="app-icon" width="36" height="36">
-            <h1>Book Sync</h1>
+            <img src="/static/icon.png" alt="PageKeeper" class="app-icon" width="36" height="36">
+            <h1>PageKeeper</h1>
         </a>
     </div>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-menu" aria-expanded="false">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Settings - Book Sync</title>
+    <title>Settings - PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">
@@ -429,7 +429,7 @@
 
                             <div class="info-box full-width" style="border-left: 3px solid var(--color-kosync); background: rgba(124, 58, 237, 0.06);">
                                 <strong>Security Note</strong>
-                                <p style="margin: 6px 0 0;">Book Sync's web dashboard has no built-in authentication. Only expose the KOSync sync endpoint to the internet &mdash; it uses password-based authentication. Use split-port mode or a reverse proxy that restricts access to the <code>/syncs/</code> and <code>/healthcheck</code> paths only.</p>
+                                <p style="margin: 6px 0 0;">PageKeeper's web dashboard has no built-in authentication. Only expose the KOSync sync endpoint to the internet &mdash; it uses password-based authentication. Use split-port mode or a reverse proxy that restricts access to the <code>/syncs/</code> and <code>/healthcheck</code> paths only.</p>
                             </div>
 
                             <div class="section-divider"></div>
@@ -493,7 +493,7 @@
                             <h3><span class="accent-dot" style="background: var(--color-kosync);"></span> Sync Engine Source</h3>
                         </div>
                         <div class="sub-section-body">
-                            <p class="help-text full-width" style="margin-bottom: 12px;">Controls where Book Sync's sync engine reads KoSync data from.</p>
+                            <p class="help-text full-width" style="margin-bottom: 12px;">Controls where PageKeeper's sync engine reads KoSync data from.</p>
 
                             <div class="full-width" style="display: flex; flex-direction: column; gap: 12px;">
                                 <label class="radio-card" style="display: flex; align-items: flex-start; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; cursor: pointer;">

--- a/templates/suggestions.html
+++ b/templates/suggestions.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Suggestions - Book Sync</title>
+    <title>Suggestions - PageKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/static/icon.png">
     <link rel="apple-touch-icon" href="/static/icon.png">

--- a/tests/test_syncmanager_paths.py
+++ b/tests/test_syncmanager_paths.py
@@ -16,7 +16,7 @@ def test_syncmanager_di_paths():
     print("[TEST] Testing SyncManager paths from DI container...")
 
     # Create temporary directories for testing
-    temp_base_dir = tempfile.mkdtemp(prefix="book_sync_test_")
+    temp_base_dir = tempfile.mkdtemp(prefix="pagekeeper_test_")
     temp_data_dir = os.path.join(temp_base_dir, "data")
     temp_books_dir = os.path.join(temp_base_dir, "books")
 


### PR DESCRIPTION
## Summary

Merges the PageKeeper rename into main. All 42 files renamed from "Book Sync" to "PageKeeper" — branding, Docker, API identifiers, scripts, docs, CSS, templates, and localStorage keys (with legacy migration).

Closes #21

## Changes included
- Full README rewrite (reading tracker framing, origin story)
- UI: navbar, page titles, settings text
- Docker: service/container names → `pagekeeper`
- API: ABS client name, Hardcover User-Agent, KoSync device defaults
- localStorage: one-time migration from `book_sync_*` → `pagekeeper_*` keys
- KoSync backward compat: legacy `'book-sync'` kept in device detection

## Post-merge TODO
- Rename GitHub repo (`serabi/book-sync` → `serabi/pagekeeper`)
- Update badge URLs, clone URLs, and releases URL in README + index.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic migration of saved user preferences to preserve settings during the application transition.

* **Chores**
  * Rebranded application from Book Sync to PageKeeper across the entire interface, configuration, and documentation.
  * Updated API client identifiers and user-agent headers for external service interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->