### PR TITLE
[codex] Deepen book intake module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ CLAUDE.md
 .sidecar-start.sh
 .sidecar-base
 .td-root
+
+# Agent scratch directories
+.agent-prompts/
+.agent-reports/
+.worktrees/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# PageKeeper Context
+
+## Book Intake Module
+
+The Book Intake Module is the domain Module that turns a user's matching or import intent into a PageKeeper `Book`.
+
+Its Interface is organized around user intent: map audiobook plus ebook, import audio-only, import ebook-only, attach an ebook, and attach an audiobook. The Module owns the implementation details behind that seam: Grimmory lookup and shelf updates, KoSync hash computation and preservation, duplicate merge migration, Storyteller reservation and async submission, Hardcover automatch, ABS collection updates, suggestion resolution, and initial book status.
+
+This Depth gives route callers leverage: blueprints parse requests and choose redirects or errors, while intake side effects stay local. The intended locality is that future changes to intake ordering or cross-service side effects happen in `src/services/book_intake_service.py`, not in matching routes.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,4 +11,6 @@ services:
       - ./tests:/app/tests:ro
       - ./templates:/app/templates:ro
       - ./static:/app/static:ro
+      - ./alembic:/app/alembic:ro
+      - ./alembic.ini:/app/alembic.ini:ro
       - ./pyproject.toml:/app/pyproject.toml:ro

--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from flask import Blueprint, current_app, flash, redirect, render_template, request, session, url_for
+from markupsafe import Markup
 
 from src.blueprints.helpers import (
     any_grimmory_configured,
@@ -29,6 +30,10 @@ from src.utils.path_utils import sanitize_filename
 logger = logging.getLogger(__name__)
 
 matching_bp = Blueprint("matching", __name__)
+
+
+def _escape_template_value(value):
+    return Markup.escape(value or "")
 
 
 def _copy_book_merge_metadata(existing_book, overrides=None):
@@ -139,8 +144,8 @@ def suggestions():
         bookfusion_enabled=bookfusion_enabled,
         bookfusion_catalog_count=bookfusion_catalog_count,
         suggestions_data=suggestions_list,
-        initial_search=initial_search,
-        selected_source_id=selected_source_id,
+        initial_search=_escape_template_value(initial_search),
+        selected_source_id=_escape_template_value(selected_source_id),
     )
 
 
@@ -339,13 +344,13 @@ def match():
         audiobooks=audiobooks,
         ebooks=ebooks,
         storyteller_books=storyteller_books,
-        search=search,
+        search=_escape_template_value(search),
         get_title=manager.get_audiobook_title,
-        attach_to=attach_to,
-        attach_title=attach_title,
-        link_to=link_to,
-        link_title=link_title,
-        preselect_abs_id=preselect_abs_id,
+        attach_to=_escape_template_value(attach_to),
+        attach_title=_escape_template_value(attach_title),
+        link_to=_escape_template_value(link_to),
+        link_title=_escape_template_value(link_title),
+        preselect_abs_id=_escape_template_value(preselect_abs_id),
         storyteller_submit_available=storyteller_submit_available,
         storyteller_force_mode=storyteller_force_mode,
         storyteller_configured=storyteller_configured,
@@ -522,7 +527,7 @@ def batch_match():
         storyteller_books=storyteller_books,
         queue=queue_view["items"],
         queue_summary=queue_view,
-        search=search,
+        search=_escape_template_value(search),
         get_title=manager.get_audiobook_title,
         storyteller_submit_available=storyteller_submit_available,
         storyteller_force_mode=storyteller_force_mode,

--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import threading
 from pathlib import Path
 
 from flask import Blueprint, current_app, flash, redirect, render_template, request, session, url_for
@@ -23,8 +22,7 @@ from src.blueprints.helpers import (
     get_searchable_ebooks,
     serialize_suggestion,
 )
-from src.db.models import Book, StorytellerSubmission
-from src.services.kosync_service import ensure_kosync_document
+from src.services.book_intake_service import BookIntakeService
 from src.utils.logging_utils import sanitize_log_data
 from src.utils.path_utils import sanitize_filename
 
@@ -33,73 +31,23 @@ logger = logging.getLogger(__name__)
 matching_bp = Blueprint("matching", __name__)
 
 
-def _create_storyteller_reservation(database_service, abs_id):
-    """Create a submission record synchronously so the job scheduler knows to defer.
-
-    This prevents a race condition where the background job picks up the book
-    and starts Whisper transcription before the async submission thread has
-    finished copying files and creating its own record.
-    """
-    book = database_service.get_book_by_ref(abs_id)
-    storyteller_uuid = book.storyteller_uuid if book else None
-    submission = StorytellerSubmission(
-        abs_id=abs_id, book_id=book.id if book else None, status="queued", storyteller_uuid=storyteller_uuid
-    )
-    database_service.save_storyteller_submission(submission)
-    return submission
-
-
-def _submit_to_storyteller_async(container, abs_id, book_title, ebook_filename, books_dir, epub_cache_dir):
-    """Submit a book to Storyteller in a background thread so the response isn't blocked."""
-
-    def _do_submit():
-        try:
-            st_sub_svc = container.storyteller_submission_service()
-            if not st_sub_svc.is_available():
-                logger.warning(f"Storyteller submission skipped for '{book_title}': service not available")
-                return
-            from src.utils.epub_resolver import get_local_epub
-
-            epub_path = get_local_epub(ebook_filename, books_dir, epub_cache_dir, container.grimmory_client())
-            audio_files = container.abs_client().get_audio_files(abs_id)
-            if epub_path and audio_files:
-                result = st_sub_svc.submit_book(abs_id, book_title, Path(epub_path), audio_files)
-                if not result.success:
-                    logger.warning(f"Storyteller submission failed for '{book_title}': {result.error}")
-            else:
-                logger.warning(
-                    f"Storyteller submission skipped for '{book_title}': "
-                    f"epub={'found' if epub_path else 'missing'}, audio={len(audio_files or [])} files"
-                )
-        except Exception as e:
-            logger.warning(f"Storyteller submission error for '{book_title}': {e}")
-            try:
-                db_svc = container.database_service()
-                book = db_svc.get_book_by_abs_id(abs_id)
-                submission = db_svc.get_active_storyteller_submission_by_book_id(book.id) if book else None
-                if submission:
-                    db_svc.update_storyteller_submission_status(submission.id, "failed")
-            except Exception:
-                pass
-
-    threading.Thread(target=_do_submit, daemon=True).start()
-
-
 def _copy_book_merge_metadata(existing_book, overrides=None):
