### PR TITLE
Centralize reading status transitions

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,14 +20,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     branch="$(echo "$remote_ref" | sed 's|refs/heads/||')"
     expected_local_ref="refs/heads/$branch"
 
-    if [ "$branch" != "dev" ] && [ "$branch" != "main" ]; then
-        echo "Blocked: refusing to push '$branch' to origin." >&2
-        echo "Push private branches to the 'private' remote instead." >&2
-        exit 1
-    fi
-
     if [ "$local_ref" != "$expected_local_ref" ]; then
-        echo "Blocked: push local '$local_ref' to matching public branch '$branch' instead of rewriting refs." >&2
+        echo "Blocked: push local '$local_ref' to matching origin branch '$branch' instead of rewriting refs." >&2
         exit 1
     fi
 
@@ -37,6 +31,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     fi
 
     "$verify_script" --ref "$local_sha"
+
+    if [ "$branch" != "dev" ] && [ "$branch" != "main" ]; then
+        echo "Verified public-safe branch '$branch' for origin." >&2
+        continue
+    fi
 
     if [ "$branch" = "main" ]; then
         echo "You're pushing directly to main on origin." >&2

--- a/scripts/git/README.md
+++ b/scripts/git/README.md
@@ -7,6 +7,7 @@ flow with repo-owned tooling.
 
 - `dev`: public development branch on `origin`
 - `main`: public release branch on `origin`
+- review and feature branches: public-safe PR branches on `origin`
 - `draft`: private unpublished branch on `private`
 - `private/dev` and `private/main`: mirrors of the public branches
 
@@ -52,5 +53,6 @@ scripts/git/sync-private-mirrors.sh main
 ## Safety Checks
 
 - `config/private-paths.txt` defines what must never land on public branches
-- `.githooks/pre-push` blocks non-public branches from pushing to `origin`
+- `.githooks/pre-push` verifies pushes to `origin` do not include private-only paths
+- `.githooks/pre-push` blocks public branch deletion and mismatched local/remote ref pushes
 - `scripts/git/verify-public-tree.sh` validates public branch content

--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -17,8 +17,6 @@ import threading
 import time
 from datetime import date
 
-import requests
-
 from src.api.http_client_base import JsonHttpClientBase
 from src.utils.string_utils import calculate_similarity, clean_book_title
 

--- a/src/api/hardcover_routes.py
+++ b/src/api/hardcover_routes.py
@@ -87,11 +87,23 @@ def api_hardcover_resolve():
     manual_input = request.args.get("input", "").strip()
 
     if not abs_id:
-        return json_error("Missing abs_id parameter", 400, found=False, user_message="Missing abs_id parameter")
+        return json_error(
+            "Missing abs_id parameter",
+            400,
+            found=False,
+            message="Missing abs_id parameter",
+            user_message="Missing abs_id parameter",
+        )
 
     hardcover_client = container.hardcover_client()
     if not hardcover_client.is_configured():
-        return json_error("Hardcover not configured", 400, found=False, user_message="Hardcover not configured")
+        return json_error(
+            "Hardcover not configured",
+            400,
+            found=False,
+            message="Hardcover not configured",
+            user_message="Hardcover not configured",
+        )
 
     book_data = None
     author = None

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -1,7 +1,6 @@
 # pyright: reportMissingImports=false, reportMissingModuleSource=false
 
 import logging
-import os
 import secrets
 import sys
 import threading

--- a/src/app_setup.py
+++ b/src/app_setup.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from pathlib import Path
 
 from dependency_injector import providers
 

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -7,8 +7,6 @@ import logging
 
 from flask import Blueprint, current_app, jsonify, request
 
