### PR TITLE
fix(docker): define LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM python:3.13-slim
 
 # LD_LIBRARY_PATH includes CUDA paths — ignored when NVIDIA/CUDA libs are not installed
+ENV LD_LIBRARY_PATH="/usr/local/lib/python3.13/site-packages/nvidia/cublas/lib:/usr/local/lib/python3.13/site-packages/nvidia/cudnn/lib"
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     FLASK_APP=web_server.py \
     PYTHONPATH="/app" \
-    HF_HOME=/data/huggingface \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.13/site-packages/nvidia/cublas/lib:/usr/local/lib/python3.13/site-packages/nvidia/cudnn/lib"
+    HF_HOME=/data/huggingface
 
 WORKDIR /app
 

--- a/src/api/hardcover_client.py
+++ b/src/api/hardcover_client.py
@@ -17,8 +17,6 @@ import threading
 import time
 from datetime import date
 
-import requests
-
 from src.api.http_client_base import JsonHttpClientBase
 from src.utils.string_utils import calculate_similarity, clean_book_title
 

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -1,7 +1,6 @@
 # pyright: reportMissingImports=false, reportMissingModuleSource=false
 
 import logging
-import os
 import secrets
 import sys
 import threading

--- a/src/app_setup.py
+++ b/src/app_setup.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from pathlib import Path
 
 from dependency_injector import providers
 

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -7,8 +7,6 @@ import logging
 
 from flask import Blueprint, current_app, jsonify, request
 
-from src.utils.http import json_detail_error, json_error
-
 from src.blueprints.helpers import (
     find_in_grimmory,
     get_book_or_404,
@@ -19,6 +17,7 @@ from src.blueprints.helpers import (
     serialize_suggestion,
 )
 from src.db.models import Book
+from src.utils.http import json_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/blueprints/reading_bp.py
+++ b/src/blueprints/reading_bp.py
@@ -8,8 +8,6 @@ from pathlib import Path
 
 from flask import Blueprint, abort, jsonify, render_template, request
 
-from src.utils.http import json_error
-
 from src.blueprints.helpers import (
     find_grimmory_metadata,
     get_abs_service,
@@ -23,6 +21,7 @@ from src.services.book_metadata_service import build_book_metadata, build_servic
 from src.services.reading_service import ReadingService
 from src.services.reading_stats_service import ReadingStatsService
 from src.utils.cover_resolver import resolve_book_covers
+from src.utils.http import json_error
 from src.utils.markdown import render_markdown_html
 
 logger = logging.getLogger(__name__)

--- a/src/blueprints/tbr_bp.py
+++ b/src/blueprints/tbr_bp.py
@@ -5,10 +5,9 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from src.utils.http import json_error
-
 from src.blueprints.helpers import get_container, get_database_service
 from src.services.hardcover_service import HC_IGNORED, HC_WANT_TO_READ
+from src.utils.http import json_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -85,9 +85,9 @@ class DatabaseService:
     def _run_alembic_migrations(self):
         """Run Alembic migrations to bring the database schema up to date."""
         try:
+            import alembic.command as alembic_command
             from alembic.config import Config
             from alembic.runtime.migration import MigrationContext
-            import alembic.command as alembic_command
 
             alembic_dir = Path(__file__).parent.parent.parent / "alembic"
             alembic_ini = alembic_dir.parent / "alembic.ini"

--- a/src/services/kosync_service.py
+++ b/src/services/kosync_service.py
@@ -6,10 +6,8 @@ document management. Route handlers in kosync_server.py delegate here.
 
 import json
 import logging
-import os
 import re
 import threading
-import time
 from pathlib import Path
 
 from src.db.models import Book, KosyncDocument

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -7,14 +7,14 @@ import signal
 from flask import Flask
 
 from src.app_runtime import (
-    apply_settings,
     get_or_create_secret_key,
     handle_exit_signal,
-    reconfigure_logging,
     reconcile_socket_listener,
+    reconfigure_logging,
     start_runtime_services,
 )
-from src.app_setup import get_runtime_state, setup_dependencies as _setup_dependencies
+from src.app_setup import get_runtime_state
+from src.app_setup import setup_dependencies as _setup_dependencies
 from src.app_template_context import inject_global_vars
 from src.blueprints import register_blueprints
 from src.blueprints.helpers import safe_folder_name


### PR DESCRIPTION
## Summary

- Fixes the Dockerfile `UndefinedVar` warning for `LD_LIBRARY_PATH`
- Defines `LD_LIBRARY_PATH` as an explicit standalone `ENV`
- Removes the self-reference from the main app environment block while preserving the CUDA library paths
- Cleans stale Python imports/import ordering so the existing PR lint workflow passes

## Verification

```bash
docker build --check .
uvx ruff@0.15.12 check src/ tests/ alembic/ scripts/
```

Results:

```text
Check complete, no warnings found.
All checks passed!
```

Fixes #55

Linear: https://linear.app/interactive-buffoonery/issue/INT-146/fix-dockerfile-ld-library-path-undefinedvar-warning


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LD_LIBRARY_PATH` in Dockerfile to set CUDA library paths explicitly
> - Sets `LD_LIBRARY_PATH` to only the two required CUDA library paths in [Dockerfile](https://github.com/serabi/pagekeeper/pull/59/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557), replacing the previous approach that concatenated with any pre-existing value.
> - Removes unused imports across several modules (`os`, `time`, `Path`, `requests`, `json_detail_error`) as minor cleanup.
> - Behavioral Change: `LD_LIBRARY_PATH` inside the container no longer inherits or appends to any value from the build environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1aef2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->