-    metadata = {
-        "storyteller_uuid": existing_book.storyteller_uuid,
-        "original_ebook_filename": existing_book.original_ebook_filename,
-        "abs_ebook_item_id": existing_book.abs_ebook_item_id,
-        "ebook_item_id": existing_book.ebook_item_id or existing_book.abs_ebook_item_id,
-        "custom_cover_url": existing_book.custom_cover_url,
-        "started_at": existing_book.started_at,
-        "finished_at": existing_book.finished_at,
-        "rating": existing_book.rating,
-        "read_count": existing_book.read_count or 1,
-    }
-    if overrides:
-        metadata.update({key: value for key, value in overrides.items() if value is not None})
-    return metadata
+    return BookIntakeService._copy_book_merge_metadata(existing_book, overrides)
+
+
+def _get_book_intake_service(container=None):
+    container = container or get_container()
+    return BookIntakeService(
+        container=container,
+        database_service=get_database_service(),
+        abs_service=get_abs_service(),
+        collection_name=current_app.config["ABS_COLLECTION_NAME"],
+        books_dir=current_app.config.get("BOOKS_DIR", ""),
+        epub_cache_dir=current_app.config.get("EPUB_CACHE_DIR", ""),
+        find_in_grimmory=find_in_grimmory,
+        get_kosync_id_for_ebook=get_kosync_id_for_ebook,
+        attempt_hardcover_automatch=attempt_hardcover_automatch,
+    )
 
 
 def _create_book_mapping(
@@ -113,127 +61,18 @@ def _create_book_mapping(
     author=None,
     subtitle=None,
 ):
-    """Create a book mapping with full pipeline: Grimmory, KOSync, merge, Hardcover, etc.
-
-    Returns (book, error_message). On success error_message is None.
-    On failure book is None and error_message describes the problem.
-    """
-    database_service = get_database_service()
-    abs_service = get_abs_service()
-
-    # Grimmory lookup
-    grimmory_id = None
-    bl_match, bl_match_client = find_in_grimmory(ebook_filename)
-    if bl_match:
-        grimmory_id = bl_match.get("id")
-
-    # KOSync ID
-    kosync_doc_id = get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_match_client)
-    if not kosync_doc_id:
-        logger.warning(f"Cannot compute KOSync ID for '{sanitize_log_data(ebook_filename)}'")
-        return None, "Could not compute KOSync ID for ebook"
-
-    # Hash preservation
-    current_book_entry = database_service.get_book_by_ref(abs_id)
-    if current_book_entry and current_book_entry.kosync_doc_id:
-        logger.info(f"Preserving existing hash '{current_book_entry.kosync_doc_id}' for '{abs_id}'")
-        kosync_doc_id = current_book_entry.kosync_doc_id
-
-    # Duplicate merge detection
-    existing_book = database_service.get_book_by_kosync_id(kosync_doc_id)
-    migration_source_id = None
-    original_ebook_filename = None
-
-    if existing_book and existing_book.abs_id != abs_id:
-        logger.info(f"Merging existing '{existing_book.abs_id}' into '{abs_id}'")
-        migration_source_id = existing_book.abs_id
-        ebook_item_id = existing_book.ebook_item_id or existing_book.abs_ebook_item_id or existing_book.abs_id
-        original_ebook_filename = existing_book.original_ebook_filename or existing_book.ebook_filename
-        merge_metadata = _copy_book_merge_metadata(
-            existing_book,
-            {
-                "abs_ebook_item_id": ebook_item_id,
-                "ebook_item_id": ebook_item_id,
-                "original_ebook_filename": original_ebook_filename,
-                "storyteller_uuid": storyteller_uuid or existing_book.storyteller_uuid,
-            },
-        )
-    else:
-        merge_metadata = {
-            "storyteller_uuid": storyteller_uuid,
-            "original_ebook_filename": None,
-            "abs_ebook_item_id": None,
-            "ebook_item_id": None,
-        }
-
-    # Create book
-    book = Book(
+    """Compatibility wrapper around the Book Intake Module."""
+    result = _get_book_intake_service(container).map_audiobook_ebook(
         abs_id=abs_id,
         title=title,
         ebook_filename=ebook_filename,
-        kosync_doc_id=kosync_doc_id,
-        transcript_file=None,
-        status="pending",
         duration=duration,
+        storyteller_uuid=storyteller_uuid,
+        storyteller_submit=storyteller_submit,
         author=author,
         subtitle=subtitle,
-        **merge_metadata,
     )
-    database_service.save_book(book, is_new=True)
-    ensure_kosync_document(book, database_service)
-
-    # Storyteller reservation (before HTTP calls to prevent race)
-    if storyteller_submit:
-        _create_storyteller_reservation(database_service, abs_id)
-
-    # Duplicate merge migration
-    if migration_source_id:
-        try:
-            database_service.migrate_book_data(migration_source_id, abs_id)
-            database_service.delete_book(existing_book.id)
-            abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
-            logger.info(f"Successfully merged {migration_source_id} into {abs_id}")
-        except Exception as e:
-            logger.error(f"Failed to merge book data: {e}")
-            raise
-
-    # Hardcover automatch
-    attempt_hardcover_automatch(container, book)
-
-    # ABS collection add
-    if not migration_source_id:
-        abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
-
-    # Grimmory shelf add
-    if bl_match_client:
-        shelf_filename = original_ebook_filename or ebook_filename
-        try:
-            bl_match_client.add_to_shelf(shelf_filename)
-        except Exception as e:
-            logger.warning(f"Grimmory add_to_shelf failed for '{sanitize_log_data(shelf_filename)}': {e}")
-
-    # Storyteller submission (background thread)
-    if storyteller_submit:
-        _submit_to_storyteller_async(
-            container,
-            abs_id,
-            title,
-            ebook_filename,
-            current_app.config.get("BOOKS_DIR", ""),
-            current_app.config.get("EPUB_CACHE_DIR", ""),
-        )
-
-    # Resolve suggestions
-    database_service.resolve_suggestion(abs_id)
-    database_service.resolve_suggestion(kosync_doc_id)
-    try:
-        device_doc = database_service.get_kosync_doc_by_filename(ebook_filename)
-        if device_doc and device_doc.document_hash != kosync_doc_id:
-            database_service.resolve_suggestion(device_doc.document_hash)
-    except Exception as e:
-        logger.warning(f"Failed to check/resolve device hash: {e}")
-
-    return book, None
+    return result.book, result.error
 
 
 def _build_batch_queue_item(item):
@@ -313,6 +152,7 @@ def match():
 
     if request.method == "POST":
         action = request.form.get("action", "")
+        intake_service = _get_book_intake_service(container)
 
         # --- Audio-only import (no ebook required) ---
         if action == "audio_only":
@@ -324,21 +164,13 @@ def match():
             selected_ab = next((ab for ab in audiobooks if ab["id"] == abs_id), None)
             if not selected_ab:
                 return "Audiobook not found", 404
-            book = Book(
+            intake_service.import_audio_only(
                 abs_id=abs_id,
                 title=manager.get_audiobook_title(selected_ab),
-                ebook_filename=None,
-                kosync_doc_id=None,
-                status="not_started",
                 duration=manager.get_duration(selected_ab),
-                sync_mode="audiobook",
                 author=get_audiobook_author(selected_ab),
                 subtitle=selected_ab.get("media", {}).get("metadata", {}).get("subtitle") or None,
             )
-            database_service.save_book(book, is_new=True)
-            abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
-            attempt_hardcover_automatch(container, book)
-            database_service.resolve_suggestion(abs_id)
             return redirect(url_for("dashboard.index"))
 
         # --- Ebook-only import (no audiobook required) ---
@@ -351,70 +183,23 @@ def match():
             if not ebook_filename and not storyteller_uuid:
                 return "An ebook or Storyteller selection is required", 400
 
-            if ebook_filename:
-                # Ebook present (possibly with Storyteller too)
-                grimmory_id = None
-                matched_bl_client = None
-                bl_book, matched_bl_client = find_in_grimmory(ebook_filename)
-                if bl_book:
-                    grimmory_id = bl_book.get("id")
-                kosync_doc_id = get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=matched_bl_client)
-                if not kosync_doc_id:
-                    return "Could not compute KOSync ID for ebook", 404
-                title = ebook_display_name or (bl_book.get("title") if bl_book else None) or Path(ebook_filename).stem
-            else:
-                # Storyteller-only (no ebook file)
-                title = storyteller_title or ebook_display_name or "Storyteller Book"
-                ebook_filename = None
-                kosync_doc_id = None
-
-            book = Book(
-                abs_id=None,
-                title=title,
+            result = intake_service.import_ebook_only(
                 ebook_filename=ebook_filename,
-                kosync_doc_id=kosync_doc_id,
-                status="not_started",
-                sync_mode="ebook_only",
+                ebook_display_name=ebook_display_name,
                 storyteller_uuid=storyteller_uuid,
+                storyteller_title=storyteller_title,
             )
-            database_service.save_book(book, is_new=True)
-            ensure_kosync_document(book, database_service)
-            # Resolve any suggestions involving these source IDs
-            if kosync_doc_id:
-                database_service.resolve_suggestion(kosync_doc_id, source="kosync")
-            if storyteller_uuid:
-                database_service.resolve_suggestion(storyteller_uuid, source="storyteller")
-            if ebook_filename:
-                database_service.resolve_suggestion(ebook_filename, source="grimmory")
+            if result.error:
+                return result.error, result.status_code
             return redirect(url_for("dashboard.index"))
 
         # --- Attach ebook to audio-only book ---
         if action == "attach_ebook":
             attach_abs_id = request.form.get("attach_abs_id")
             ebook_filename = sanitize_filename(request.form.get("ebook_filename"))
-            if not attach_abs_id or not ebook_filename:
-                return "Missing book ID or ebook filename", 400
-            book = database_service.get_book_by_ref(attach_abs_id)
-            if not book:
-                return "Book not found", 404
-            grimmory_id = None
-            bl_book, bl_client = find_in_grimmory(ebook_filename)
-            if bl_book:
-                grimmory_id = bl_book.get("id")
-            kosync_doc_id = get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
-            if not kosync_doc_id:
-                return "Could not compute KOSync ID for ebook", 404
-            book.ebook_filename = ebook_filename
-            book.kosync_doc_id = kosync_doc_id
-            book.status = "pending"
-            database_service.save_book(book)
-            ensure_kosync_document(book, database_service)
-            if bl_client:
-                try:
-                    bl_client.add_to_shelf(ebook_filename)
-                except Exception as e:
-                    logger.warning(f"Grimmory add_to_shelf failed for '{sanitize_log_data(ebook_filename)}': {e}")
-            database_service.resolve_suggestion(kosync_doc_id)
+            result = intake_service.attach_ebook(abs_id=attach_abs_id, ebook_filename=ebook_filename)
+            if result.error:
+                return result.error, result.status_code
             return redirect(url_for("dashboard.index"))
 
         # --- Attach audiobook to ebook-only book ---
@@ -433,38 +218,16 @@ def match():
             selected_ab = next((ab for ab in audiobooks if ab["id"] == abs_id), None)
             if not selected_ab:
                 return "Audiobook not found", 404
-            new_book = Book(
+            result = intake_service.attach_audiobook(
+                source_book_id=link_book_id,
                 abs_id=abs_id,
                 title=manager.get_audiobook_title(selected_ab),
-                ebook_filename=book.ebook_filename,
-                kosync_doc_id=book.kosync_doc_id,
-                status=book.status or "not_started",
                 duration=manager.get_duration(selected_ab),
-                sync_mode="audiobook",
                 author=get_audiobook_author(selected_ab),
                 subtitle=selected_ab.get("media", {}).get("metadata", {}).get("subtitle") or None,
-                **_copy_book_merge_metadata(
-                    book,
-                    {
-                        "storyteller_uuid": book.storyteller_uuid,
-                        "original_ebook_filename": book.original_ebook_filename,
-                    },
-                ),
             )
-            database_service.save_book(new_book)
-            ensure_kosync_document(new_book, database_service)
-            try:
-                database_service.migrate_book_data(link_book_id, abs_id)
-                database_service.delete_book(book.id)
-                abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
-                logger.info(f"Successfully merged {link_book_id} into {abs_id}")
-            except Exception as e:
-                logger.error(f"Failed to merge book data: {e}")
-                raise
-            attempt_hardcover_automatch(container, new_book)
-            database_service.resolve_suggestion(abs_id)
-            if new_book.kosync_doc_id:
-                database_service.resolve_suggestion(new_book.kosync_doc_id)
+            if result.error:
+                return result.error, result.status_code
             return redirect(url_for("dashboard.index"))
 
         # --- Standard flow (requires audiobook) ---
@@ -597,12 +360,12 @@ def match():
 def batch_match():
     container = get_container()
     manager = get_manager()
-    database_service = get_database_service()
 
     abs_service = get_abs_service()
 
     if request.method == "POST":
         action = request.form.get("action")
+        intake_service = _get_book_intake_service(container)
         if action == "add_to_queue":
             session.setdefault("queue", [])
             abs_id = request.form.get("audiobook_id") or ""
@@ -669,63 +432,28 @@ def batch_match():
             for item in session.get("queue", []):
                 item_label = item.get("ebook_display_name") or item.get("ebook_filename") or item.get("abs_id")
                 try:
-                    # Handle audio-only queue items
                     if item.get("audio_only"):
-                        book = Book(
+                        intake_service.import_audio_only(
                             abs_id=item["abs_id"],
                             title=item["title"],
-                            ebook_filename=None,
-                            kosync_doc_id=None,
-                            status="not_started",
                             duration=item["duration"],
-                            sync_mode="audiobook",
                             author=item.get("author"),
                             subtitle=item.get("subtitle"),
                         )
-                        database_service.save_book(book, is_new=True)
-                        abs_service.add_to_collection(item["abs_id"], current_app.config["ABS_COLLECTION_NAME"])
-                        attempt_hardcover_automatch(container, book)
-                        database_service.resolve_suggestion(item["abs_id"])
                         continue
 
-                    # Handle ebook-only queue items
                     if item.get("ebook_only"):
-                        ebook_filename = item["ebook_filename"]
-                        storyteller_uuid = item.get("storyteller_uuid") or None
-
-                        if ebook_filename:
-                            bl_book, bl_client = find_in_grimmory(ebook_filename)
-                            grimmory_id = bl_book.get("id") if bl_book else None
-                            kosync_doc_id = get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
-                            if not kosync_doc_id:
-                                failed_items.append(item.get("ebook_display_name") or ebook_filename)
-                                continue
-                            title = (
-                                item.get("ebook_display_name")
-                                or (bl_book.get("title") if bl_book else None)
-                                or Path(ebook_filename).stem
-                            )
-                        else:
-                            title = item.get("title", "Storyteller Book")
-                            ebook_filename = None
-                            kosync_doc_id = None
-
-                        book = Book(
-                            abs_id=None,
-                            title=title,
-                            ebook_filename=ebook_filename,
-                            kosync_doc_id=kosync_doc_id,
-                            status="not_started",
-                            sync_mode="ebook_only",
-                            storyteller_uuid=storyteller_uuid,
+                        result = intake_service.import_ebook_only(
+                            ebook_filename=item["ebook_filename"],
+                            ebook_display_name=item.get("ebook_display_name") or "",
+                            storyteller_uuid=item.get("storyteller_uuid") or None,
+                            storyteller_title=item.get("title", "Storyteller Book"),
                         )
-                        database_service.save_book(book, is_new=True)
-                        ensure_kosync_document(book, database_service)
-                        if kosync_doc_id:
-                            database_service.resolve_suggestion(kosync_doc_id)
+                        if result.error:
+                            failed_items.append(item.get("ebook_display_name") or item["ebook_filename"])
                         continue
 
-                    book, error = _create_book_mapping(
+                    _book, error = _create_book_mapping(
                         container,
                         abs_id=item["abs_id"],
                         title=item["title"],

--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -36,6 +36,11 @@ def _escape_template_value(value):
     return Markup.escape(value or "")
 
 
+def _redirect_search_value():
+    """Return a bounded same-route search value for redirects."""
+    return (request.form.get("search") or "")[:200]
+
+
 def _copy_book_merge_metadata(existing_book, overrides=None):
     return BookIntakeService._copy_book_merge_metadata(existing_book, overrides)
 
@@ -318,8 +323,8 @@ def match():
     try:
         st_sub_svc = container.storyteller_submission_service()
         storyteller_submit_available = st_sub_svc.is_available()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Storyteller submission availability check failed: %s", e)
 
     storyteller_force_mode = os.environ.get("STORYTELLER_FORCE_MODE", "false").lower() == "true"
     storyteller_configured = container.storyteller_client().is_configured()
@@ -382,7 +387,7 @@ def batch_match():
             storyteller_uuid = request.form.get("storyteller_uuid", "")
 
             if not abs_id and not ebook_filename and not storyteller_uuid:
-                return redirect(url_for("matching.batch_match", search=request.form.get("search", "")))
+                return redirect(url_for("matching.batch_match", search=_redirect_search_value()))
 
             # Resolve audiobook metadata if present
             selected_ab = None
@@ -390,7 +395,7 @@ def batch_match():
                 audiobooks = abs_service.get_audiobooks()
                 selected_ab = next((ab for ab in audiobooks if ab["id"] == abs_id), None)
                 if not selected_ab:
-                    return redirect(url_for("matching.batch_match", search=request.form.get("search", "")))
+                    return redirect(url_for("matching.batch_match", search=_redirect_search_value()))
 
             # Dedup key: abs_id if present, otherwise ebook_filename
             queue_key = abs_id or ebook_filename
@@ -423,7 +428,7 @@ def batch_match():
                     }
                 )
                 session.modified = True
-            return redirect(url_for("matching.batch_match", search=request.form.get("search", "")))
+            return redirect(url_for("matching.batch_match", search=_redirect_search_value()))
         elif action == "remove_from_queue":
             remove_key = request.form.get("queue_key") or request.form.get("abs_id")
             session["queue"] = [
@@ -512,8 +517,8 @@ def batch_match():
     try:
         st_sub_svc = container.storyteller_submission_service()
         storyteller_submit_available = st_sub_svc.is_available()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Storyteller submission availability check failed: %s", e)
 
     storyteller_force_mode = os.environ.get("STORYTELLER_FORCE_MODE", "false").lower() == "true"
     storyteller_configured = container.storyteller_client().is_configured()

--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -4,7 +4,7 @@ import logging
 import os
 from pathlib import Path
 
-from flask import Blueprint, current_app, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint, Response, current_app, flash, redirect, render_template, request, session, url_for
 from markupsafe import Markup
 
 from src.blueprints.helpers import (
@@ -39,6 +39,10 @@ def _escape_template_value(value):
 def _redirect_search_value():
     """Return a bounded same-route search value for redirects."""
     return (request.form.get("search") or "")[:200]
+
+
+def _plain_error_response(message, status_code):
+    return Response(message or "Request failed", status=status_code, mimetype="text/plain")
 
 
 def _copy_book_merge_metadata(existing_book, overrides=None):
@@ -200,7 +204,7 @@ def match():
                 storyteller_title=storyteller_title,
             )
             if result.error:
-                return result.error, result.status_code
+                return _plain_error_response(result.error, result.status_code)
             return redirect(url_for("dashboard.index"))
 
         # --- Attach ebook to audio-only book ---
@@ -209,7 +213,7 @@ def match():
             ebook_filename = sanitize_filename(request.form.get("ebook_filename"))
             result = intake_service.attach_ebook(abs_id=attach_abs_id, ebook_filename=ebook_filename)
             if result.error:
-                return result.error, result.status_code
+                return _plain_error_response(result.error, result.status_code)
             return redirect(url_for("dashboard.index"))
 
         # --- Attach audiobook to ebook-only book ---
@@ -237,7 +241,7 @@ def match():
                 subtitle=selected_ab.get("media", {}).get("metadata", {}).get("subtitle") or None,
             )
             if result.error:
-                return result.error, result.status_code
+                return _plain_error_response(result.error, result.status_code)
             return redirect(url_for("dashboard.index"))
 
         # --- Standard flow (requires audiobook) ---
@@ -268,7 +272,7 @@ def match():
             subtitle=_ab_meta.get("subtitle") or None,
         )
         if error:
-            return error, 404
+            return _plain_error_response(error, 404)
 
         return redirect(url_for("dashboard.index"))
 

--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -242,6 +242,9 @@ def match():
         storyteller_uuid = request.form.get("storyteller_uuid")
         storyteller_submit = request.form.get("storyteller_submit")
 
+        if not ebook_filename:
+            return "An ebook selection is required for audiobook + ebook matching", 400
+
         audiobooks = abs_service.get_audiobooks()
         selected_ab = next((ab for ab in audiobooks if ab["id"] == abs_id), None)
         if not selected_ab:
@@ -456,6 +459,10 @@ def batch_match():
                         )
                         if result.error:
                             failed_items.append(item.get("ebook_display_name") or item["ebook_filename"])
+                        continue
+
+                    if not item.get("ebook_filename"):
+                        failed_items.append(item_label)
                         continue
 
                     _book, error = _create_book_mapping(

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -339,21 +339,21 @@ class BookRepository(BaseRepository):
                 session.expunge(existing)
                 return existing
 
+            snapshot = self._snapshot_state_scalars(state, update_attrs)
             try:
                 session.add(state)
                 session.flush()
             except IntegrityError:
                 session.rollback()
-                self._hydrate_state_book_reference(session, state)
-                if not state.book_id:
-                    logger.warning("save_state could not resolve abs_id '%s' to a book after conflict — skipping", state.abs_id)
+                if not snapshot["book_id"] and not snapshot["abs_id"]:
+                    logger.warning("save_state could not resolve abs_id '%s' to a book after conflict — skipping", snapshot["abs_id"])
                     return None
 
-                lookup = self._state_lookup_filters(state)
+                lookup = self._snapshot_lookup_filters(snapshot)
                 existing = self._dedupe_existing_states(session, lookup)
                 if not existing:
                     raise
-                self._apply_state_attrs(existing, state, update_attrs)
+                self._apply_snapshot_attrs(existing, snapshot, update_attrs)
                 session.flush()
                 session.refresh(existing)
                 session.expunge(existing)
@@ -382,6 +382,37 @@ class BookRepository(BaseRepository):
         if state.book_id:
             return [State.book_id == state.book_id, State.client_name == state.client_name]
         return [State.abs_id == state.abs_id, State.client_name == state.client_name]
+
+    @staticmethod
+    def _snapshot_state_scalars(state, update_attrs):
+        """Capture scalar values off the ORM object so conflict recovery never
+        re-reads it after rollback (post-rollback lifecycle is brittle)."""
+        snapshot = {
+            "book_id": state.book_id,
+            "client_name": state.client_name,
+            "abs_id": state.abs_id,
+        }
+        for attr in update_attrs:
+            if hasattr(state, attr):
+                snapshot[attr] = getattr(state, attr)
+        return snapshot
+
+    @staticmethod
+    def _snapshot_lookup_filters(snapshot):
+        if snapshot["book_id"]:
+            return [State.book_id == snapshot["book_id"], State.client_name == snapshot["client_name"]]
+        return [State.abs_id == snapshot["abs_id"], State.client_name == snapshot["client_name"]]
+
+    @staticmethod
+    def _apply_snapshot_attrs(existing, snapshot, update_attrs):
+        for attr in update_attrs:
+            if attr in snapshot:
+                value = snapshot[attr]
+                if attr == "book_id" and value is None:
+                    continue
+                if attr == "abs_id" and not value:
+                    continue
+                setattr(existing, attr, value)
 
     @staticmethod
     def _dedupe_existing_states(session, lookup_filters):

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -46,6 +46,10 @@ _BOOK_MERGE_METADATA_ATTRS = (
     "read_count",
 )
 
+# A freshly created target book never carries these alignment/UX hints, so a
+# falsy value must not clobber the canonical book that already holds them.
+_BOOK_MERGE_PRESERVE_IF_EMPTY = {"transcript_file", "activity_flag"}
+
 
 class BookRepository(BaseRepository):
     # ── Book CRUD ──
@@ -201,7 +205,10 @@ class BookRepository(BaseRepository):
 
                 if target_book and target_book_id != canonical_book_id:
                     for attr in _BOOK_MERGE_METADATA_ATTRS:
-                        setattr(book, attr, getattr(target_book, attr))
+                        value = getattr(target_book, attr)
+                        if attr in _BOOK_MERGE_PRESERVE_IF_EMPTY and not value:
+                            continue
+                        setattr(book, attr, value)
 
                     if incoming_clients:
                         session.query(State).filter(

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -200,7 +200,7 @@ class BookIntakeService:
 
         if existing_book and existing_book.abs_id != abs_id:
             logger.info("Merging existing '%s' into '%s'", existing_book.abs_id, abs_id)
-            migration_source_id = existing_book.abs_id
+            migration_source_id = existing_book.abs_id or existing_book.id
             ebook_item_id = existing_book.ebook_item_id or existing_book.abs_ebook_item_id or existing_book.abs_id
             original_ebook_filename = existing_book.original_ebook_filename or existing_book.ebook_filename
             merge_metadata = self._copy_book_merge_metadata(

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -1,0 +1,354 @@
+"""Book intake orchestration for matching and import flows."""
+
+import logging
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from src.db.models import Book, StorytellerSubmission
+from src.services.kosync_service import ensure_kosync_document
+from src.utils.logging_utils import sanitize_log_data
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IntakeResult:
+    book: Book | None = None
+    error: str | None = None
+    status_code: int = 400
+
+
+class BookIntakeService:
+    """Deep Module for creating and joining PageKeeper books from user intent.
+
+    The Interface is intentionally shaped around the match UI's intents, while
+    the implementation keeps the cross-service side effects local.
+    """
+
+    def __init__(
+        self,
+        *,
+        container,
+        database_service,
+        abs_service,
+        collection_name: str,
+        books_dir: str,
+        epub_cache_dir: str,
+        find_in_grimmory: Callable,
+        get_kosync_id_for_ebook: Callable,
+        attempt_hardcover_automatch: Callable,
+    ):
+        self.container = container
+        self.database_service = database_service
+        self.abs_service = abs_service
+        self.collection_name = collection_name
+        self.books_dir = books_dir
+        self.epub_cache_dir = epub_cache_dir
+        self.find_in_grimmory = find_in_grimmory
+        self.get_kosync_id_for_ebook = get_kosync_id_for_ebook
+        self.attempt_hardcover_automatch = attempt_hardcover_automatch
+
+    def import_audio_only(self, *, abs_id, title, duration, author=None, subtitle=None) -> Book:
+        book = Book(
+            abs_id=abs_id,
+            title=title,
+            ebook_filename=None,
+            kosync_doc_id=None,
+            status="not_started",
+            duration=duration,
+            sync_mode="audiobook",
+            author=author,
+            subtitle=subtitle,
+        )
+        self.database_service.save_book(book, is_new=True)
+        self.abs_service.add_to_collection(abs_id, self.collection_name)
+        self.attempt_hardcover_automatch(self.container, book)
+        self.database_service.resolve_suggestion(abs_id)
+        return book
+
+    def import_ebook_only(
+        self,
+        *,
+        ebook_filename=None,
+        ebook_display_name="",
+        storyteller_uuid=None,
+        storyteller_title="",
+    ) -> IntakeResult:
+        if not ebook_filename and not storyteller_uuid:
+            return IntakeResult(error="An ebook or Storyteller selection is required", status_code=400)
+
+        kosync_doc_id = None
+        if ebook_filename:
+            bl_book, bl_client = self.find_in_grimmory(ebook_filename)
+            grimmory_id = bl_book.get("id") if bl_book else None
+            kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
+            if not kosync_doc_id:
+                return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
+            title = ebook_display_name or (bl_book.get("title") if bl_book else None) or Path(ebook_filename).stem
+        else:
+            title = storyteller_title or ebook_display_name or "Storyteller Book"
+            ebook_filename = None
+
+        book = Book(
+            abs_id=None,
+            title=title,
+            ebook_filename=ebook_filename,
+            kosync_doc_id=kosync_doc_id,
+            status="not_started",
+            sync_mode="ebook_only",
+            storyteller_uuid=storyteller_uuid,
+        )
+        self.database_service.save_book(book, is_new=True)
+        ensure_kosync_document(book, self.database_service)
+        if kosync_doc_id:
+            self.database_service.resolve_suggestion(kosync_doc_id, source="kosync")
+        if storyteller_uuid:
+            self.database_service.resolve_suggestion(storyteller_uuid, source="storyteller")
+        if ebook_filename:
+            self.database_service.resolve_suggestion(ebook_filename, source="grimmory")
+        return IntakeResult(book=book)
+
+    def attach_ebook(self, *, abs_id, ebook_filename) -> IntakeResult:
+        if not abs_id or not ebook_filename:
+            return IntakeResult(error="Missing book ID or ebook filename", status_code=400)
+
+        book = self.database_service.get_book_by_ref(abs_id)
+        if not book:
+            return IntakeResult(error="Book not found", status_code=404)
+
+        bl_book, bl_client = self.find_in_grimmory(ebook_filename)
+        grimmory_id = bl_book.get("id") if bl_book else None
+        kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
+        if not kosync_doc_id:
+            return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
+
+        book.ebook_filename = ebook_filename
+        book.kosync_doc_id = kosync_doc_id
+        book.status = "pending"
+        self.database_service.save_book(book)
+        ensure_kosync_document(book, self.database_service)
+        self._add_to_grimmory_shelf(bl_client, ebook_filename)
+        self.database_service.resolve_suggestion(kosync_doc_id)
+        return IntakeResult(book=book)
+
+    def attach_audiobook(self, *, source_book_id, abs_id, title, duration, author=None, subtitle=None) -> IntakeResult:
+        if not source_book_id or not abs_id:
+            return IntakeResult(error="Missing book ID or audiobook ID", status_code=400)
+
+        book = self.database_service.get_book_by_ref(source_book_id)
+        if not book:
+            return IntakeResult(error="Book not found", status_code=404)
+
+        new_book = Book(
+            abs_id=abs_id,
+            title=title,
+            ebook_filename=book.ebook_filename,
+            kosync_doc_id=book.kosync_doc_id,
+            status=book.status or "not_started",
+            duration=duration,
+            sync_mode="audiobook",
+            author=author,
+            subtitle=subtitle,
+            **self._copy_book_merge_metadata(
+                book,
+                {
+                    "storyteller_uuid": book.storyteller_uuid,
+                    "original_ebook_filename": book.original_ebook_filename,
+                },
+            ),
+        )
+        self.database_service.save_book(new_book)
+        ensure_kosync_document(new_book, self.database_service)
+        self._migrate_and_delete_source(source_book_id, abs_id, book)
+        self.abs_service.add_to_collection(abs_id, self.collection_name)
+        self.attempt_hardcover_automatch(self.container, new_book)
+        self.database_service.resolve_suggestion(abs_id)
+        if new_book.kosync_doc_id:
+            self.database_service.resolve_suggestion(new_book.kosync_doc_id)
+        return IntakeResult(book=new_book)
+
+    def map_audiobook_ebook(
+        self,
+        *,
+        abs_id,
+        title,
+        ebook_filename,
+        duration,
+        storyteller_uuid=None,
+        storyteller_submit=False,
+        author=None,
+        subtitle=None,
+    ) -> IntakeResult:
+        bl_match, bl_match_client = self.find_in_grimmory(ebook_filename)
+        grimmory_id = bl_match.get("id") if bl_match else None
+
+        kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_match_client)
+        if not kosync_doc_id:
+            logger.warning("Cannot compute KOSync ID for '%s'", sanitize_log_data(ebook_filename))
+            return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
+
+        current_book_entry = self.database_service.get_book_by_ref(abs_id)
+        if current_book_entry and current_book_entry.kosync_doc_id:
+            logger.info("Preserving existing hash '%s' for '%s'", current_book_entry.kosync_doc_id, abs_id)
+            kosync_doc_id = current_book_entry.kosync_doc_id
+
+        existing_book = self.database_service.get_book_by_kosync_id(kosync_doc_id)
+        migration_source_id = None
+        original_ebook_filename = None
+
+        if existing_book and existing_book.abs_id != abs_id:
+            logger.info("Merging existing '%s' into '%s'", existing_book.abs_id, abs_id)
+            migration_source_id = existing_book.abs_id
+            ebook_item_id = existing_book.ebook_item_id or existing_book.abs_ebook_item_id or existing_book.abs_id
+            original_ebook_filename = existing_book.original_ebook_filename or existing_book.ebook_filename
+            merge_metadata = self._copy_book_merge_metadata(
+                existing_book,
+                {
+                    "abs_ebook_item_id": ebook_item_id,
+                    "ebook_item_id": ebook_item_id,
+                    "original_ebook_filename": original_ebook_filename,
+                    "storyteller_uuid": storyteller_uuid or existing_book.storyteller_uuid,
+                },
+            )
+        else:
+            merge_metadata = {
+                "storyteller_uuid": storyteller_uuid,
+                "original_ebook_filename": None,
+                "abs_ebook_item_id": None,
+                "ebook_item_id": None,
+            }
+
+        book = Book(
+            abs_id=abs_id,
+            title=title,
+            ebook_filename=ebook_filename,
+            kosync_doc_id=kosync_doc_id,
+            transcript_file=None,
+            status="pending",
+            duration=duration,
+            author=author,
+            subtitle=subtitle,
+            **merge_metadata,
+        )
+        self.database_service.save_book(book, is_new=True)
+        ensure_kosync_document(book, self.database_service)
+
+        if storyteller_submit:
+            self._create_storyteller_reservation(abs_id)
+
+        if migration_source_id:
+            self._migrate_and_delete_source(migration_source_id, abs_id, existing_book)
+            self.abs_service.add_to_collection(abs_id, self.collection_name)
+        else:
+            self.abs_service.add_to_collection(abs_id, self.collection_name)
+
+        self.attempt_hardcover_automatch(self.container, book)
+
+        if bl_match_client:
+            self._add_to_grimmory_shelf(bl_match_client, original_ebook_filename or ebook_filename)
+
+        if storyteller_submit:
+            self._submit_to_storyteller_async(abs_id, title, ebook_filename)
+
+        self._resolve_mapping_suggestions(abs_id, kosync_doc_id, ebook_filename)
+        return IntakeResult(book=book)
+
+    def _create_storyteller_reservation(self, abs_id):
+        book = self.database_service.get_book_by_ref(abs_id)
+        storyteller_uuid = book.storyteller_uuid if book else None
+        submission = StorytellerSubmission(
+            abs_id=abs_id,
+            book_id=book.id if book else None,
+            status="queued",
+            storyteller_uuid=storyteller_uuid,
+        )
+        self.database_service.save_storyteller_submission(submission)
+        return submission
+
+    def _submit_to_storyteller_async(self, abs_id, book_title, ebook_filename):
+        def _do_submit():
+            try:
+                st_sub_svc = self.container.storyteller_submission_service()
+                if not st_sub_svc.is_available():
+                    logger.warning("Storyteller submission skipped for '%s': service not available", book_title)
+                    return
+
+                from src.utils.epub_resolver import get_local_epub
+
+                epub_path = get_local_epub(
+                    ebook_filename,
+                    self.books_dir,
+                    self.epub_cache_dir,
+                    self.container.grimmory_client(),
+                )
+                audio_files = self.container.abs_client().get_audio_files(abs_id)
+                if epub_path and audio_files:
+                    result = st_sub_svc.submit_book(abs_id, book_title, Path(epub_path), audio_files)
+                    if not result.success:
+                        logger.warning("Storyteller submission failed for '%s': %s", book_title, result.error)
+                else:
+                    logger.warning(
+                        "Storyteller submission skipped for '%s': epub=%s, audio=%s files",
+                        book_title,
+                        "found" if epub_path else "missing",
+                        len(audio_files or []),
+                    )
+            except Exception as e:
+                logger.warning("Storyteller submission error for '%s': %s", book_title, e)
+                try:
+                    book = self.database_service.get_book_by_abs_id(abs_id)
+                    submission = (
+                        self.database_service.get_active_storyteller_submission_by_book_id(book.id) if book else None
+                    )
+                    if submission:
+                        self.database_service.update_storyteller_submission_status(submission.id, "failed")
+                except Exception:
+                    pass
+
+        threading.Thread(target=_do_submit, daemon=True).start()
+
+    def _migrate_and_delete_source(self, source_id, target_abs_id, source_book):
+        try:
+            self.database_service.migrate_book_data(source_id, target_abs_id)
+            self.database_service.delete_book(source_book.id)
+            logger.info("Successfully merged %s into %s", source_id, target_abs_id)
+        except Exception as e:
+            logger.error("Failed to merge book data: %s", e)
+            raise
+
+    def _add_to_grimmory_shelf(self, bl_client, ebook_filename):
+        if not bl_client:
+            return
+        try:
+            bl_client.add_to_shelf(ebook_filename)
+        except Exception as e:
+            logger.warning("Grimmory add_to_shelf failed for '%s': %s", sanitize_log_data(ebook_filename), e)
+
+    def _resolve_mapping_suggestions(self, abs_id, kosync_doc_id, ebook_filename):
+        self.database_service.resolve_suggestion(abs_id)
+        self.database_service.resolve_suggestion(kosync_doc_id)
+        try:
+            device_doc = self.database_service.get_kosync_doc_by_filename(ebook_filename)
+            if device_doc and device_doc.document_hash != kosync_doc_id:
+                self.database_service.resolve_suggestion(device_doc.document_hash)
+        except Exception as e:
+            logger.warning("Failed to check/resolve device hash: %s", e)
+
+    @staticmethod
+    def _copy_book_merge_metadata(existing_book, overrides=None):
+        metadata = {
+            "storyteller_uuid": existing_book.storyteller_uuid,
+            "original_ebook_filename": existing_book.original_ebook_filename,
+            "abs_ebook_item_id": existing_book.abs_ebook_item_id,
+            "ebook_item_id": existing_book.ebook_item_id or existing_book.abs_ebook_item_id,
+            "custom_cover_url": existing_book.custom_cover_url,
+            "started_at": existing_book.started_at,
+            "finished_at": existing_book.finished_at,
+            "rating": existing_book.rating,
+            "read_count": existing_book.read_count or 1,
+        }
+        if overrides:
+            metadata.update({key: value for key, value in overrides.items() if value is not None})
+        return metadata

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -307,8 +307,8 @@ class BookIntakeService:
                     )
                     if submission:
                         self.database_service.update_storyteller_submission_status(submission.id, "failed")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Failed to mark Storyteller submission as failed: %s", e)
 
         threading.Thread(target=_do_submit, daemon=True).start()
 

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -161,7 +161,7 @@ class BookIntakeService:
         )
         self.database_service.save_book(new_book)
         ensure_kosync_document(new_book, self.database_service)
-        self._migrate_and_delete_source(source_book_id, abs_id, book)
+        self._migrate_source_identity(book.abs_id or source_book_id, abs_id)
         self.abs_service.add_to_collection(abs_id, self.collection_name)
         self.attempt_hardcover_automatch(self.container, new_book)
         self.database_service.resolve_suggestion(abs_id)
@@ -239,7 +239,7 @@ class BookIntakeService:
             self._create_storyteller_reservation(abs_id)
 
         if migration_source_id:
-            self._migrate_and_delete_source(migration_source_id, abs_id, existing_book)
+            self._migrate_source_identity(migration_source_id, abs_id)
             self.abs_service.add_to_collection(abs_id, self.collection_name)
         else:
             self.abs_service.add_to_collection(abs_id, self.collection_name)
@@ -312,10 +312,9 @@ class BookIntakeService:
 
         threading.Thread(target=_do_submit, daemon=True).start()
 
-    def _migrate_and_delete_source(self, source_id, target_abs_id, source_book):
+    def _migrate_source_identity(self, source_id, target_abs_id):
         try:
             self.database_service.migrate_book_data(source_id, target_abs_id)
-            self.database_service.delete_book(source_book.id)
             logger.info("Successfully merged %s into %s", source_id, target_abs_id)
         except Exception as e:
             logger.error("Failed to merge book data: %s", e)

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -257,10 +257,13 @@ class BookIntakeService:
 
     def _create_storyteller_reservation(self, abs_id):
         book = self.database_service.get_book_by_ref(abs_id)
-        storyteller_uuid = book.storyteller_uuid if book else None
+        if not book:
+            logger.warning("Cannot create Storyteller reservation: book not found for abs_id=%s", abs_id)
+            return None
+        storyteller_uuid = book.storyteller_uuid
         submission = StorytellerSubmission(
             abs_id=abs_id,
-            book_id=book.id if book else None,
+            book_id=book.id,
             status="queued",
             storyteller_uuid=storyteller_uuid,
         )

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -272,6 +272,7 @@ class BookIntakeService:
 
     def _submit_to_storyteller_async(self, abs_id, book_title, ebook_filename):
         def _do_submit():
+            submission_succeeded = False
             try:
                 st_sub_svc = self.container.storyteller_submission_service()
                 if not st_sub_svc.is_available():
@@ -289,7 +290,8 @@ class BookIntakeService:
                 audio_files = self.container.abs_client().get_audio_files(abs_id)
                 if epub_path and audio_files:
                     result = st_sub_svc.submit_book(abs_id, book_title, Path(epub_path), audio_files)
-                    if not result.success:
+                    submission_succeeded = result.success
+                    if not submission_succeeded:
                         logger.warning("Storyteller submission failed for '%s': %s", book_title, result.error)
                 else:
                     logger.warning(
@@ -300,17 +302,20 @@ class BookIntakeService:
                     )
             except Exception as e:
                 logger.warning("Storyteller submission error for '%s': %s", book_title, e)
-                try:
-                    book = self.database_service.get_book_by_abs_id(abs_id)
-                    submission = (
-                        self.database_service.get_active_storyteller_submission_by_book_id(book.id) if book else None
-                    )
-                    if submission:
-                        self.database_service.update_storyteller_submission_status(submission.id, "failed")
-                except Exception as e:
-                    logger.debug("Failed to mark Storyteller submission as failed: %s", e)
+            finally:
+                if not submission_succeeded:
+                    self._mark_storyteller_submission_failed(abs_id)
 
         threading.Thread(target=_do_submit, daemon=True).start()
+
+    def _mark_storyteller_submission_failed(self, abs_id):
+        try:
+            book = self.database_service.get_book_by_abs_id(abs_id)
+            submission = self.database_service.get_active_storyteller_submission_by_book_id(book.id) if book else None
+            if submission:
+                self.database_service.update_storyteller_submission_status(submission.id, "failed")
+        except Exception as e:
+            logger.debug("Failed to mark Storyteller submission as failed: %s", e)
 
     def _migrate_source_identity(self, source_id, target_abs_id):
         try:

--- a/src/services/progress_reset_service.py
+++ b/src/services/progress_reset_service.py
@@ -63,15 +63,6 @@ class ProgressResetService:
             cleared_count = self.database_service.delete_states_for_book(book.id)
             logger.info(f"Cleared {cleared_count} state records from database")
 
-            # Delete KOSync document records to prevent stale re-sync
-            sibling_docs = self.database_service.get_kosync_documents_for_book_by_book_id(book.id)
-            for doc in sibling_docs:
-                self.database_service.delete_kosync_document(doc.document_hash)
-                logger.info(f"Deleted KOSync document record: {doc.document_hash[:8]}...")
-            if not sibling_docs and book.kosync_doc_id:
-                self.database_service.delete_kosync_document(book.kosync_doc_id)
-                logger.info(f"Deleted KOSync document record: {book.kosync_doc_id[:8]}...")
-
             # Save 0% states with a fresh timestamp so the sync daemon sees
             # "already up to date" and won't pull stale progress from external services
             now = time.time()
@@ -105,6 +96,9 @@ class ProgressResetService:
                     f"Sync lock busy — external clients will be reset on next clear attempt. "
                     f"Local progress already cleared for '{sanitize_log_data(str(book_id))}'"
                 )
+                # Delete KOSync docs only after all save_book status writes so they
+                # are not resurrected by _ensure_book_kosync_document.
+                self._delete_kosync_documents(book)
                 # Keep book_id in _pending_clears so _process_deferred_clears picks it up
                 return {
                     "book_id": book_id,
@@ -130,6 +124,10 @@ class ProgressResetService:
                 # Handle alignment-based re-processing (status already set to not_started in Phase 1)
                 self._finalize_clear_status(book_id)
 
+                # Delete KOSync docs only after all save_book status writes so they
+                # are not resurrected by _ensure_book_kosync_document.
+                self._delete_kosync_documents(book)
+
                 logger.info(f"Progress clearing completed for '{sanitize_log_data(book.title)}'")
                 logger.info(f"   Database states cleared: {cleared_count}")
                 logger.info(f"   Client resets: {summary['successful_resets']}/{summary['total_clients']} successful")
@@ -146,6 +144,21 @@ class ProgressResetService:
             logger.error(f"Error clearing progress for {sanitize_log_data(str(book_id))}: {type(e).__name__}")
             logger.debug(traceback.format_exc())
             raise RuntimeError(f"Failed to clear progress for book {sanitize_log_data(str(book_id))}") from e
+
+    def _delete_kosync_documents(self, book):
+        """Delete KOSync document records for a book to prevent stale re-sync.
+
+        Must run only after all ``save_book`` status writes for this clear have
+        completed; ``save_book`` calls ``_ensure_book_kosync_document``, which
+        would otherwise resurrect a document deleted earlier in the process.
+        """
+        sibling_docs = self.database_service.get_kosync_documents_for_book_by_book_id(book.id)
+        for doc in sibling_docs:
+            self.database_service.delete_kosync_document(doc.document_hash)
+            logger.info(f"Deleted KOSync document record: {doc.document_hash[:8]}...")
+        if not sibling_docs and book.kosync_doc_id:
+            self.database_service.delete_kosync_document(book.kosync_doc_id)
+            logger.info(f"Deleted KOSync document record: {book.kosync_doc_id[:8]}...")
 
     def _finalize_clear_status(self, book_id):
         """Handle smart-reset status finalization after clearing progress."""

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1052,7 +1052,7 @@
 
     <script>
         window.SETTINGS_CONFIG = {
-            kosyncPort: "{{ get_val('KOSYNC_PORT', '4477') }}"
+            kosyncPort: {{ get_val('KOSYNC_PORT', '4477')|tojson }}
         };
     </script>
     <script src="/static/js/confirm-modal.js"></script>

--- a/templates/tbr_detail.html
+++ b/templates/tbr_detail.html
@@ -72,8 +72,9 @@
 
                     {# Info row: rating, pages, year #}
                     {% set info_parts = [] %}
+                    {% set has_rating = item.rating is not none %}
                     {% if item.rating is not none %}
-                        {% set _ = info_parts.append('<span class="r-tbr-card-info-star">&#9733;</span> ' ~ '%.1f'|format(item.rating)) %}
+                        {% set _ = info_parts.append('%.1f'|format(item.rating)) %}
                     {% endif %}
                     {% if item.page_count %}
                         {% set _ = info_parts.append(item.page_count|string ~ 'p') %}
@@ -84,7 +85,7 @@
                     {% if info_parts %}
                     <div class="r-tbr-card-info" style="font-size: 14px; margin-top: 8px;">
                         {% for part in info_parts %}
-                        <span>{{ part|safe }}</span>
+                        <span>{% if has_rating and loop.first %}<span class="r-tbr-card-info-star">&#9733;</span> {% endif %}{{ part }}</span>
                         {% endfor %}
                     </div>
                     {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,53 @@ class MockContainer:
 # ── Pytest fixtures ────────────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _reset_app_globals():
+    """Restore process-global state after each test.
+
+    Three classes of process-global state leak across tests and cause
+    order-dependent failures:
+
+    1. ``src.app_setup`` keeps module-level ``container``/``manager``/
+       ``database_service``/``SYNC_PERIOD_MINS`` singletons that
+       ``setup_dependencies`` mutates.
+    2. ``src.web_server`` re-exports those via a module-level ``__getattr__``.
+       A test that assigns directly onto the ``web_server`` module would create
+       a real attribute that permanently shadows ``__getattr__`` and leak a real
+       instance into later tests.
+    3. ``ConfigLoader`` (invoked by ``create_app``/``setup_dependencies``) writes
+       feature-flag settings such as ``GRIMMORY_ENABLED`` into ``os.environ``,
+       defaulting absent flags to ``"false"``. Leaked flags flip later tests'
+       configuration probes (e.g. ``GrimmoryClient.is_configured``).
+
+    This fixture snapshots all three before each test and restores them
+    afterwards.
+    """
+    import src.app_setup as app_setup
+    import src.web_server as web_server
+
+    tracked = ("container", "manager", "database_service", "SYNC_PERIOD_MINS")
+    saved = {name: getattr(app_setup, name) for name in tracked}
+    web_server_baseline = {
+        name: vars(web_server).get(name) for name in (*tracked, "app")
+    }
+    saved_env = os.environ.copy()
+
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            setattr(app_setup, name, value)
+        # Drop any real attributes that a test assigned onto the web_server
+        # module, which would otherwise shadow its delegating __getattr__.
+        for name in (*tracked, "app"):
+            if web_server_baseline[name] is None and name in vars(web_server):
+                delattr(web_server, name)
+        # Restore os.environ to undo any settings bootstrapped into it.
+        os.environ.clear()
+        os.environ.update(saved_env)
+
+
 @pytest.fixture()
 def mock_container():
     """Yield a fresh MockContainer for each test."""

--- a/tests/test_book_identity_merge.py
+++ b/tests/test_book_identity_merge.py
@@ -211,6 +211,52 @@ class TestBookIdentityMerge(unittest.TestCase):
             self.assertEqual(kosync_doc.linked_book_id, source.id)
             self.assertEqual(kosync_doc.linked_abs_id, survivor.abs_id)
 
+    def test_merge_preserves_alignment_and_activity_when_target_is_empty(self):
+        aligned_source = Book(
+            abs_id="ebook-aligned-1",
+            title="Aligned EPUB",
+            ebook_filename="aligned.epub",
+            kosync_doc_id="c" * 32,
+            status="active",
+            sync_mode="ebook_only",
+            transcript_file="DB_MANAGED",
+        )
+        aligned_source.activity_flag = True
+        source = self.db.save_book(aligned_source)
+
+        # A freshly mapped audiobook target never carries these hints.
+        target = self.db.save_book(
+            Book(
+                abs_id="abs-audiobook-aligned-1",
+                title="ABS Aligned Audiobook",
+                author="Aligned Author",
+                ebook_filename=source.ebook_filename,
+                kosync_doc_id=source.kosync_doc_id,
+                status="active",
+                duration=3600,
+                sync_mode="audiobook",
+                transcript_file=None,
+            )
+        )
+
+        self.db.migrate_book_data(source.abs_id, target.abs_id)
+
+        with self.db.get_session() as session:
+            books = session.query(Book).all()
+            self.assertEqual(len(books), 1)
+
+            survivor = books[0]
+            self.assertEqual(survivor.id, source.id)
+            # Alignment routing + paused-book UX hint survive the merge.
+            self.assertEqual(survivor.transcript_file, "DB_MANAGED")
+            self.assertTrue(survivor.activity_flag)
+            # Legitimately populated target fields still flow through.
+            self.assertEqual(survivor.abs_id, "abs-audiobook-aligned-1")
+            self.assertEqual(survivor.title, "ABS Aligned Audiobook")
+            self.assertEqual(survivor.author, "Aligned Author")
+            self.assertEqual(survivor.duration, 3600)
+            self.assertEqual(survivor.sync_mode, "audiobook")
+
     def test_attach_audiobook_route_merges_when_link_book_id_is_numeric(self):
         import src.db.migration_utils
 

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -1,0 +1,175 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from src.services.book_intake_service import BookIntakeService
+
+
+def _book_ref(**overrides):
+    defaults = {
+        "id": 11,
+        "abs_id": "source-abs",
+        "ebook_filename": "source.epub",
+        "original_ebook_filename": None,
+        "kosync_doc_id": None,
+        "storyteller_uuid": None,
+        "abs_ebook_item_id": None,
+        "ebook_item_id": None,
+        "custom_cover_url": None,
+        "started_at": None,
+        "finished_at": None,
+        "rating": None,
+        "read_count": 1,
+        "status": "not_started",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_service(*, db=None, abs_service=None, bl_match=None, bl_client=None, kosync_id="hash-new"):
+    container = Mock()
+    container.grimmory_client.return_value = Mock()
+    container.abs_client.return_value.get_audio_files.return_value = []
+    container.storyteller_submission_service.return_value.is_available.return_value = False
+
+    if db is None:
+        db = Mock()
+        db.get_book_by_ref.return_value = None
+        db.get_book_by_kosync_id.return_value = None
+        db.get_kosync_doc_by_filename.return_value = None
+        db.get_kosync_document.return_value = None
+
+    next_id = {"value": 100}
+
+    def save_book(book, *args, **kwargs):
+        if not getattr(book, "id", None):
+            book.id = next_id["value"]
+            next_id["value"] += 1
+        return book
+
+    db.save_book.side_effect = save_book
+
+    abs_service = abs_service or Mock()
+    bl_client = bl_client or Mock()
+    find_in_grimmory = Mock(return_value=(bl_match, bl_client if bl_match else None))
+    get_kosync_id_for_ebook = Mock(return_value=kosync_id)
+    attempt_hardcover_automatch = Mock()
+
+    service = BookIntakeService(
+        container=container,
+        database_service=db,
+        abs_service=abs_service,
+        collection_name="Synced",
+        books_dir="/books",
+        epub_cache_dir="/cache",
+        find_in_grimmory=find_in_grimmory,
+        get_kosync_id_for_ebook=get_kosync_id_for_ebook,
+        attempt_hardcover_automatch=attempt_hardcover_automatch,
+    )
+    return service, db, abs_service, bl_client, attempt_hardcover_automatch
+
+
+def test_map_audiobook_ebook_preserves_existing_kosync_hash():
+    db = Mock()
+    db.get_book_by_ref.return_value = _book_ref(abs_id="abs-1", kosync_doc_id="hash-existing")
+    service, db, _abs, _bl, _hc = _make_service(db=db, kosync_id="hash-new")
+
+    result = service.map_audiobook_ebook(
+        abs_id="abs-1",
+        title="Book",
+        ebook_filename="book.epub",
+        duration=123,
+    )
+
+    assert result.error is None
+    assert result.book.kosync_doc_id == "hash-existing"
+    db.resolve_suggestion.assert_any_call("hash-existing")
+
+
+def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():
+    existing = _book_ref(
+        id=22,
+        abs_id="ebook-source",
+        ebook_filename="old.epub",
+        original_ebook_filename="original.epub",
+        kosync_doc_id="hash-dup",
+        storyteller_uuid="story-1",
+        abs_ebook_item_id="ebook-item",
+        custom_cover_url="https://cover",
+        read_count=3,
+    )
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_kosync_id.return_value = existing
+    service, db, abs_service, _bl, _hc = _make_service(db=db, kosync_id="hash-dup")
+
+    result = service.map_audiobook_ebook(
+        abs_id="abs-new",
+        title="Merged Book",
+        ebook_filename="new.epub",
+        duration=456,
+    )
+
+    assert result.error is None
+    assert result.book.original_ebook_filename == "original.epub"
+    assert result.book.ebook_item_id == "ebook-item"
+    assert result.book.custom_cover_url == "https://cover"
+    assert result.book.read_count == 3
+    db.migrate_book_data.assert_called_once_with("ebook-source", "abs-new")
+    db.delete_book.assert_called_once_with(22)
+    abs_service.add_to_collection.assert_called_once_with("abs-new", "Synced")
+
+
+def test_storyteller_reservation_happens_before_async_submission_thread():
+    events = []
+    service, db, _abs, _bl, _hc = _make_service()
+    db.save_storyteller_submission.side_effect = lambda submission: events.append(("reservation", submission.abs_id))
+
+    thread = Mock()
+    thread.start.side_effect = lambda: events.append(("thread_start", None))
+
+    with patch("src.services.book_intake_service.threading.Thread", return_value=thread):
+        result = service.map_audiobook_ebook(
+            abs_id="abs-story",
+            title="Story Book",
+            ebook_filename="story.epub",
+            duration=789,
+            storyteller_submit=True,
+        )
+
+    assert result.error is None
+    assert events == [("reservation", "abs-story"), ("thread_start", None)]
+
+
+def test_map_audiobook_ebook_resolves_abs_hash_and_device_suggestions():
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.get_kosync_doc_by_filename.return_value = SimpleNamespace(document_hash="device-hash")
+    service, db, _abs, _bl, _hc = _make_service(db=db, kosync_id="primary-hash")
+
+    result = service.map_audiobook_ebook(
+        abs_id="abs-suggest",
+        title="Suggest Book",
+        ebook_filename="suggest.epub",
+        duration=100,
+    )
+
+    assert result.error is None
+    db.resolve_suggestion.assert_any_call("abs-suggest")
+    db.resolve_suggestion.assert_any_call("primary-hash")
+    db.resolve_suggestion.assert_any_call("device-hash")
+
+
+def test_map_audiobook_ebook_updates_abs_collection_and_grimmory_shelf():
+    service, _db, abs_service, bl_client, _hc = _make_service(bl_match={"id": "grimmory-1"})
+
+    result = service.map_audiobook_ebook(
+        abs_id="abs-side-effects",
+        title="Side Effects",
+        ebook_filename="side.epub",
+        duration=321,
+    )
+
+    assert result.error is None
+    abs_service.add_to_collection.assert_called_once_with("abs-side-effects", "Synced")
+    bl_client.add_to_shelf.assert_called_once_with("side.epub")

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -122,6 +122,7 @@ def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():
 def test_storyteller_reservation_happens_before_async_submission_thread():
     events = []
     service, db, _abs, _bl, _hc = _make_service()
+    db.get_book_by_ref.side_effect = [None, _book_ref(id=100, abs_id="abs-story")]
     db.save_storyteller_submission.side_effect = lambda submission: events.append(("reservation", submission.abs_id))
 
     thread = Mock()
@@ -138,6 +139,17 @@ def test_storyteller_reservation_happens_before_async_submission_thread():
 
     assert result.error is None
     assert events == [("reservation", "abs-story"), ("thread_start", None)]
+
+
+def test_storyteller_reservation_returns_none_when_book_not_found(caplog):
+    service, db, _abs, _bl, _hc = _make_service()
+
+    with caplog.at_level("WARNING"):
+        submission = service._create_storyteller_reservation("missing-abs")
+
+    assert submission is None
+    assert "Cannot create Storyteller reservation: book not found for abs_id=missing-abs" in caplog.messages
+    db.save_storyteller_submission.assert_not_called()
 
 
 def test_map_audiobook_ebook_resolves_abs_hash_and_device_suggestions():

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -115,7 +115,7 @@ def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():
     assert result.book.custom_cover_url == "https://cover"
     assert result.book.read_count == 3
     db.migrate_book_data.assert_called_once_with("ebook-source", "abs-new")
-    db.delete_book.assert_called_once_with(22)
+    db.delete_book.assert_not_called()
     abs_service.add_to_collection.assert_called_once_with("abs-new", "Synced")
 
 

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from src.services.book_intake_service import BookIntakeService
+from src.services.storyteller_submission_service import SubmissionResult
 
 
 def _book_ref(**overrides):
@@ -66,6 +67,17 @@ def _make_service(*, db=None, abs_service=None, bl_match=None, bl_client=None, k
         attempt_hardcover_automatch=attempt_hardcover_automatch,
     )
     return service, db, abs_service, bl_client, attempt_hardcover_automatch
+
+
+def _run_storyteller_submission_synchronously(service, *, abs_id="abs-story", title="Story Book", ebook="story.epub"):
+    def thread_factory(*, target, daemon):
+        thread = Mock()
+        thread.daemon = daemon
+        thread.start.side_effect = target
+        return thread
+
+    with patch("src.services.book_intake_service.threading.Thread", side_effect=thread_factory):
+        service._submit_to_storyteller_async(abs_id, title, ebook)
 
 
 def test_map_audiobook_ebook_preserves_existing_kosync_hash():
@@ -173,6 +185,33 @@ def test_storyteller_reservation_returns_none_when_book_not_found(caplog):
     assert submission is None
     assert "Cannot create Storyteller reservation: book not found for abs_id=missing-abs" in caplog.messages
     db.save_storyteller_submission.assert_not_called()
+
+
+def test_storyteller_submission_marks_reservation_failed_when_service_unavailable():
+    service, db, _abs, _bl, _hc = _make_service()
+    db.get_book_by_abs_id.return_value = _book_ref(id=42, abs_id="abs-story")
+    db.get_active_storyteller_submission_by_book_id.return_value = SimpleNamespace(id=84)
+
+    _run_storyteller_submission_synchronously(service)
+
+    db.update_storyteller_submission_status.assert_called_once_with(84, "failed")
+    service.container.storyteller_submission_service.return_value.submit_book.assert_not_called()
+
+
+def test_storyteller_submission_marks_reservation_failed_when_submit_book_fails():
+    service, db, _abs, _bl, _hc = _make_service()
+    db.get_book_by_abs_id.return_value = _book_ref(id=42, abs_id="abs-story")
+    db.get_active_storyteller_submission_by_book_id.return_value = SimpleNamespace(id=84)
+    storyteller_service = service.container.storyteller_submission_service.return_value
+    storyteller_service.is_available.return_value = True
+    storyteller_service.submit_book.return_value = SubmissionResult(success=False, error="copy failed")
+    service.container.abs_client.return_value.get_audio_files.return_value = [{"stream_url": "https://audio"}]
+
+    with patch("src.utils.epub_resolver.get_local_epub", return_value="/cache/story.epub"):
+        _run_storyteller_submission_synchronously(service)
+
+    db.update_storyteller_submission_status.assert_called_once_with(84, "failed")
+    storyteller_service.submit_book.assert_called_once()
 
 
 def test_map_audiobook_ebook_resolves_abs_hash_and_device_suggestions():

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -119,6 +119,29 @@ def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():
     abs_service.add_to_collection.assert_called_once_with("abs-new", "Synced")
 
 
+def test_map_audiobook_ebook_merges_ebook_only_book_by_integer_id():
+    existing = _book_ref(
+        id=22,
+        abs_id=None,
+        ebook_filename="old.epub",
+        kosync_doc_id="hash-dup",
+    )
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_kosync_id.return_value = existing
+    service, db, _abs_service, _bl, _hc = _make_service(db=db, kosync_id="hash-dup")
+
+    result = service.map_audiobook_ebook(
+        abs_id="abs-new",
+        title="Merged Book",
+        ebook_filename="new.epub",
+        duration=456,
+    )
+
+    assert result.error is None
+    db.migrate_book_data.assert_called_once_with(22, "abs-new")
+
+
 def test_storyteller_reservation_happens_before_async_submission_thread():
     events = []
     service, db, _abs, _bl, _hc = _make_service()

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -338,6 +338,136 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(saved.id, existing.id)
         self.assertEqual(states[0].percentage, 0.65)
 
+    def test_save_state_recovers_from_genuine_unique_index_conflict(self):
+        """A real partial unique index conflict on the second save_state is
+        recovered by updating the existing row (no raise, single row)."""
+        book = self.db_service.save_book(self.Book(abs_id="genuine-conflict-book", title="Genuine Conflict"))
+        existing = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=100.0,
+                percentage=0.10,
+            )
+        )
+
+        repo = self.db_service._books
+        original_dedupe = repo._dedupe_existing_states
+        calls = 0
+
+        def miss_first_lookup(session, lookup_filters):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                # Force the INSERT path so the real uq_states_book_id_client_name
+                # partial unique index raises a genuine IntegrityError.
+                return None
+            return original_dedupe(session, lookup_filters)
+
+        repo._dedupe_existing_states = miss_first_lookup
+        try:
+            saved = self.db_service.save_state(
+                self.State(
+                    abs_id=book.abs_id,
+                    book_id=book.id,
+                    client_name="kosync",
+                    last_updated=250.0,
+                    percentage=0.65,
+                )
+            )
+        finally:
+            repo._dedupe_existing_states = original_dedupe
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertGreaterEqual(calls, 2)
+        self.assertIsNotNone(saved)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(saved.id, existing.id)
+        self.assertEqual(states[0].percentage, 0.65)
+
+    def test_save_state_recovery_never_reads_orm_state_after_rollback(self):
+        """The conflict-recovery branch must operate on the snapshot, never the
+        ORM state object (whose post-rollback lifecycle is unreliable)."""
+        book = self.db_service.save_book(self.Book(abs_id="armed-state-book", title="Armed State"))
+        existing = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=100.0,
+                percentage=0.10,
+            )
+        )
+
+        repo = self.db_service._books
+        original_dedupe = repo._dedupe_existing_states
+        original_snapshot = repo._snapshot_state_scalars
+        calls = 0
+        snapshot_taken = False
+        incoming_state = self.State(
+            abs_id=book.abs_id,
+            book_id=book.id,
+            client_name="kosync",
+            last_updated=250.0,
+            percentage=0.65,
+        )
+
+        def miss_first_lookup(session, lookup_filters):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                # Force the INSERT path so the real unique index conflicts.
+                return None
+            return original_dedupe(session, lookup_filters)
+
+        def snapshot_then_mark(state, update_attrs):
+            # Snapshot is captured from the live ORM object (allowed). After this
+            # point — i.e. in the post-rollback recovery branch — the ORM state
+            # object must never be read again. We don't subclass the mapped State
+            # model (that would register a stray entity in the global declarative
+            # registry and corrupt later metadata/migration tests); instead we
+            # spy on the helpers that take the ORM `state`, which the fixed
+            # recovery branch must avoid.
+            nonlocal snapshot_taken
+            snapshot_taken = True
+            return original_snapshot(state, update_attrs)
+
+        def guard_state_helper(name, original):
+            def wrapper(*args, **kwargs):
+                if snapshot_taken:
+                    raise AssertionError(f"recovery branch used ORM-state helper '{name}' after snapshot")
+                return original(*args, **kwargs)
+
+            return wrapper
+
+        original_hydrate = repo._hydrate_state_book_reference
+        original_state_lookup = repo._state_lookup_filters
+        original_apply_state = repo._apply_state_attrs
+
+        repo._dedupe_existing_states = miss_first_lookup
+        repo._snapshot_state_scalars = snapshot_then_mark
+        repo._hydrate_state_book_reference = guard_state_helper(
+            "_hydrate_state_book_reference", original_hydrate
+        )
+        repo._state_lookup_filters = guard_state_helper("_state_lookup_filters", original_state_lookup)
+        repo._apply_state_attrs = guard_state_helper("_apply_state_attrs", original_apply_state)
+        try:
+            saved = self.db_service.save_state(incoming_state)
+        finally:
+            repo._dedupe_existing_states = original_dedupe
+            repo._snapshot_state_scalars = original_snapshot
+            repo._hydrate_state_book_reference = original_hydrate
+            repo._state_lookup_filters = original_state_lookup
+            repo._apply_state_attrs = original_apply_state
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertGreaterEqual(calls, 2)
+        self.assertIsNotNone(saved)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(saved.id, existing.id)
+        self.assertEqual(states[0].percentage, 0.65)
+
     def test_save_state_resolves_legacy_abs_id_only_input(self):
         """Legacy callers that only pass abs_id still update the canonical book state."""
         book = self.db_service.save_book(self.Book(abs_id="legacy-abs-state", title="Legacy State"))

--- a/tests/test_kosync_server.py
+++ b/tests/test_kosync_server.py
@@ -188,17 +188,22 @@ class TestKosyncEndpoints(unittest.TestCase):
         cls.db_path = os.path.join(TEST_DIR, "test.db")
         from src import web_server
 
-        web_server.database_service = DatabaseService(cls.db_path)
+        cls.database_service = DatabaseService(cls.db_path)
         # Use MockContainer to avoid epubcfi import chain
         cls.mock_container = _KosyncMockContainer()
-        if not hasattr(web_server, "app"):
-            web_server.app, _ = web_server.create_app(test_container=cls.mock_container)
-        cls.app = web_server.app
-        cls.app.config["database_service"] = web_server.database_service
+        # create_app bootstraps settings into os.environ; snapshot and restore
+        # so feature flags (e.g. GRIMMORY_ENABLED) do not leak into later tests.
+        _saved_env = os.environ.copy()
+        try:
+            cls.app, _ = web_server.create_app(test_container=cls.mock_container)
+        finally:
+            os.environ.clear()
+            os.environ.update(_saved_env)
+        cls.app.config["database_service"] = cls.database_service
         from src.services.kosync_service import KosyncService
 
         cls.app.config["kosync_service"] = KosyncService(
-            web_server.database_service,
+            cls.database_service,
             cls.mock_container,
             cls.mock_container.mock_sync_manager,
         )
@@ -214,9 +219,7 @@ class TestKosyncEndpoints(unittest.TestCase):
             "Content-Type": "application/json",
         }
         # Clear specific tables
-        from src import web_server
-
-        with web_server.database_service.get_session() as session:
+        with self.database_service.get_session() as session:
             session.query(KosyncDocument).delete()
         # Reset rate limiter between tests
         with self.app.app_context():
@@ -409,8 +412,6 @@ class TestKosyncEndpoints(unittest.TestCase):
 
     def test_get_progress_unknown_hash_creates_stub(self):
         """Test that GET for a completely unknown hash returns 502 and creates a stub for background discovery."""
-        from src import web_server
-
         # Create a book with a known kosync_doc_id
         book = Book(
             abs_id="test-sibling-book",
@@ -420,7 +421,7 @@ class TestKosyncEndpoints(unittest.TestCase):
             status="active",
             sync_mode="ebook_only",
         )
-        book = web_server.database_service.save_book(book)
+        book = self.database_service.save_book(book)
 
         # Create a KosyncDocument for hash_A linked to the book, with progress
         self.client.put(
@@ -435,7 +436,7 @@ class TestKosyncEndpoints(unittest.TestCase):
             },
         )
         # Link it to the book
