### PR TITLE
Add PageKeeper book metadata overrides

### DIFF
--- a/alembic/versions/u1v2w3x4y5z6_add_book_metadata_overrides.py
+++ b/alembic/versions/u1v2w3x4y5z6_add_book_metadata_overrides.py
@@ -1,0 +1,41 @@
+"""add book metadata override columns
+
+Revision ID: u1v2w3x4y5z6
+Revises: t9u0v1w2x3y4
+Create Date: 2026-05-04
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "u1v2w3x4y5z6"
+down_revision: str | Sequence[str] | None = "t9u0v1w2x3y4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    book_cols = {col["name"] for col in inspector.get_columns("books")}
+
+    if "title_override" not in book_cols:
+        op.add_column("books", sa.Column("title_override", sa.String(500), nullable=True))
+    if "author_override" not in book_cols:
+        op.add_column("books", sa.Column("author_override", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    book_cols = {col["name"] for col in inspector.get_columns("books")}
+
+    if "author_override" in book_cols:
+        op.drop_column("books", "author_override")
+    if "title_override" in book_cols:
+        op.drop_column("books", "title_override")

--- a/src/blueprints/dashboard.py
+++ b/src/blueprints/dashboard.py
@@ -192,12 +192,15 @@ def index():
                 if book not in books_needing_title_save:
                     books_needing_title_save.append(book)
 
+        display_title = book.title_override or enriched_title
+        display_author = book.author_override or abs_author
+
         mapping = {
             "id": book.id,
             "abs_id": book.abs_id,
-            "title": enriched_title,
+            "title": display_title,
             "abs_subtitle": abs_subtitle,
-            "abs_author": abs_author,
+            "abs_author": display_author,
             "ebook_filename": book.ebook_filename,
             "kosync_doc_id": book.kosync_doc_id,
             "transcript_file": book.transcript_file,
@@ -265,7 +268,7 @@ def index():
                     "asin": hardcover_details.asin,
                     "matched_by": hardcover_details.matched_by,
                     "hardcover_linked": True,
-                    "hardcover_title": book.title,
+                    "hardcover_title": display_title,
                     "hardcover_cover_url": hardcover_details.hardcover_cover_url,
                     "hardcover_status_mismatch": hc_mismatch,
                 }

--- a/src/blueprints/reading_bp.py
+++ b/src/blueprints/reading_bp.py
@@ -58,16 +58,17 @@ def _metadata_override_value(book, field):
     return value if isinstance(value, str) and value else None
 
 
-def _build_book_reading_data(
-    book,
-    database_service,
-    abs_service,
-    states_by_book,
-    grimmory_by_filename=None,
-    abs_metadata_by_id=None,
-    hardcover_details=None,
-):
-    """Build a reading-focused data dict for a single book."""
+def _compute_reading_display_names(book, *, grimmory_by_filename=None, abs_metadata_by_id=None):
+    """Resolve enriched title/author the same way as reading cards and detail `book` dict.
+
+    Used by `_build_book_reading_data` and the metadata-overrides API so clients see
+    the same strings as the web UI (Grimmory stem replacement, optional ABS bulk author,
+    then PageKeeper overrides).
+
+    Returns a dict with display_title, display_author (reading card byline and detail hero),
+    source_*
+    fields, override flags, bl_meta for cover resolution, and book_type.
+    """
     sync_mode = book.sync_mode
     if sync_mode == "ebook_only":
         book_type = "ebook-only"
@@ -76,11 +77,6 @@ def _build_book_reading_data(
     else:
         book_type = "linked"
 
-    # Get unified progress from states
-    states = states_by_book.get(book.id, [])
-    max_progress = ReadingService.max_progress(states, as_percent=True)
-
-    # Enrich title/author from Grimmory or ABS metadata when available
     display_title = book.title or ""
     display_author = ""
     bl_meta = find_grimmory_metadata(book, grimmory_by_filename) if grimmory_by_filename else None
@@ -95,8 +91,8 @@ def _build_book_reading_data(
     if bl_meta and bl_meta.authors:
         display_author = bl_meta.authors
 
-    if not display_author and book_type != "ebook-only":
-        abs_meta = (abs_metadata_by_id or {}).get(book.abs_id, {})
+    if not display_author and book_type != "ebook-only" and book.abs_id:
+        abs_meta = (abs_metadata_by_id or {}).get(str(book.abs_id), {})
         display_author = abs_meta.get("author") or ""
 
     if not display_author and book.author:
@@ -112,6 +108,63 @@ def _build_book_reading_data(
     display_title = title_override or display_title
     display_author = author_override or display_author
 
+    return {
+        "display_title": display_title,
+        "display_author": display_author,
+        "source_title": source_title,
+        "source_author": source_author,
+        "title_override": title_override,
+        "author_override": author_override,
+        "has_metadata_override": bool(title_override or author_override),
+        "bl_meta": bl_meta,
+        "book_type": book_type,
+    }
+
+
+def _load_abs_reading_metadata_by_id(abs_service):
+    """Bulk ABS author map keyed by library item id (same source as the reading log)."""
+    abs_metadata_by_id: dict[str, dict[str, str]] = {}
+    try:
+        all_abs_books = abs_service.get_audiobooks()
+        for ab in all_abs_books:
+            ab_id = ab.get("id")
+            if not ab_id:
+                continue
+            metadata = ab.get("media", {}).get("metadata", {})
+            abs_metadata_by_id[str(ab_id)] = {
+                "author": metadata.get("authorName") or "",
+            }
+    except Exception as e:
+        logger.warning("Could not fetch ABS metadata for reading enrichment: %s", e)
+    return abs_metadata_by_id
+
+
+def _build_book_reading_data(
+    book,
+    database_service,
+    abs_service,
+    states_by_book,
+    grimmory_by_filename=None,
+    abs_metadata_by_id=None,
+    hardcover_details=None,
+):
+    """Build a reading-focused data dict for a single book."""
+    names = _compute_reading_display_names(
+        book, grimmory_by_filename=grimmory_by_filename, abs_metadata_by_id=abs_metadata_by_id
+    )
+    display_title = names["display_title"]
+    display_author = names["display_author"]
+    source_title = names["source_title"]
+    source_author = names["source_author"]
+    title_override = names["title_override"]
+    author_override = names["author_override"]
+    bl_meta = names["bl_meta"]
+    book_type = names["book_type"]
+
+    # Get unified progress from states
+    states = states_by_book.get(book.id, [])
+    max_progress = ReadingService.max_progress(states, as_percent=True)
+
     covers = resolve_book_covers(
         book, abs_service, database_service, book_type, grimmory_meta=bl_meta, hardcover_details=hardcover_details
     )
@@ -125,7 +178,7 @@ def _build_book_reading_data(
         "source_author": source_author,
         "title_override": title_override,
         "author_override": author_override,
-        "has_metadata_override": bool(title_override or author_override),
+        "has_metadata_override": names["has_metadata_override"],
         "ebook_filename": book.ebook_filename,
         "kosync_doc_id": book.kosync_doc_id,
         "status": book.status,
@@ -171,19 +224,7 @@ def reading_index():
     reading_statuses = {"active", "completed", "paused", "dnf", "not_started"}
     books = [b for b in books if b.status in reading_statuses]
 
-    abs_metadata_by_id = {}
-    try:
-        all_abs_books = abs_service.get_audiobooks()
-        for ab in all_abs_books:
-            ab_id = ab.get("id")
-            if not ab_id:
-                continue
-            metadata = ab.get("media", {}).get("metadata", {})
-            abs_metadata_by_id[ab_id] = {
-                "author": metadata.get("authorName") or "",
-            }
-    except Exception as e:
-        logger.warning(f"Could not fetch ABS metadata for reading log enrichment: {e}")
+    abs_metadata_by_id = _load_abs_reading_metadata_by_id(abs_service)
 
     # Fetch all states at once to avoid N+1
     states_by_book = database_service.get_states_by_book()
@@ -334,13 +375,20 @@ def reading_detail(book_ref):
 
     states_by_book = database_service.get_states_by_book()
 
-    # Grimmory enrichment
+    # Grimmory + ABS bulk enrichment (same inputs as the reading log for list/detail parity)
     enabled_bl_ids = get_enabled_grimmory_server_ids()
     grimmory_by_filename = database_service.get_grimmory_by_filename(enabled_server_ids=enabled_bl_ids)
+    abs_metadata_by_id = _load_abs_reading_metadata_by_id(abs_service)
 
     hc_details = database_service.get_hardcover_details(book.id)
     book_data = _build_book_reading_data(
-        book, database_service, abs_service, states_by_book, grimmory_by_filename, hardcover_details=hc_details
+        book,
+        database_service,
+        abs_service,
+        states_by_book,
+        grimmory_by_filename,
+        abs_metadata_by_id=abs_metadata_by_id,
+        hardcover_details=hc_details,
     )
     journals = database_service.get_reading_journals(book.id)
 
@@ -603,7 +651,12 @@ def update_dates(book_ref):
 
 @reading_bp.route("/api/reading/book/<book_ref>/metadata-overrides", methods=["POST"])
 def update_metadata_overrides(book_ref):
-    """Update PageKeeper-local title/author display overrides."""
+    """Update PageKeeper-local title/author display overrides.
+
+    Response title and author match the reading log and detail page after reload: same
+    Grimmory title enrichment, ABS bulk author map, and overrides as the reading card dict.
+    Native apps can treat these as canonical display strings without re-implementing enrichment.
+    """
     database_service = get_database_service()
     book = get_book_or_404(book_ref)
     data = request.get_json(silent=True) or {}
@@ -636,11 +689,21 @@ def update_metadata_overrides(book_ref):
     if not updated:
         return json_error("Book not found", 404)
 
+    abs_service = get_abs_service()
+    enabled_bl_ids = get_enabled_grimmory_server_ids()
+    grimmory_by_filename = database_service.get_grimmory_by_filename(enabled_server_ids=enabled_bl_ids)
+    abs_metadata_by_id = _load_abs_reading_metadata_by_id(abs_service)
+    names = _compute_reading_display_names(
+        updated,
+        grimmory_by_filename=grimmory_by_filename,
+        abs_metadata_by_id=abs_metadata_by_id,
+    )
+
     return jsonify(
         {
             "success": True,
-            "title": updated.display_title,
-            "author": updated.display_author,
+            "title": names["display_title"],
+            "author": names["display_author"],
             "title_override": updated.title_override,
             "author_override": updated.author_override,
         }

--- a/src/blueprints/reading_bp.py
+++ b/src/blueprints/reading_bp.py
@@ -53,6 +53,11 @@ def _synthetic_journal(abs_id, event, date_str, percentage=None):
     return _SyntheticJournal()
 
 
+def _metadata_override_value(book, field):
+    value = getattr(book, field, None)
+    return value if isinstance(value, str) and value else None
+
+
 def _build_book_reading_data(
     book,
     database_service,
@@ -100,6 +105,13 @@ def _build_book_reading_data(
     if not display_author:
         display_author = book.ebook_filename or ""
 
+    source_title = display_title
+    source_author = display_author
+    title_override = _metadata_override_value(book, "title_override")
+    author_override = _metadata_override_value(book, "author_override")
+    display_title = title_override or display_title
+    display_author = author_override or display_author
+
     covers = resolve_book_covers(
         book, abs_service, database_service, book_type, grimmory_meta=bl_meta, hardcover_details=hardcover_details
     )
@@ -109,6 +121,11 @@ def _build_book_reading_data(
         "abs_id": book.abs_id,
         "title": display_title,
         "abs_author": display_author,
+        "source_title": source_title,
+        "source_author": source_author,
+        "title_override": title_override,
+        "author_override": author_override,
+        "has_metadata_override": bool(title_override or author_override),
         "ebook_filename": book.ebook_filename,
         "kosync_doc_id": book.kosync_doc_id,
         "status": book.status,
@@ -352,6 +369,9 @@ def reading_detail(book_ref):
 
     container = get_container()
     metadata = build_book_metadata(book, container, database_service, abs_service)
+    author_override = _metadata_override_value(book, "author_override")
+    if author_override:
+        metadata["author"] = author_override
     hardcover = metadata.get("_hardcover")
 
     service_states, integrations, services_enabled = build_service_info(
@@ -577,6 +597,52 @@ def update_dates(book_ref):
             "success": True,
             "started_at": book.started_at,
             "finished_at": book.finished_at,
+        }
+    )
+
+
+@reading_bp.route("/api/reading/book/<book_ref>/metadata-overrides", methods=["POST"])
+def update_metadata_overrides(book_ref):
+    """Update PageKeeper-local title/author display overrides."""
+    database_service = get_database_service()
+    book = get_book_or_404(book_ref)
+    data = request.get_json(silent=True) or {}
+    allowed_fields = {"title_override", "author_override"}
+    present_fields = allowed_fields.intersection(data)
+
+    if not present_fields:
+        return json_error("No metadata override fields provided", 400)
+
+    updates = {}
+    for field in ("title_override", "author_override"):
+        if field not in data:
+            continue
+        value = data.get(field)
+        if value is None:
+            updates[field] = None
+            continue
+        value = str(value).strip()
+        if len(value) > 500:
+            label = "Title" if field == "title_override" else "Author"
+            return json_error(f"{label} override must be 500 characters or fewer", 400)
+        updates[field] = value or None
+
+    clears_all = updates.get("title_override") is None and updates.get("author_override") is None
+    has_existing_override = bool(book.title_override or book.author_override)
+    if set(updates) == allowed_fields and clears_all and not has_existing_override:
+        return json_error("Enter a title or author override before saving", 400)
+
+    updated = database_service.update_book_metadata_overrides(book.id, **updates)
+    if not updated:
+        return json_error("Book not found", 404)
+
+    return jsonify(
+        {
+            "success": True,
+            "title": updated.display_title,
+            "author": updated.display_author,
+            "title_override": updated.title_override,
+            "author_override": updated.author_override,
         }
     )
 

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -15,6 +15,7 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+_UNSET = object()
 
 
 class BookRepository(BaseRepository):
@@ -112,6 +113,23 @@ class BookRepository(BaseRepository):
             return self._upsert(Book, [Book.abs_id == book.abs_id], book, update_attrs)
         else:
             return self._save_new(book)
+
+    def update_book_metadata_overrides(self, book_id, *, title_override=_UNSET, author_override=_UNSET):
+        """Update PageKeeper-local metadata override fields for a book."""
+        with self.get_session() as session:
+            book = session.query(Book).filter(Book.id == book_id).first()
+            if not book:
+                return None
+
+            if title_override is not _UNSET:
+                book.title_override = title_override or None
+            if author_override is not _UNSET:
+                book.author_override = author_override or None
+
+            session.flush()
+            session.refresh(book)
+            session.expunge(book)
+            return book
 
     def delete_book(self, book_id):
         with self.get_session() as session:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -115,6 +115,8 @@ class Book(Base):
     custom_cover_url = Column(String(500), nullable=True)
     author = Column(String(500), nullable=True)
     subtitle = Column(String(500), nullable=True)
+    title_override = Column(String(500), nullable=True)
+    author_override = Column(String(500), nullable=True)
 
     # Reading tracker fields
     started_at = Column(String(10), nullable=True)  # YYYY-MM-DD
@@ -160,6 +162,8 @@ class Book(Base):
         custom_cover_url: str = None,
         author: str = None,
         subtitle: str = None,
+        title_override: str = None,
+        author_override: str = None,
         started_at: str = None,
         finished_at: str = None,
         rating: float = None,
@@ -180,10 +184,20 @@ class Book(Base):
         self.custom_cover_url = custom_cover_url
         self.author = author
         self.subtitle = subtitle
+        self.title_override = title_override
+        self.author_override = author_override
         self.started_at = started_at
         self.finished_at = finished_at
         self.rating = rating
         self.read_count = read_count
+
+    @property
+    def display_title(self):
+        return self.title_override or self.title or ""
+
+    @property
+    def display_author(self):
+        return self.author_override or self.author or ""
 
     def __repr__(self):
         return f"<Book(id={self.id}, abs_id='{self.abs_id}', title='{self.title}')>"

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -193,10 +193,12 @@ class Book(Base):
 
     @property
     def display_title(self):
+        """Stored title plus override only (no Grimmory/ABS enrichment). Prefer reading APIs for UI strings."""
         return self.title_override or self.title or ""
 
     @property
     def display_author(self):
+        """Stored author plus override only. Prefer reading APIs for detail hero author."""
         return self.author_override or self.author or ""
 
     def __repr__(self):

--- a/src/services/book_metadata_service.py
+++ b/src/services/book_metadata_service.py
@@ -121,7 +121,10 @@ def build_book_metadata(book, container, database_service, abs_service, grimmory
 
     # ABS item URL
     if sync_mode != "ebook_only":
-        abs_base = get_service_web_url("ABS") or (abs_service.abs_client.base_url if abs_service.is_available() else "")
+        abs_client = getattr(abs_service, "abs_client", None)
+        abs_base = get_service_web_url("ABS") or (
+            getattr(abs_client, "base_url", "") if abs_service.is_available() else ""
+        )
         metadata["abs_url"] = f"{abs_base}/item/{abs_id}" if abs_base else None
 
     # Stash the hardcover row for callers that need it (service info, template flags)

--- a/static/css/reading.css
+++ b/static/css/reading.css
@@ -1107,6 +1107,53 @@
   line-height: 1.3;
 }
 
+.r-detail-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.r-detail-title-copy {
+  min-width: 0;
+}
+
+.r-metadata-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.r-metadata-override-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary-border);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+
+.r-metadata-edit-btn {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.r-metadata-edit-btn:hover {
+  color: var(--color-text);
+  background: var(--color-surface-hover);
+  border-color: var(--color-border);
+}
+
 .r-detail-badges {
   display: flex;
   align-items: center;
@@ -1428,6 +1475,53 @@
   color: var(--color-error);
   border-color: rgba(239,68,68,0.3);
   background: rgba(239,68,68,0.08);
+}
+
+.metadata-override-modal-content {
+  max-width: 480px;
+}
+
+.metadata-override-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metadata-override-help {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.metadata-override-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.metadata-override-field input {
+  width: 100%;
+}
+
+.metadata-override-status {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.metadata-override-status--error {
+  color: var(--color-error);
+}
+
+.metadata-override-footer {
+  align-items: center;
+}
+
+.metadata-override-footer .btn-danger-subtle {
+  margin-right: auto;
 }
 
 /* Metadata within overview tab (not wrapped in .r-meta-panel) */
@@ -2222,6 +2316,16 @@ a.r-service-row-name:hover { text-decoration: underline; }
   .r-hero-info {
     width: 100%;
     gap: 10px;
+  }
+
+  .r-detail-title-row {
+    align-items: center;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .r-metadata-actions {
+    align-items: center;
   }
 
   .r-detail-title {

--- a/static/js/reading.js
+++ b/static/js/reading.js
@@ -434,6 +434,78 @@ function initReadingPage(currentYear, activeTab) {
 
 
 function initReadingDetail() {
+  // ── PageKeeper metadata overrides ──
+  const metadataModal = document.getElementById('metadata-override-modal');
+  const metadataTitleInput = document.getElementById('metadata-title-override');
+  const metadataAuthorInput = document.getElementById('metadata-author-override');
+  const metadataStatus = document.getElementById('metadata-override-status');
+  const metadataSaveBtn = document.getElementById('metadata-save-btn');
+  const metadataClearBtn = document.getElementById('metadata-clear-btn');
+
+  function setMetadataStatus(message, state) {
+    if (!metadataStatus) return;
+    metadataStatus.hidden = !message;
+    metadataStatus.textContent = message || '';
+    metadataStatus.className = 'metadata-override-status' + (state ? ` metadata-override-status--${state}` : '');
+  }
+
+  function setMetadataSaving(isSaving) {
+    if (metadataSaveBtn) metadataSaveBtn.disabled = isSaving;
+    if (metadataClearBtn) metadataClearBtn.disabled = isSaving;
+  }
+
+  function openMetadataOverrideModal() {
+    if (!metadataModal) return;
+    setMetadataStatus('', '');
+    metadataModal.style.display = 'flex';
+    if (metadataTitleInput) metadataTitleInput.focus();
+  }
+
+  function closeMetadataOverrideModal() {
+    if (!metadataModal) return;
+    metadataModal.style.display = 'none';
+    setMetadataStatus('', '');
+  }
+
+  function saveMetadataOverrides(clear) {
+    if (!metadataModal) return;
+    const bookId = metadataModal.dataset.bookId;
+    const hasExistingOverride = metadataModal.dataset.hasOverride === 'true';
+    const titleOverride = clear ? null : ((metadataTitleInput && metadataTitleInput.value.trim()) || null);
+    const authorOverride = clear ? null : ((metadataAuthorInput && metadataAuthorInput.value.trim()) || null);
+
+    if (!clear && !hasExistingOverride && !titleOverride && !authorOverride) {
+      setMetadataStatus('Enter a title or author override before saving.', 'error');
+      return;
+    }
+
+    setMetadataSaving(true);
+    setMetadataStatus(clear ? 'Clearing overrides...' : 'Saving...', 'muted');
+    fetch(`/api/reading/book/${bookId}/metadata-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title_override: titleOverride,
+        author_override: authorOverride,
+      }),
+    })
+      .then(r => r.json().then(data => ({ ok: r.ok, data })))
+      .then(result => {
+        if (!result.ok || !result.data.success) {
+          throw result.data;
+        }
+        window.location.reload();
+      })
+      .catch(err => {
+        setMetadataSaving(false);
+        setMetadataStatus((err && err.error) || 'Metadata was not saved.', 'error');
+      });
+  }
+
+  window.openMetadataOverrideModal = openMetadataOverrideModal;
+  window.closeMetadataOverrideModal = closeMetadataOverrideModal;
+  window.saveMetadataOverrides = saveMetadataOverrides;
+
   // ── Rating stars (5 stars, half-star support) ──
   const rc = document.getElementById('rating-stars');
   if (rc) {

--- a/templates/reading_detail.html
+++ b/templates/reading_detail.html
@@ -62,10 +62,22 @@
                     </button>
                 </div>
                 <div class="r-hero-info">
-                    <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle %}: {{ metadata.subtitle }}{% endif %}</h1>
-                    {% if metadata.author %}
-                    <div class="r-detail-author">{{ metadata.author }}</div>
-                    {% endif %}
+                    <div class="r-detail-title-row">
+                        <div class="r-detail-title-copy">
+                            <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle %}: {{ metadata.subtitle }}{% endif %}</h1>
+                            {% if metadata.author %}
+                            <div class="r-detail-author">{{ metadata.author }}</div>
+                            {% endif %}
+                        </div>
+                        <div class="r-metadata-actions">
+                            {% if book.has_metadata_override %}
+                            <span class="r-metadata-override-badge">PageKeeper override</span>
+                            {% endif %}
+                            <button type="button" class="r-metadata-edit-btn" onclick="openMetadataOverrideModal()">
+                                Edit PageKeeper Metadata
+                            </button>
+                        </div>
+                    </div>
 
                     <div class="r-detail-badges">
                         <span class="status-badge status-{{ book.status }}">{{ book.status|replace('_', ' ')|title }}</span>
@@ -657,6 +669,52 @@
             </div>
         </div>
         {% endif %}
+    </div>
+
+    {# ── Metadata Override Modal ── #}
+    <div id="metadata-override-modal"
+         class="modal-backdrop"
+         style="display:none;"
+         data-book-id="{{ book.id }}"
+         data-has-override="{{ 'true' if book.has_metadata_override else 'false' }}"
+         onclick="if(event.target===this)closeMetadataOverrideModal()">
+        <div class="modal-content metadata-override-modal-content">
+            <div class="modal-header">
+                <h3>Edit PageKeeper Metadata</h3>
+                <button class="modal-close" onclick="closeMetadataOverrideModal()">&times;</button>
+            </div>
+            <div class="modal-body metadata-override-modal-body">
+                <p class="metadata-override-help">
+                    These values change how PageKeeper displays this book. They do not update source services.
+                </p>
+                <label class="metadata-override-field" for="metadata-title-override">
+                    <span>Title override</span>
+                    <input type="text"
+                           id="metadata-title-override"
+                           class="input-inline"
+                           maxlength="500"
+                           value="{{ book.title_override or '' }}"
+                           placeholder="{{ book.source_title or 'Source title' }}">
+                </label>
+                <label class="metadata-override-field" for="metadata-author-override">
+                    <span>Author override</span>
+                    <input type="text"
+                           id="metadata-author-override"
+                           class="input-inline"
+                           maxlength="500"
+                           value="{{ book.author_override or '' }}"
+                           placeholder="{{ book.source_author or 'Source author' }}">
+                </label>
+                <div id="metadata-override-status" class="metadata-override-status" hidden></div>
+            </div>
+            <div class="modal-footer metadata-override-footer">
+                {% if book.has_metadata_override %}
+                <button type="button" class="btn btn-sm btn-danger-subtle" id="metadata-clear-btn" onclick="saveMetadataOverrides(true)">Clear Overrides</button>
+                {% endif %}
+                <button type="button" class="btn btn-secondary btn-sm" onclick="closeMetadataOverrideModal()">Cancel</button>
+                <button type="button" class="btn btn-primary btn-sm" id="metadata-save-btn" onclick="saveMetadataOverrides(false)">Save</button>
+            </div>
+        </div>
     </div>
 
     {# ── Cover Picker Modal ── #}

--- a/templates/reading_detail.html
+++ b/templates/reading_detail.html
@@ -64,9 +64,9 @@
                 <div class="r-hero-info">
                     <div class="r-detail-title-row">
                         <div class="r-detail-title-copy">
-                            <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle %}: {{ metadata.subtitle }}{% endif %}</h1>
-                            {% if metadata.author %}
-                            <div class="r-detail-author">{{ metadata.author }}</div>
+                            <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle and not book.has_metadata_override %}: {{ metadata.subtitle }}{% endif %}</h1>
+                            {% if book.abs_author %}
+                            <div class="r-detail-author">{{ book.abs_author|e }}</div>
                             {% endif %}
                         </div>
                         <div class="r-metadata-actions">

--- a/templates/reading_detail.html
+++ b/templates/reading_detail.html
@@ -64,7 +64,7 @@
                 <div class="r-hero-info">
                     <div class="r-detail-title-row">
                         <div class="r-detail-title-copy">
-                            <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle and not book.has_metadata_override %}: {{ metadata.subtitle }}{% endif %}</h1>
+                            <h1 class="r-detail-title">{{ book.title }}{% if metadata.subtitle and not book.title_override %}: {{ metadata.subtitle }}{% endif %}</h1>
                             {% if book.abs_author %}
                             <div class="r-detail-author">{{ book.abs_author|e }}</div>
                             {% endif %}

--- a/tests/test_dashboard_errors.py
+++ b/tests/test_dashboard_errors.py
@@ -1,6 +1,9 @@
 """Tests for dashboard graceful degradation when services fail."""
 
+from types import SimpleNamespace
 from unittest.mock import Mock
+
+from src.db.models import Book
 
 
 def _setup_dashboard_db_defaults(mock_db):
@@ -91,6 +94,50 @@ def test_index_renders_with_no_books(client, mock_container):
     _setup_dashboard_db_defaults(mock_container.mock_database_service)
     response = client.get("/")
     assert response.status_code == 200
+
+
+def test_index_uses_metadata_overrides_over_source_enrichment(flask_app, mock_container):
+    """Dashboard cards should prefer PageKeeper metadata overrides."""
+    book = Book(
+        abs_id="abs-1",
+        title="default_source_title",
+        author="Cached Author",
+        ebook_filename="default_source_title.epub",
+        status="completed",
+        title_override="Override Title",
+        author_override="Override Author",
+    )
+    book.id = 1
+    db = mock_container.mock_database_service
+    _setup_dashboard_db_defaults(db)
+    db.get_all_books.return_value = [book]
+    db.get_grimmory_by_filename.return_value = {
+        "default_source_title.epub": [
+            SimpleNamespace(
+                title="Grimmory Title",
+                authors="Grimmory Author",
+                raw_metadata_dict={},
+                server_id="1",
+            )
+        ]
+    }
+
+    abs_service = Mock()
+    abs_service.get_audiobooks.return_value = [
+        {"id": "abs-1", "media": {"metadata": {"authorName": "Live ABS Author", "subtitle": ""}}}
+    ]
+    abs_service.is_available.return_value = True
+    abs_service.get_cover_proxy_url.return_value = "/covers/abs-1.jpg"
+    flask_app.config["abs_service"] = abs_service
+
+    with flask_app.test_client() as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"Override Title" in response.data
+    assert b"Override Author" in response.data
+    assert b"Grimmory Title" not in response.data
+    assert b"Live ABS Author" not in response.data
 
 
 # ── Multiple service failures ─────────────────────────────────────

--- a/tests/test_reading_routes.py
+++ b/tests/test_reading_routes.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -19,6 +19,10 @@ class MockABSService:
 
     def get_audiobooks(self):
         return []
+
+    def get_item_details(self, abs_id):
+        """Return None so build_book_metadata falls back to stored book fields in route tests."""
+        return None
 
     def get_cover_proxy_url(self, abs_id):
         return f"/covers/{abs_id}.jpg"
@@ -158,6 +162,8 @@ class TestReadingRoutes(unittest.TestCase):
         self.client = self.app.test_client()
         self.db = self.mock_container.mock_database_service
         self.db.get_hardcover_details.return_value = None
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_bookfusion_book_by_book_id.return_value = None
 
     def test_stats_endpoint_returns_rich_payload(self):
         self.db.get_all_books.return_value = [
@@ -359,6 +365,61 @@ class TestReadingRoutes(unittest.TestCase):
 
         self.assertEqual(resp.status_code, 404)
 
+    def test_metadata_overrides_response_includes_grimmory_title_when_only_author_changes(self):
+        bl = SimpleNamespace(title="Enriched From Grimmory", authors="")
+        self.db.get_grimmory_by_filename.return_value = {"bar.epub": [bl]}
+        book = Book(
+            abs_id="abs-99",
+            title="bar",
+            ebook_filename="bar.epub",
+            author="Shelf Author",
+            status="active",
+        )
+        book.id = 101
+        updated = Book(
+            abs_id="abs-99",
+            title="bar",
+            ebook_filename="bar.epub",
+            author="Shelf Author",
+            status="active",
+            author_override="Override Author",
+        )
+        updated.id = 101
+        self.db.get_book_by_ref.return_value = book
+        self.db.update_book_metadata_overrides.return_value = updated
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"author_override": "Override Author"},
+        )
+        data = resp.get_json()
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["title"], "Enriched From Grimmory")
+        self.assertEqual(data["author"], "Override Author")
+
+    def test_metadata_overrides_response_uses_abs_bulk_author_when_stored_author_empty(self):
+        abs_row = {"id": "bulk-abs-1", "media": {"metadata": {"authorName": "Audiobookshelf Author"}}}
+        with patch.object(self.mock_container.mock_abs_service, "get_audiobooks", return_value=[abs_row]):
+            book = Book(abs_id="bulk-abs-1", title="T", author="", status="active")
+            book.id = 42
+            updated = Book(abs_id="bulk-abs-1", title="T", author="", status="active", title_override="T2")
+            updated.id = 42
+            self.db.get_book_by_ref.return_value = book
+            self.db.update_book_metadata_overrides.return_value = updated
+
+            resp = self.client.post(
+                "/api/reading/book/42/metadata-overrides",
+                json={"title_override": "T2"},
+            )
+        data = resp.get_json()
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["title"], "T2")
+        self.assertEqual(data["author"], "Audiobookshelf Author")
+
     def test_reading_page_renders_log_and_stats_tabs(self):
         book = Book(abs_id="book-1", title="Test Book", status="active")
         state = State(abs_id="book-1", client_name="manual", percentage=0.5)
@@ -433,3 +494,54 @@ class TestReadingRoutes(unittest.TestCase):
         self.assertIn(b"Override Author", resp.data)
         self.assertIn(b"PageKeeper override", resp.data)
         self.assertIn(b"Edit PageKeeper Metadata", resp.data)
+
+    def test_reading_detail_omits_hero_subtitle_when_metadata_override_active(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            subtitle="Catalog Subtitle",
+            status="active",
+            title_override="Override Title",
+            author_override="Override Author",
+        )
+        book.id = 1
+        self.db.get_book_by_ref.return_value = book
+        self.db.get_states_by_book.return_value = {}
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_hardcover_details.return_value = None
+        self.db.get_reading_journals.return_value = []
+        self.db.get_bookfusion_highlights_for_book_by_book_id.return_value = []
+        self.db.is_bookfusion_linked_by_book_id.return_value = False
+        self.db.find_tbr_by_book_id.return_value = None
+        self.db.get_bookfusion_book_by_book_id.return_value = None
+
+        resp = self.client.get("/reading/book/1")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn(b"Override Title: Catalog Subtitle", resp.data)
+        self.assertIn(b'<h1 class="r-detail-title">Override Title</h1>', resp.data)
+
+    def test_reading_detail_includes_hero_subtitle_without_metadata_override(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            subtitle="Catalog Subtitle",
+            status="active",
+        )
+        book.id = 1
+        self.db.get_book_by_ref.return_value = book
+        self.db.get_states_by_book.return_value = {}
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_hardcover_details.return_value = None
+        self.db.get_reading_journals.return_value = []
+        self.db.get_bookfusion_highlights_for_book_by_book_id.return_value = []
+        self.db.is_bookfusion_linked_by_book_id.return_value = False
+        self.db.find_tbr_by_book_id.return_value = None
+        self.db.get_bookfusion_book_by_book_id.return_value = None
+
+        resp = self.client.get("/reading/book/1")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b'<h1 class="r-detail-title">Source Title: Catalog Subtitle</h1>', resp.data)

--- a/tests/test_reading_routes.py
+++ b/tests/test_reading_routes.py
@@ -242,6 +242,123 @@ class TestReadingRoutes(unittest.TestCase):
         self.db.get_book_by_ref.assert_called_with("42")
         self.db.update_book_reading_fields.assert_called_with(42, rating=5.0)
 
+    def test_metadata_overrides_endpoint_saves_trimmed_values(self):
+        book = Book(abs_id="book-1", title="Source Title", author="Source Author", status="active")
+        book.id = 101
+        updated = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            status="active",
+            title_override="Clean Title",
+            author_override="Clean Author",
+        )
+        updated.id = 101
+        self.db.get_book_by_ref.return_value = book
+        self.db.update_book_metadata_overrides.return_value = updated
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"title_override": "  Clean Title  ", "author_override": "  Clean Author  "},
+        )
+        data = resp.get_json()
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["title"], "Clean Title")
+        self.assertEqual(data["author"], "Clean Author")
+        self.db.update_book_metadata_overrides.assert_called_once_with(
+            101,
+            title_override="Clean Title",
+            author_override="Clean Author",
+        )
+
+    def test_metadata_overrides_endpoint_clears_blank_values(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            status="active",
+            title_override="Old Title",
+            author_override="Old Author",
+        )
+        book.id = 101
+        updated = Book(abs_id="book-1", title="Source Title", author="Source Author", status="active")
+        updated.id = 101
+        self.db.get_book_by_ref.return_value = book
+        self.db.update_book_metadata_overrides.return_value = updated
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"title_override": "", "author_override": "   "},
+        )
+        data = resp.get_json()
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["title"], "Source Title")
+        self.assertEqual(data["author"], "Source Author")
+        self.db.update_book_metadata_overrides.assert_called_once_with(
+            101,
+            title_override=None,
+            author_override=None,
+        )
+
+    def test_metadata_overrides_endpoint_rejects_no_allowed_fields(self):
+        book = Book(abs_id="book-1", title="Source Title", status="active")
+        book.id = 101
+        self.db.get_book_by_ref.return_value = book
+
+        resp = self.client.post("/api/reading/book/101/metadata-overrides", json={"title": "Nope"})
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_metadata_overrides_endpoint_rejects_empty_save_without_existing_override(self):
+        book = Book(abs_id="book-1", title="Source Title", status="active")
+        book.id = 101
+        self.db.get_book_by_ref.return_value = book
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"title_override": "", "author_override": ""},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_metadata_overrides_endpoint_rejects_long_title(self):
+        book = Book(abs_id="book-1", title="Source Title", status="active")
+        book.id = 101
+        self.db.get_book_by_ref.return_value = book
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"title_override": "x" * 501},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_metadata_overrides_endpoint_rejects_long_author(self):
+        book = Book(abs_id="book-1", title="Source Title", status="active")
+        book.id = 101
+        self.db.get_book_by_ref.return_value = book
+
+        resp = self.client.post(
+            "/api/reading/book/101/metadata-overrides",
+            json={"author_override": "x" * 501},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_metadata_overrides_endpoint_missing_book_returns_404(self):
+        self.db.get_book_by_ref.return_value = None
+
+        resp = self.client.post(
+            "/api/reading/book/missing/metadata-overrides",
+            json={"title_override": "Clean Title"},
+        )
+
+        self.assertEqual(resp.status_code, 404)
+
     def test_reading_page_renders_log_and_stats_tabs(self):
         book = Book(abs_id="book-1", title="Test Book", status="active")
         state = State(abs_id="book-1", client_name="manual", percentage=0.5)
@@ -259,3 +376,60 @@ class TestReadingRoutes(unittest.TestCase):
         self.assertIn(b">Log<", resp.data)
         self.assertIn(b">Stats<", resp.data)
         self.assertIn(b"Monthly Completions", resp.data)
+
+    def test_reading_page_uses_metadata_overrides_for_cards(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            status="active",
+            title_override="Override Title",
+            author_override="Override Author",
+        )
+        book.id = 1
+        state = State(abs_id="book-1", book_id=1, client_name="manual", percentage=0.5)
+        self.db.get_all_books.return_value = [book]
+        self.db.get_all_states.return_value = [state]
+        self.db.get_states_by_book.return_value = {1: [state]}
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_all_grimmory_books.return_value = []
+        self.db.get_all_hardcover_details.return_value = []
+        self.db.get_reading_goal.return_value = None
+        self.db.get_tbr_items.return_value = []
+        self.db.get_tbr_count.return_value = 0
+
+        resp = self.client.get("/reading")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Override Title", resp.data)
+        self.assertIn(b"Override Author", resp.data)
+        self.assertIn(b'data-title="Override Title"', resp.data)
+        self.assertIn(b'data-author="Override Author"', resp.data)
+
+    def test_reading_detail_uses_metadata_overrides_for_hero(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            status="active",
+            title_override="Override Title",
+            author_override="Override Author",
+        )
+        book.id = 1
+        self.db.get_book_by_ref.return_value = book
+        self.db.get_states_by_book.return_value = {}
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_hardcover_details.return_value = None
+        self.db.get_reading_journals.return_value = []
+        self.db.get_bookfusion_highlights_for_book_by_book_id.return_value = []
+        self.db.is_bookfusion_linked_by_book_id.return_value = False
+        self.db.find_tbr_by_book_id.return_value = None
+        self.db.get_bookfusion_book_by_book_id.return_value = None
+
+        resp = self.client.get("/reading/book/1")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Override Title", resp.data)
+        self.assertIn(b"Override Author", resp.data)
+        self.assertIn(b"PageKeeper override", resp.data)
+        self.assertIn(b"Edit PageKeeper Metadata", resp.data)

--- a/tests/test_reading_routes.py
+++ b/tests/test_reading_routes.py
@@ -545,3 +545,29 @@ class TestReadingRoutes(unittest.TestCase):
 
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b'<h1 class="r-detail-title">Source Title: Catalog Subtitle</h1>', resp.data)
+
+    def test_reading_detail_keeps_subtitle_with_author_only_override(self):
+        book = Book(
+            abs_id="book-1",
+            title="Source Title",
+            author="Source Author",
+            subtitle="Catalog Subtitle",
+            status="active",
+            author_override="Override Author",
+        )
+        book.id = 1
+        self.db.get_book_by_ref.return_value = book
+        self.db.get_states_by_book.return_value = {}
+        self.db.get_grimmory_by_filename.return_value = {}
+        self.db.get_hardcover_details.return_value = None
+        self.db.get_reading_journals.return_value = []
+        self.db.get_bookfusion_highlights_for_book_by_book_id.return_value = []
+        self.db.is_bookfusion_linked_by_book_id.return_value = False
+        self.db.find_tbr_by_book_id.return_value = None
+        self.db.get_bookfusion_book_by_book_id.return_value = None
+
+        resp = self.client.get("/reading/book/1")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b'<h1 class="r-detail-title">Source Title: Catalog Subtitle</h1>', resp.data)
+        self.assertIn(b"Override Author", resp.data)

--- a/tests/test_reading_tracker.py
+++ b/tests/test_reading_tracker.py
@@ -36,10 +36,10 @@ class TestReadingTrackerModels(unittest.TestCase):
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def _create_book(self, abs_id="test-book-1", title="Test Book", status="active"):
+    def _create_book(self, abs_id="test-book-1", title="Test Book", status="active", author=None):
         from src.db.models import Book
 
-        book = Book(abs_id=abs_id, title=title, status=status)
+        book = Book(abs_id=abs_id, title=title, status=status, author=author)
         return self.db.save_book(book)
 
     # -- Book reading fields --
@@ -51,6 +51,69 @@ class TestReadingTrackerModels(unittest.TestCase):
         self.assertIsNone(book.finished_at)
         self.assertIsNone(book.rating)
         self.assertEqual(book.read_count, 1)
+
+    def test_book_metadata_override_defaults(self):
+        """New books fall back to imported title/author when no overrides exist."""
+        book = self._create_book(author="Source Author")
+        self.assertIsNone(book.title_override)
+        self.assertIsNone(book.author_override)
+        self.assertEqual(book.display_title, "Test Book")
+        self.assertEqual(book.display_author, "Source Author")
+
+    def test_update_book_metadata_overrides(self):
+        """Metadata overrides persist separately from imported metadata."""
+        book = self._create_book(author="Source Author")
+        updated = self.db.update_book_metadata_overrides(
+            book.id,
+            title_override="Clean Title",
+            author_override="Clean Author",
+        )
+        self.assertEqual(updated.title_override, "Clean Title")
+        self.assertEqual(updated.author_override, "Clean Author")
+        self.assertEqual(updated.display_title, "Clean Title")
+        self.assertEqual(updated.display_author, "Clean Author")
+
+    def test_clearing_book_metadata_override_falls_back_to_source(self):
+        """Clearing one override restores source metadata for that field."""
+        book = self._create_book(author="Source Author")
+        self.db.update_book_metadata_overrides(
+            book.id,
+            title_override="Clean Title",
+            author_override="Clean Author",
+        )
+
+        updated = self.db.update_book_metadata_overrides(book.id, title_override=None)
+
+        self.assertIsNone(updated.title_override)
+        self.assertEqual(updated.author_override, "Clean Author")
+        self.assertEqual(updated.display_title, "Test Book")
+        self.assertEqual(updated.display_author, "Clean Author")
+
+    def test_update_book_metadata_overrides_nonexistent(self):
+        """Returns None for a missing book."""
+        result = self.db.update_book_metadata_overrides(99999, title_override="Missing")
+        self.assertIsNone(result)
+
+    def test_save_book_source_refresh_preserves_metadata_overrides(self):
+        """Source metadata refreshes should not clear PageKeeper overrides."""
+        from src.db.models import Book
+
+        book = self._create_book(title="Imported Title", author="Imported Author")
+        self.db.update_book_metadata_overrides(
+            book.id,
+            title_override="Override Title",
+            author_override="Override Author",
+        )
+
+        self.db.save_book(Book(abs_id=book.abs_id, title="Refreshed Title", author="Refreshed Author"))
+        refreshed = self.db.get_book_by_abs_id(book.abs_id)
+
+        self.assertEqual(refreshed.title, "Refreshed Title")
+        self.assertEqual(refreshed.author, "Refreshed Author")
+        self.assertEqual(refreshed.title_override, "Override Title")
+        self.assertEqual(refreshed.author_override, "Override Author")
+        self.assertEqual(refreshed.display_title, "Override Title")
+        self.assertEqual(refreshed.display_author, "Override Author")
 
     def test_update_book_reading_fields(self):
         """update_book_reading_fields sets only reading fields."""


### PR DESCRIPTION
## Summary
- add local book title and author override columns with an Alembic migration
- add a reading metadata override API that trims, validates, clears, and returns canonical display strings
- update dashboard, reading log, and reading detail display paths to prefer PageKeeper overrides
- add the reading detail modal for editing/clearing overrides
- cover override persistence, display precedence, validation, and author-only subtitle behavior in tests

## Verification
- `scripts/git/verify-public-tree.sh --ref HEAD`
- `./run-tests.sh tests/test_reading_routes.py` ran the full Docker suite instead of only the requested file: 822 passed, 2 skipped, 5 failed

## Known unrelated test failures
- `tests/test_hardcover_routes.py::TestHardcoverResolveEndpoint::test_resolve_hardcover_not_configured_returns_400`
- `tests/test_hardcover_routes.py::TestHardcoverResolveEndpoint::test_resolve_missing_abs_id_returns_400`
- `tests/test_reading_bp_errors.py::test_update_rating_hardcover_sync_fails_local_succeeds`
- `tests/test_sync_manager_startup.py::test_startup_checks_treats_false_return_as_failed_connection`
- `tests/test_sync_manager_startup.py::test_startup_checks_logs_retry_success_only_when_second_attempt_succeeds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to override book titles and authors in the reading detail page and dashboard via a new metadata override modal.
  * Overrides are applied across all book displays when set, automatically falling back to original metadata when not configured.

* **Style**
  * Added styling for the metadata override UI, including edit button, status badge, and modal dialog.

* **Tests**
  * Expanded test coverage for metadata override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-book title and author metadata overrides to PageKeeper reading views
> - Adds `title_override` and `author_override` nullable columns to the `books` table via an Alembic migration, with corresponding ORM properties (`display_title`, `display_author`) that fall back to stored values when no override is set.
> - Introduces a `POST /api/reading/book/<book_ref>/metadata-overrides` endpoint that validates, trims, and persists overrides, returning updated display values.
> - Updates the reading detail page with an override badge and modal editor; the dashboard card rendering also prefers override values for title and author.
> - Centralizes display name computation in `_compute_reading_display_names` in [reading_bp.py](https://github.com/serabi/pagekeeper/pull/60/files#diff-6b917855e1a3d779736dc689cb19f2d1fe338de2f3957cf10780ec18dcc84918), consolidating Grimmory enrichment, ABS bulk metadata fallback, and override application.
> - Fixes an `AttributeError` in [book_metadata_service.py](https://github.com/serabi/pagekeeper/pull/60/files#diff-fec9dba1a0ccef45b96c31b885edad8f0024383f3fb76647d34d140774bb69a9) when `abs_service` lacks an `abs_client`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a009f8b. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->