-from src.utils.http import json_detail_error, json_error
-
 from src.blueprints.helpers import (
     find_in_grimmory,
     get_book_or_404,
@@ -19,6 +17,7 @@ from src.blueprints.helpers import (
     serialize_suggestion,
 )
 from src.db.models import Book
+from src.utils.http import json_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/blueprints/helpers.py
+++ b/src/blueprints/helpers.py
@@ -15,8 +15,6 @@ from pathlib import Path
 
 from flask import abort, current_app
 
-from src.sync_clients.abs_sync_client import TRANSCRIPT_DB_MANAGED
-from src.utils.path_utils import is_safe_path_within
 from src.utils.service_url_helper import get_hardcover_book_url, get_service_web_url  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -457,70 +455,17 @@ def cleanup_mapping_resources(book):
     if not book:
         return
 
-    container = get_container()
-    manager = get_manager()
-    database_service = get_database_service()
+    from src.services.mapping_cleanup_service import cleanup_mapping_resources as cleanup_resources
 
-    if book.transcript_file and book.transcript_file != TRANSCRIPT_DB_MANAGED:
-        data_dir = container.data_dir()
-        transcript_dir = data_dir / "transcripts"
-        transcript_path = Path(book.transcript_file)
-        if is_safe_path_within(transcript_path, transcript_dir):
-            try:
-                transcript_path.unlink()
-            except Exception as e:
-                logger.debug(f"Failed to delete transcript file '{book.transcript_file}': {e}")
-        else:
-            logger.warning(f"Blocked transcript deletion — path escapes transcripts dir: '{book.transcript_file}'")
-
-    if book.ebook_filename:
-        cache_dirs = []
-        try:
-            cache_dirs.append(container.epub_cache_dir())
-        except Exception as e:
-            logger.debug(f"Failed to get epub cache dir: {e}")
-
-        manager_cache_dir = getattr(manager, "epub_cache_dir", None)
-        if manager_cache_dir:
-            cache_dirs.append(manager_cache_dir)
-
-        seen_dirs = set()
-        for cache_dir in cache_dirs:
-            cache_dir_path = Path(cache_dir)
-            cache_dir_key = str(cache_dir_path)
-            if cache_dir_key in seen_dirs:
-                continue
-            seen_dirs.add(cache_dir_key)
-
-            cached_path = cache_dir_path / book.ebook_filename
-            if not is_safe_path_within(cached_path, cache_dir_path):
-                logger.warning(f"Blocked ebook cache deletion — path escapes cache dir: '{book.ebook_filename}'")
-                continue
-            if cached_path.exists():
-                try:
-                    cached_path.unlink()
-                    logger.info(f"Deleted cached ebook file: {book.ebook_filename}")
-                except Exception as e:
-                    logger.warning(f"Failed to delete cached ebook {book.ebook_filename}: {e}")
-
-    if book.sync_mode == "ebook_only" and book.kosync_doc_id:
-        logger.info(f"Deleting KOSync document record for ebook-only mapping: '{book.kosync_doc_id[:8]}'")
-        database_service.delete_kosync_document(book.kosync_doc_id)
-
-    collection_name = os.environ.get("ABS_COLLECTION_NAME", "Synced with KOReader")
-    try:
-        get_abs_service().remove_from_collection(book.abs_id, collection_name)
-    except Exception as e:
-        logger.warning(f"Failed to remove from ABS collection: {e}")
-
-    if book.ebook_filename:
-        shelf_filename = book.original_ebook_filename or book.ebook_filename
-        bl_client = get_grimmory_client()
-        if bl_client.is_configured():
-            try:
-                bl_client.remove_from_shelf(shelf_filename)
-            except Exception as e:
-                logger.warning(f"Failed to remove from Grimmory shelf: {e}")
+    cleanup_resources(
+        book,
+        container=get_container(),
+        manager=get_manager(),
+        database_service=get_database_service(),
+        abs_service=get_abs_service(),
+        grimmory_client=get_grimmory_client(),
+        collection_name=os.environ.get("ABS_COLLECTION_NAME", "Synced with KOReader"),
+    )
 
 
 def restart_server():

--- a/src/blueprints/reading_bp.py
+++ b/src/blueprints/reading_bp.py
@@ -8,8 +8,6 @@ from pathlib import Path
 
 from flask import Blueprint, abort, jsonify, render_template, request
 
-from src.utils.http import json_error
-
 from src.blueprints.helpers import (
     find_grimmory_metadata,
     get_abs_service,
@@ -23,6 +21,7 @@ from src.services.book_metadata_service import build_book_metadata, build_servic
 from src.services.reading_service import ReadingService
 from src.services.reading_stats_service import ReadingStatsService
 from src.utils.cover_resolver import resolve_book_covers
+from src.utils.http import json_error
 from src.utils.markdown import render_markdown_html
 
 logger = logging.getLogger(__name__)

--- a/src/blueprints/reading_bp.py
+++ b/src/blueprints/reading_bp.py
@@ -493,7 +493,7 @@ def update_rating(book_ref):
             hardcover_error = sync_result.get("hardcover_error")
     except Exception as e:
         logger.warning("Hardcover rating sync failed for book %s: %s", book.id, e)
-        hardcover_error = "Hardcover sync failed"
+        hardcover_error = str(e)
 
     return jsonify(
         {

--- a/src/blueprints/tbr_bp.py
+++ b/src/blueprints/tbr_bp.py
@@ -5,10 +5,9 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from src.utils.http import json_error
-
 from src.blueprints.helpers import get_container, get_database_service
 from src.services.hardcover_service import HC_IGNORED, HC_WANT_TO_READ
+from src.utils.http import json_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -85,9 +85,9 @@ class DatabaseService:
     def _run_alembic_migrations(self):
         """Run Alembic migrations to bring the database schema up to date."""
         try:
+            import alembic.command as alembic_command
             from alembic.config import Config
             from alembic.runtime.migration import MigrationContext
-            import alembic.command as alembic_command
 
             alembic_dir = Path(__file__).parent.parent.parent / "alembic"
             alembic_ini = alembic_dir.parent / "alembic.ini"

--- a/src/services/kosync_service.py
+++ b/src/services/kosync_service.py
@@ -6,10 +6,8 @@ document management. Route handlers in kosync_server.py delegate here.
 
 import json
 import logging
-import os
 import re
 import threading
-import time
 from pathlib import Path
 
 from src.db.models import Book, KosyncDocument

--- a/src/services/mapping_cleanup_service.py
+++ b/src/services/mapping_cleanup_service.py
@@ -1,0 +1,82 @@
+import logging
+import os
+from pathlib import Path
+
+from src.sync_clients.abs_sync_client import TRANSCRIPT_DB_MANAGED
+from src.utils.path_utils import is_safe_path_within
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_mapping_resources(
+    book,
+    *,
+    container,
+    manager,
+    database_service,
+    abs_service,
+    grimmory_client,
+    collection_name: str | None = None,
+):
+    """Delete external artifacts and membership data for a mapped book."""
+    if not book:
+        return
+
+    if book.transcript_file and book.transcript_file != TRANSCRIPT_DB_MANAGED:
+        data_dir = container.data_dir()
+        transcript_dir = data_dir / "transcripts"
+        transcript_path = Path(book.transcript_file)
+        if is_safe_path_within(transcript_path, transcript_dir):
+            try:
+                transcript_path.unlink()
+            except Exception as e:
+                logger.debug(f"Failed to delete transcript file '{book.transcript_file}': {e}")
+        else:
+            logger.warning(f"Blocked transcript deletion — path escapes transcripts dir: '{book.transcript_file}'")
+
+    if book.ebook_filename:
+        cache_dirs = []
+        try:
+            cache_dirs.append(container.epub_cache_dir())
+        except Exception as e:
+            logger.debug(f"Failed to get epub cache dir: {e}")
+
+        manager_cache_dir = getattr(manager, "epub_cache_dir", None)
+        if manager_cache_dir:
+            cache_dirs.append(manager_cache_dir)
+
+        seen_dirs = set()
+        for cache_dir in cache_dirs:
+            cache_dir_path = Path(cache_dir)
+            cache_dir_key = str(cache_dir_path)
+            if cache_dir_key in seen_dirs:
+                continue
+            seen_dirs.add(cache_dir_key)
+
+            cached_path = cache_dir_path / book.ebook_filename
+            if not is_safe_path_within(cached_path, cache_dir_path):
+                logger.warning(f"Blocked ebook cache deletion — path escapes cache dir: '{book.ebook_filename}'")
+                continue
+            if cached_path.exists():
+                try:
+                    cached_path.unlink()
+                    logger.info(f"Deleted cached ebook file: {book.ebook_filename}")
+                except Exception as e:
+                    logger.warning(f"Failed to delete cached ebook {book.ebook_filename}: {e}")
+
+    if book.sync_mode == "ebook_only" and book.kosync_doc_id:
+        logger.info(f"Deleting KOSync document record for ebook-only mapping: '{book.kosync_doc_id[:8]}'")
+        database_service.delete_kosync_document(book.kosync_doc_id)
+
+    collection_name = collection_name or os.environ.get("ABS_COLLECTION_NAME", "Synced with KOReader")
+    try:
+        abs_service.remove_from_collection(book.abs_id, collection_name)
+    except Exception as e:
+        logger.warning(f"Failed to remove from ABS collection: {e}")
+
+    if book.ebook_filename and grimmory_client.is_configured():
+        shelf_filename = book.original_ebook_filename or book.ebook_filename
+        try:
+            grimmory_client.remove_from_shelf(shelf_filename)
+        except Exception as e:
+            logger.warning(f"Failed to remove from Grimmory shelf: {e}")

--- a/src/services/reading_service.py
+++ b/src/services/reading_service.py
@@ -1,11 +1,12 @@
 """Service for reading status transitions, progress updates, and related side effects."""
 
 import logging
+import os
 import time
 from datetime import date
 
 from src.db.models import State
-from src.services.reading_date_service import push_grimmory_read_status
+from src.services.mapping_cleanup_service import cleanup_mapping_resources
 from src.services.status_machine import StatusMachine
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,6 @@ class ReadingService:
         This is the books.py mark_complete path which pushes progress to all sync clients
         and handles the delete-after-completion flow.
         """
-        from src.blueprints.helpers import cleanup_mapping_resources
         from src.sync_clients.sync_client_interface import LocatorResult, UpdateProgressRequest
 
         book = self.database_service.get_book_by_ref(book_id)
@@ -96,26 +96,21 @@ class ReadingService:
                 )
                 self.database_service.save_state(state)
 
-        # Record completion locally (skip if already completed — idempotent)
         if book.status != "completed":
-            today = date.today().isoformat()
-            reading_updates = {"finished_at": today}
-            if not book.started_at:
-                reading_updates["started_at"] = self.pull_started_at(book_id, container)
-            if book.finished_at:
-                reading_updates["read_count"] = (book.read_count or 1) + 1
-
-            book.status = "completed"
-            self.database_service.save_book(book)
-            self.database_service.update_book_reading_fields(book.id, **reading_updates)
-            self.database_service.add_reading_journal(book.id, event="finished", percentage=1.0, abs_id=book.abs_id)
-
-        # Push READ status to Grimmory instances
-        if book.ebook_filename:
-            push_grimmory_read_status(book, container, "READ")
+            result = self.status_machine.transition(book, "completed", "completion_sync", container=container)
+            if not result["success"]:
+                return result
 
         if perform_delete:
-            cleanup_mapping_resources(book)
+            cleanup_mapping_resources(
+                book,
+                container=container,
+                manager=container.sync_manager(),
+                database_service=self.database_service,
+                abs_service=container.abs_service(),
+                grimmory_client=container.grimmory_client_group(),
+                collection_name=os.environ.get("ABS_COLLECTION_NAME", "Synced with KOReader"),
+            )
             self.database_service.delete_book(book.id)
 
         return {"success": True}
@@ -129,12 +124,10 @@ class ReadingService:
         if not book:
             return {"success": False, "error": "Book not found"}
 
-        # Mark book as active if it hasn't been started yet
         if percentage > 0 and book.status not in ("active", "paused", "dnf", "completed"):
-            book.status = "active"
-            if not book.started_at:
-                book.started_at = self.pull_started_at(book_id, container)
-            self.database_service.save_book(book)
+            result = self.status_machine.transition(book, "active", "manual_progress", container=container)
+            if not result["success"]:
+                return result
 
         state = State(
             abs_id=book.abs_id,

--- a/src/services/status_machine.py
+++ b/src/services/status_machine.py
@@ -59,7 +59,10 @@ class StatusMachine:
         Args:
             book: Book model instance (will be mutated).
             new_status: Target status string.
-            source: 'local' or 'auto_complete'.
+            source: Transition source. Valid values are 'local' for full local
+                status changes, 'auto_complete' for automatic completion without
+                Grimmory push, 'completion_sync' for completion sync without
+                Hardcover push, and 'manual_progress' for date fill only.
             container: DI container (needed for HC push, Grimmory push, date pull).
             dates: Optional dict with 'started_at'/'finished_at' to use instead of pulling.
             allowed_from: If set, only allow transition from these statuses.

--- a/src/services/status_machine.py
+++ b/src/services/status_machine.py
@@ -5,6 +5,7 @@ consistent side effects (journal entries, date filling, HC push, etc.).
 """
 
 import logging
+from dataclasses import dataclass
 from datetime import date
 
 from src.utils.logging_utils import sanitize_log_data
@@ -22,12 +23,31 @@ EVENT_MAP = {
 }
 
 
+@dataclass(frozen=True)
+class TransitionSideEffects:
+    journal: bool = True
+    fill_dates: bool = True
+    push_hardcover: bool = True
+    cleanup_tbr: bool = True
+    push_grimmory: bool = True
+
+
+SOURCE_EFFECTS = {
+    "local": TransitionSideEffects(),
+    "auto_complete": TransitionSideEffects(push_grimmory=False),
+    "completion_sync": TransitionSideEffects(push_hardcover=False),
+    "manual_progress": TransitionSideEffects(journal=False, push_hardcover=False, cleanup_tbr=False, push_grimmory=False),
+}
+
+
 class StatusMachine:
     """Single entry point for all book status transitions.
 
     The `source` parameter controls which side effects fire:
     - 'local': journal + HC push + Grimmory push + TBR cleanup + date fill
     - 'auto_complete': journal + date fill + HC push + TBR cleanup
+    - 'completion_sync': journal + Grimmory push + TBR cleanup + date fill
+    - 'manual_progress': date fill only
     """
 
     def __init__(self, database_service):
@@ -47,6 +67,10 @@ class StatusMachine:
         Returns:
             dict with 'success', 'status', 'previous_status', and optionally 'error'.
         """
+        effects = SOURCE_EFFECTS.get(source)
+        if effects is None:
+            return {"success": False, "error": f"Invalid transition source: {source}"}
+
         if new_status not in VALID_STATUSES:
             return {"success": False, "error": f"Invalid status. Must be one of: {', '.join(sorted(VALID_STATUSES))}"}
 
@@ -56,6 +80,8 @@ class StatusMachine:
             return {"success": False, "error": f"Cannot change to '{new_status}' from status '{old_status}'"}
 
         if old_status == new_status:
+            if source == "completion_sync" and effects.push_grimmory and book.ebook_filename and container:
+                self._push_to_grimmory(book, new_status, old_status, container)
             return {"success": True, "status": new_status, "previous_status": old_status}
 
         # Apply status change
@@ -64,25 +90,23 @@ class StatusMachine:
             book.activity_flag = False
         self.database_service.save_book(book)
 
-        # Journal entry
-        self._record_journal(book, new_status, old_status, source, container)
+        if effects.journal:
+            self._record_journal(book, new_status, old_status, source, container)
 
-        # Date filling
-        self._fill_dates(book, new_status, old_status, source, container, dates)
+        if effects.fill_dates:
+            self._fill_dates(book, new_status, old_status, source, container, dates)
 
         if new_status in ("active", "paused", "dnf", "completed"):
             logger.info(f"Book status changed to '{new_status}': '{sanitize_log_data(book.title or book.abs_id)}'")
 
         # HC push
-        if source in ("local", "auto_complete") and container:
+        if effects.push_hardcover and container:
             self._push_to_hardcover(book, new_status, container)
 
-        # TBR cleanup — remove from Want to Read when book becomes active/finished
-        if new_status in ("active", "completed", "paused", "dnf") and source in ("local", "auto_complete"):
+        if effects.cleanup_tbr and new_status in ("active", "completed", "paused", "dnf"):
             self._cleanup_tbr(book)
 
-        # Grimmory push (local only)
-        if source == "local" and book.ebook_filename and container:
+        if effects.push_grimmory and book.ebook_filename and container:
             self._push_to_grimmory(book, new_status, old_status, container)
 
         return {"success": True, "status": new_status, "previous_status": old_status}

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -7,14 +7,14 @@ import signal
 from flask import Flask
 
 from src.app_runtime import (
-    apply_settings,
     get_or_create_secret_key,
     handle_exit_signal,
-    reconfigure_logging,
     reconcile_socket_listener,
+    reconfigure_logging,
     start_runtime_services,
 )
-from src.app_setup import get_runtime_state, setup_dependencies as _setup_dependencies
+from src.app_setup import get_runtime_state
+from src.app_setup import setup_dependencies as _setup_dependencies
 from src.app_template_context import inject_global_vars
 from src.blueprints import register_blueprints
 from src.blueprints.helpers import safe_folder_name

--- a/tests/test_reading_service.py
+++ b/tests/test_reading_service.py
@@ -193,6 +193,25 @@ class TestReadingServiceSetProgress:
         assert result["success"] is True
         assert result["percentage"] == 0.5
 
+    def test_set_progress_starts_book_through_status_machine(self):
+        book = _make_mock_book(id=1, status="not_started")
+        book.abs_id = "abs-1"
+        db = Mock()
+        db.get_book_by_id.return_value = book
+
+        container = Mock()
+        container.sync_clients.return_value = {}
+
+        svc = ReadingService(db)
+        svc.status_machine = Mock()
+        svc.status_machine.transition.return_value = {"success": True, "status": "active", "previous_status": "not_started"}
+
+        result = svc.set_progress(1, 0.5, container)
+
+        assert result["success"] is True
+        svc.status_machine.transition.assert_called_once_with(book, "active", "manual_progress", container=container)
+        db.save_book.assert_not_called()
+
 
 class TestReadingServiceUpdateStatus:
     @patch("src.services.reading_service.StatusMachine")
@@ -205,3 +224,56 @@ class TestReadingServiceUpdateStatus:
 
         assert result["success"] is False
         assert "not found" in result["error"].lower()
+
+
+class TestReadingServiceMarkComplete:
+    def test_mark_complete_records_transition_through_status_machine(self):
+        book = _make_mock_book(id=1, status="active")
+        book.abs_id = "abs-1"
+        book.ebook_filename = None
+        db = Mock()
+        db.get_book_by_ref.return_value = book
+
+        container = Mock()
+        container.sync_clients.return_value = {}
+
+        svc = ReadingService(db)
+        svc.status_machine = Mock()
+        svc.status_machine.transition.return_value = {
+            "success": True,
+            "status": "completed",
+            "previous_status": "active",
+        }
+
+        result = svc.mark_complete_with_sync(1, container)
+
+        assert result["success"] is True
+        svc.status_machine.transition.assert_called_once_with(book, "completed", "completion_sync", container=container)
+        db.add_reading_journal.assert_not_called()
+        db.update_book_reading_fields.assert_not_called()
+
+    def test_mark_complete_keeps_external_state_sync(self):
+        book = _make_mock_book(id=1, status="active")
+        book.abs_id = "abs-1"
+        book.ebook_filename = None
+        db = Mock()
+        db.get_book_by_ref.return_value = book
+
+        client = Mock()
+        client.is_configured.return_value = True
+        container = Mock()
+        container.sync_clients.return_value = {"Storyteller": client}
+
+        svc = ReadingService(db)
+        svc.status_machine = Mock()
+        svc.status_machine.transition.return_value = {
+            "success": True,
+            "status": "completed",
+            "previous_status": "active",
+        }
+
+        result = svc.mark_complete_with_sync(1, container)
+
+        assert result["success"] is True
+        client.update_progress.assert_called_once()
+        db.save_state.assert_called_once()

--- a/tests/test_sync_manager_startup.py
+++ b/tests/test_sync_manager_startup.py
@@ -41,7 +41,9 @@ def test_startup_checks_treats_false_return_as_failed_connection():
 
     manager = _make_sync_manager({"Storyteller": client})
 
-    with patch("src.sync_manager.time.sleep"), patch("src.sync_manager.logger") as mock_logger:
+    with patch("src.services.sync_manager_startup.time.sleep"), patch(
+        "src.services.sync_manager_startup.logger"
+    ) as mock_logger:
         manager.startup_checks()
 
     assert client.check_connection.call_count == 2
@@ -56,7 +58,9 @@ def test_startup_checks_logs_retry_success_only_when_second_attempt_succeeds():
 
     manager = _make_sync_manager({"Storyteller": client})
 
-    with patch("src.sync_manager.time.sleep"), patch("src.sync_manager.logger") as mock_logger:
+    with patch("src.services.sync_manager_startup.time.sleep"), patch(
+        "src.services.sync_manager_startup.logger"
+    ) as mock_logger:
         manager.startup_checks()
 
     assert client.check_connection.call_count == 2


### PR DESCRIPTION
## Summary
- centralize reading status side effects in `StatusMachine`
- extract mapping cleanup out of blueprint helpers into a service module
- preserve Hardcover error response contracts and sync-manager startup tests

## Verification
- `python3 -m py_compile src/services/status_machine.py src/services/reading_service.py src/blueprints/helpers.py src/services/mapping_cleanup_service.py`
- targeted Docker tests for reading, status, and path traversal passed
- focused failing-test rerun passed
- `./run-tests.sh -q` -> 810 passed, 2 skipped
- `scripts/git/verify-public-tree.sh`

Linear: INT-144 https://linear.app/interactive-buffoonery/issue/INT-144/centralize-reading-status-transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for sync failures—actual exceptions now displayed instead of generic messages, providing clearer feedback when operations encounter issues.

* **Improvements**
  * Enhanced status transition handling for more consistent and reliable book status management and syncing across different sync sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize reading status transitions through `StatusMachine` with source-based side effects
> - Introduces a `TransitionSideEffects` dataclass and `SOURCE_EFFECTS` map in [`status_machine.py`](https://github.com/serabi/pagekeeper/pull/58/files#diff-ab436aea3b36981b369107a46472a0accfc2057c1a7e5b6d63f70a32e96b2878) to configure per-source side effects (journal, date filling, Hardcover push, TBR cleanup, Grimmory push).
> - `ReadingService.mark_complete_with_sync` now delegates to `StatusMachine.transition` with source `'completion_sync'` instead of directly mutating status, dates, and journal; Grimmory push is handled by the state machine.
> - `ReadingService.set_progress` now uses `StatusMachine.transition` with source `'manual_progress'` when activating an unstarted book, instead of directly setting status and saving.
> - Extracts mapping cleanup into a new [`mapping_cleanup_service.py`](https://github.com/serabi/pagekeeper/pull/58/files#diff-495331591a9f03fceed1eea21e8c91768f9c486349d1fa4d5cba53e6f4d4fc83) and delegates to it from both `reading_service.py` and `blueprints/helpers.py`.
> - Risk: `transition()` now rejects unknown sources with an error; transition failures in `set_progress` will bubble up and abort the call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2a29b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->