-        web_server.database_service.link_kosync_document("a" * 32, book.id)
+        self.database_service.link_kosync_document("a" * 32, book.id)
 
         # Now GET with an unknown hash_B — should resolve via the book's sibling docs
         # First, we need hash_B to be findable. The sibling resolution requires
@@ -447,13 +448,11 @@ class TestKosyncEndpoints(unittest.TestCase):
         self.assertEqual(response.status_code, 502)
 
         # Clean up
-        with web_server.database_service.get_session() as session:
+        with self.database_service.get_session() as session:
             session.query(Book).filter(Book.abs_id == "test-sibling-book").delete()
 
     def test_get_progress_resolves_via_book_kosync_id(self):
         """Test that GET resolves via book.kosync_doc_id fallback (Step 2) and returns sibling progress."""
-        from src import web_server
-
         # Create a book whose kosync_doc_id matches the GET hash
         book = Book(
             abs_id="test-step2-book",
@@ -463,10 +462,10 @@ class TestKosyncEndpoints(unittest.TestCase):
             status="active",
             sync_mode="ebook_only",
         )
-        web_server.database_service.save_book(book)
+        self.database_service.save_book(book)
 
         # Retrieve saved book to get its DB-assigned id
-        saved_book = web_server.database_service.get_book_by_abs_id("test-step2-book")
+        saved_book = self.database_service.get_book_by_abs_id("test-step2-book")
 
         # Create a sibling KosyncDocument linked to the same book with progress
         sibling_doc = KosyncDocument(
@@ -479,7 +478,7 @@ class TestKosyncEndpoints(unittest.TestCase):
             linked_abs_id="test-step2-book",
             linked_book_id=saved_book.id,
         )
