### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/AGENT_PR_GUIDELINES.md
+++ b/.github/AGENT_PR_GUIDELINES.md
@@ -1,0 +1,31 @@
+# Agent PR Guidelines
+
+These rules apply to PRs opened by AI coding agents such as Codex, Claude, Cursor, or other automated assistants.
+
+## Branch and scope
+
+- Target `dev` unless Sarah explicitly says otherwise.
+- Keep PRs small, focused, and independently reviewable.
+- Prefer one bug fix, one workflow improvement, or one documentation/tooling change per PR.
+- Do not mix unrelated cleanup with feature work.
+
+## PR body
+
+- Use `.github/pull_request_template.md`.
+- Keep prose concise and concrete.
+- Fill every applicable section.
+- For UI changes, include before/after screenshots or explain why screenshots are not available.
+- For database, sync, external API, or migration changes, explicitly describe data/migration risk and compatibility notes.
+- Include exact validation commands and results. If a command cannot run, state the blocker honestly.
+
+## Commits and attribution
+
+- Do not add AI signatures, marketing footers, or generated-by boilerplate.
+- Do not add `Generated with Claude`, `Generated with Codex`, `Co-Authored-By: Claude`, `Co-Authored-By: Codex`, or similar attribution footers.
+- Do not sign commits unless the repository/user explicitly requires signing.
+
+## Review loop
+
+- Before opening a PR, run relevant lint/tests for the touched area.
+- When using a second agent for review, fix valid findings before opening the PR.
+- If a PR remains risky or incomplete, leave it as draft and call out the blocker in the PR body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## What Changed
+
+<!-- Describe the change clearly. Keep scope tight. -->
+
+## Why
+
+<!-- Explain the problem being solved and why this approach is appropriate. -->
+
+## Validation
+
+<!-- List commands run and results. Include failures/blockers honestly. -->
+
+## Screenshots / UI Notes
+
+<!-- Required for UI changes. Include before/after screenshots when possible.
+For non-UI changes, write "Not applicable." -->
+
+## Data / Migration Risk
+
+<!-- Does this touch database schema, sync identity, external APIs, or migrations?
+If yes, explain risk and rollback/compatibility considerations.
+If no, write "None expected." -->
+
+## Checklist
+
+- [ ] This PR is small and focused
+- [ ] I explained what changed and why
+- [ ] I ran relevant tests or documented why they could not run
+- [ ] I included screenshots/video for UI changes, or marked UI as not applicable
+- [ ] I considered data, migration, and sync risks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,8 @@ git push origin my-feature
 
 I use AI to build PageKeeper and I'm fine with others also using AI. With that said, **please make sure you understand what your code does before submitting a PR.** AI is great as a tool but lousy as a decision maker.
 
+When opening PRs with AI assistance, follow [Agent PR Guidelines](.github/AGENT_PR_GUIDELINES.md): keep changes small, fill out the PR template, and document validation honestly.
+
 ## Reporting Bugs
 
 When opening a bug report, please include:


### PR DESCRIPTION
## What Changed

- Added a PageKeeper pull request template with sections for change summary, rationale, validation, UI notes, and data/migration risk.
- Added agent-specific PR guidelines for small scoped PRs, validation reporting, and avoiding AI attribution footers.
- Linked the agent PR guidelines from `CONTRIBUTING.md`.

## Why

PageKeeper has multiple human/agent-created PRs in flight, and a consistent template should make reviews cleaner, more focused, and safer around sync/database changes.

## Validation

- `git diff --check` — passed

## Screenshots / UI Notes

Not applicable.

## Data / Migration Risk

None expected. Documentation-only change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I ran relevant tests or documented why they could not run
- [x] I included screenshots/video for UI changes, or marked UI as not applicable
- [x] I considered data, migration, and sync risks

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull request template and AI contributor guidelines
> - Adds [pull_request_template.md](.github/pull_request_template.md) with sections for What Changed, Why, Validation, Screenshots/UI Notes, Data/Migration Risk, and a completion checklist.
> - Adds [AGENT_PR_GUIDELINES.md](.github/AGENT_PR_GUIDELINES.md) defining conventions for AI-assisted PRs: branch/PR scope, body requirements, commit attribution rules, and review loop expectations.
> - Updates [CONTRIBUTING.md](https://github.com/serabi/pagekeeper/pull/64/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) to direct AI-assisted contributors to the new guidelines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e02adc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->