-        web_server.database_service.save_kosync_document(sibling_doc)
+        self.database_service.save_kosync_document(sibling_doc)
 
         # GET with the book's kosync_doc_id (not in kosync_documents itself)
         response = self.client.get("/syncs/progress/" + "s" * 32, headers=self.auth_headers)
@@ -491,13 +490,11 @@ class TestKosyncEndpoints(unittest.TestCase):
         self.assertEqual(data["document"], "s" * 32)
 
         # Clean up
-        with web_server.database_service.get_session() as session:
+        with self.database_service.get_session() as session:
             session.query(Book).filter(Book.abs_id == "test-step2-book").delete()
 
     def test_get_progress_sibling_via_filename(self):
         """Test that GET resolves an unknown hash when a sibling with the same filename is linked to a book."""
-        from src import web_server
-
         # Create a book
         book = Book(
             abs_id="test-filename-book",
@@ -507,8 +504,8 @@ class TestKosyncEndpoints(unittest.TestCase):
             status="active",
             sync_mode="ebook_only",
         )
-        web_server.database_service.save_book(book)
-        saved_book = web_server.database_service.get_book_by_abs_id("test-filename-book")
+        self.database_service.save_book(book)
+        saved_book = self.database_service.get_book_by_abs_id("test-filename-book")
 
         # Create a KosyncDocument for hash_A linked to the book, with a filename and progress
         doc_a = KosyncDocument(
@@ -522,11 +519,11 @@ class TestKosyncEndpoints(unittest.TestCase):
             linked_abs_id="test-filename-book",
             linked_book_id=saved_book.id,
         )
-        web_server.database_service.save_kosync_document(doc_a)
+        self.database_service.save_kosync_document(doc_a)
 
         # Create a KosyncDocument for hash_B with the SAME filename but NOT linked
         doc_b = KosyncDocument(document_hash="e" * 32, filename="shared_name.epub")
-        web_server.database_service.save_kosync_document(doc_b)
+        self.database_service.save_kosync_document(doc_b)
 
         # GET with hash_B — should resolve via filename sibling to the book
         response = self.client.get("/syncs/progress/" + "e" * 32, headers=self.auth_headers)
@@ -537,7 +534,7 @@ class TestKosyncEndpoints(unittest.TestCase):
         self.assertEqual(data["document"], "e" * 32)
 
         # Clean up
-        with web_server.database_service.get_session() as session:
+        with self.database_service.get_session() as session:
             session.query(Book).filter(Book.abs_id == "test-filename-book").delete()
 
     # ---------------- Security Tests ----------------
@@ -659,11 +656,16 @@ class TestCleanupCacheTraversal(unittest.TestCase):
         cls.db_path = os.path.join(TEST_DIR, "test.db")
         from src import web_server
 
-        web_server.database_service = DatabaseService(cls.db_path)
+        cls.database_service = DatabaseService(cls.db_path)
         cls.mock_container = _KosyncMockContainer()
-        if not hasattr(web_server, "app"):
-            web_server.app, _ = web_server.create_app(test_container=cls.mock_container)
-        cls.app = web_server.app
+        # create_app bootstraps settings into os.environ; snapshot and restore
+        # so feature flags (e.g. GRIMMORY_ENABLED) do not leak into later tests.
+        _saved_env = os.environ.copy()
+        try:
+            cls.app, _ = web_server.create_app(test_container=cls.mock_container)
+        finally:
+            os.environ.clear()
+            os.environ.update(_saved_env)
 
     def test_traversal_filename_blocked(self):
         """A filename containing '../' must be rejected, not deleted."""

--- a/tests/test_matching_errors.py
+++ b/tests/test_matching_errors.py
@@ -229,6 +229,32 @@ def test_batch_match_ebook_only_kosync_failure_adds_to_failed(flask_app, mock_co
     assert response.status_code == 302
 
 
+def test_batch_match_skips_standard_item_without_ebook(flask_app, mock_container, client):
+    """Queued audiobook+ebook mappings without an ebook are marked failed before mapping."""
+    _setup_matching_db_defaults(mock_container.mock_database_service)
+
+    with flask_app.test_client() as test_client:
+        with test_client.session_transaction() as sess:
+            sess["queue"] = [
+                {
+                    "queue_key": "abs-missing-ebook",
+                    "abs_id": "abs-missing-ebook",
+                    "title": "Missing Ebook",
+                    "ebook_filename": "",
+                    "duration": 100,
+                    "storyteller_uuid": "storyteller-id",
+                    "audio_only": False,
+                    "ebook_only": False,
+                },
+            ]
+
+        with patch("src.blueprints.matching_bp._create_book_mapping") as create_mapping:
+            response = test_client.post("/batch-match", data={"action": "process_queue"})
+
+    assert response.status_code == 302
+    create_mapping.assert_not_called()
+
+
 # ── Suggestions page: serialize edge cases ────────────────────────
 
 

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -470,6 +470,18 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         finally:
             src.blueprints.matching_bp.get_kosync_id_for_ebook = original_get_kosync
 
+    def test_standard_match_requires_ebook_selection(self):
+        """Standard audiobook+ebook matching rejects missing ebook selection."""
+        self.mock_abs_client.get_all_audiobooks.return_value = [
+            {"id": "test-audiobook-123", "media": {"metadata": {"title": "Test Book"}, "duration": 3600}}
+        ]
+
+        response = self.client.post("/match", data={"audiobook_id": "test-audiobook-123"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"ebook selection is required", response.data)
+        self.mock_database_service.save_book.assert_not_called()
+
     def test_clear_progress_endpoint_clean_di(self):
         """Test clear progress endpoint with clean dependency injection."""
         # Setup mock book


### PR DESCRIPTION
## What Changed

- Extracts the book intake/matching side effects from `matching_bp.py` into `BookIntakeService`.
- Keeps route handlers as thin adapters for audio-only, ebook-only, attach-ebook, attach-audiobook, and audiobook+ebook mapping flows.
- Preserves the compatibility `_create_book_mapping` wrapper while routing the actual workflow through the new service.
- Adds focused coverage for intake behavior, merge preservation, missing ebook handling, Storyteller reservation behavior, and matching regressions.
- Adds `CONTEXT.md` vocabulary for the new Book Intake Module.

Follow-up correctness fixes included on this branch:

- Adds a partial unique index on `states (book_id, client_name)` (migration `w3x4y5z6a7b8`) and rewrites `save_state` upserts to dedupe and recover from insert conflicts using a pre-rollback scalar snapshot (no stale ORM reads after rollback).
- Preserves the canonical book's `transcript_file` and `activity_flag` during identity merges so an aligned ebook gaining an audiobook no longer loses its `DB_MANAGED` alignment routing.
- Fixes `clear_progress` resurrecting the KoSync document it had just deleted (status `save_book` calls re-created it); document deletion now runs after all status writes.
- Hardens test isolation (module-shadowing and `os.environ` leaks) so the suite is order-independent, and mounts `alembic/` into the test container so migration changes are exercised without an image rebuild.

## Why

Book intake had grown into a dense route-level workflow that mixed UI handling with database writes, KOSync document creation, ABS collection updates, Grimmory shelf updates, Hardcover automatch, Storyteller submission, and suggestion resolution.

Moving that orchestration into an intent-shaped service makes the matching routes easier to reason about while keeping existing behavior stable. The follow-up fixes also preserve canonical book identity during merges and prevent invalid standard matches from crashing when no ebook is selected.

## Validation

- `ruff check` on changed files → passed
- Full suite via `./run-tests.sh` → `872 passed, 2 skipped`, deterministic across repeated runs (after the test container picks up the mounted `alembic/`)
- Dev container rebuilt and verified: migrates cleanly to head `w3x4y5z6a7b8`, web UI returns HTTP 200
- GitHub checks currently passing:
  - `ruff`
  - `Macroscope - Correctness Check`
  - `code/snyk`
  - `security/snyk`

## Screenshots / UI Notes

No screenshots included. This is primarily a backend/service extraction with small template value-safety changes and no intended visual redesign.

## Data / Migration Risk

Moderate sync/data risk area, because this touches book identity merge behavior, reading-state writes, and intake side effects.

Schema change: migration `w3x4y5z6a7b8` rebuilds the `states` table to make `book_id` nullable, dedupes any existing duplicate `(book_id, client_name)` rows (keeping the most recently updated), and adds a partial unique index `uq_states_book_id_client_name` on `(book_id, client_name) WHERE book_id IS NOT NULL`. The rebuild copies all rows and recreates `ix_states_book_id`; legacy `abs_id`-only rows (`book_id IS NULL`) are intentionally left outside the unique constraint.

Risk controls in this PR:

- Preserves canonical source book rows during duplicate/identity merges instead of deleting the source row after migration, and preserves canonical alignment/activity hints when folding in a freshly created target book.
- Keeps KOSync document creation and suggestion resolution in the intake path.
- `save_state` deduplicates and recovers from unique-index conflicts without raising or reading a rolled-back ORM object.
- Adds regression coverage for duplicate merge preservation, missing ebook handling, the `save_state` conflict path, and the legacy-DB migration dedupe-before-index path.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I ran relevant tests or documented why they could not run
- [x] I included screenshots/video for UI changes, or marked UI as not applicable
- [x] I considered data, migration, and sync risks


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract book intake logic into `BookIntakeService` and expand test coverage
> - Introduces [book_intake_service.py](https://github.com/serabi/pagekeeper/pull/63/files#diff-14e35330d73ceab5ebe7bec550a71692e669f1b43685d48906aa0ccaf45d10fd) to centralize audiobook/ebook intake flows: KOSync ID computation, duplicate detection and merge, ABS collection updates, Grimmory shelf adds, Storyteller reservation/async submission, and suggestion resolution.
> - Refactors [matching_bp.py](https://github.com/serabi/pagekeeper/pull/63/files#diff-f5d2e619420610f4d9c08a5dc3aa96feb0b874563513f646a632a8f8a4ae5eed) to delegate all mapping and intake operations to `BookIntakeService`, removing inline DB model construction and background thread management from the blueprint.
> - Fixes a bug in `BookRepository.save_state` where insert conflicts are now recovered using a pre-rollback scalar snapshot, preventing stale ORM reads after rollback.
> - Fixes a book merge bug in `BookRepository` where falsy `transcript_file` and `activity_flag` values from a merge target no longer overwrite existing values on the canonical book.
> - Adds test isolation via a new `_reset_app_globals` autouse fixture in [conftest.py](https://github.com/serabi/pagekeeper/pull/63/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) that restores app globals and environment variables after each test.
> - Adds a large suite of unit and integration tests covering intake flows, merge paths, Storyteller submission failure handling, and `save_state` conflict recovery.
> - Behavioral Change: standard audiobook+ebook match via `POST /matching/match` now returns HTTP 400 with a plain-text error if `ebook_filename` is missing, rather than silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 558ebfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
