### PR TITLE
Fix Hardcover audiobook progress edition selection

### DIFF
--- a/src/services/hardcover_service.py
+++ b/src/services/hardcover_service.py
@@ -34,6 +34,11 @@ LOCAL_TO_HC_STATUS = {
 }
 
 
+def uses_hardcover_audio_progress(book: Book) -> bool:
+    """Return True when Hardcover should mirror progress as audiobook seconds."""
+    return getattr(book, "sync_mode", "audiobook") != "ebook_only"
+
+
 class HardcoverService:
     """Non-sync Hardcover operations: status push, ratings, matching."""
 
@@ -59,9 +64,8 @@ class HardcoverService:
     # ── Edition Selection ─────────────────────────────────────────────
 
     def select_edition_id(self, book, hardcover_details):
-        """Select the appropriate edition based on sync source."""
-        sync_source = getattr(book, "sync_source", None)
-        if sync_source == "audiobook" and hardcover_details.hardcover_audio_edition_id:
+        """Select the appropriate edition based on the book's sync mode."""
+        if uses_hardcover_audio_progress(book) and hardcover_details.hardcover_audio_edition_id:
             return hardcover_details.hardcover_audio_edition_id
         return hardcover_details.hardcover_edition_id
 
@@ -69,18 +73,24 @@ class HardcoverService:
         """Fetch and cache edition info (pages, audio_seconds, edition IDs).
 
         Called at match time to ensure update_progress has the data it needs.
-        If pages are already cached (>0 or -1), this is a no-op.
+        If pages and audio availability are already cached, this is a no-op.
         Returns True if editions were resolved, False otherwise.
         """
         current_pages = hardcover_details.hardcover_pages or 0
-        if current_pages != 0:
+        audio_availability_resolved = (
+            hardcover_details.hardcover_audio_seconds is not None
+            or hardcover_details.hardcover_audio_edition_id is not None
+        )
+        if current_pages != 0 and audio_availability_resolved:
             return True  # Already resolved
 
         book_id = hardcover_details.hardcover_book_id
         if not book_id:
             return False
 
-        editions = self.hardcover_client.get_all_editions(int(book_id))
+        editions = self.hardcover_client.get_all_editions(int(book_id)) or {}
+        if not isinstance(editions, dict):
+            editions = {}
         page_ed = editions.get("ebook") or editions.get("physical")
         audio_ed = editions.get("audio")
 
@@ -90,6 +100,8 @@ class HardcoverService:
             if audio_ed and audio_ed.get("audio_seconds") and audio_ed["audio_seconds"] > 0:
                 hardcover_details.hardcover_audio_edition_id = str(audio_ed["id"])
                 hardcover_details.hardcover_audio_seconds = audio_ed["audio_seconds"]
+            else:
+                hardcover_details.hardcover_audio_seconds = 0
             self.database_service.save_hardcover_details(hardcover_details)
             return True
         elif audio_ed and audio_ed.get("audio_seconds") and audio_ed["audio_seconds"] > 0:
@@ -99,8 +111,13 @@ class HardcoverService:
             hardcover_details.hardcover_pages = -1  # Audio-only
             self.database_service.save_hardcover_details(hardcover_details)
             return True
+        elif current_pages > 0:
+            hardcover_details.hardcover_audio_seconds = 0
+            self.database_service.save_hardcover_details(hardcover_details)
+            return True
         else:
             hardcover_details.hardcover_pages = -1  # No usable editions
+            hardcover_details.hardcover_audio_seconds = 0
             self.database_service.save_hardcover_details(hardcover_details)
             return False
 
@@ -479,7 +496,7 @@ class HardcoverService:
 
             self.database_service.save_hardcover_details(hardcover_details)
             self.resolve_editions(hardcover_details)
-            self._get_or_create_user_book(book, hardcover_details, match.get("edition_id"))
+            self._get_or_create_user_book(book, hardcover_details, self.select_edition_id(book, hardcover_details))
             self._pull_dates_at_match(book)
             log_hardcover_action(
                 self.database_service,
@@ -550,6 +567,6 @@ class HardcoverService:
         if not book:
             book = Book(abs_id=book_abs_id, title="", status="")
             book = self.database_service.save_book(book)
-        self._get_or_create_user_book(book, details, match.get("edition_id"))
+        self._get_or_create_user_book(book, details, self.select_edition_id(book, details))
         self._pull_dates_at_match(book)
         return True

--- a/src/sync_clients/hardcover_sync_client.py
+++ b/src/sync_clients/hardcover_sync_client.py
@@ -18,6 +18,7 @@ from src.services.hardcover_service import (
     HC_WANT_TO_READ,
     PROGRESS_COMPLETE_THRESHOLD,
     PROGRESS_START_THRESHOLD,
+    uses_hardcover_audio_progress,
 )
 from src.services.write_tracker import record_write
 from src.sync_clients.sync_client_interface import ServiceState, SyncClient, SyncResult, UpdateProgressRequest
@@ -76,14 +77,13 @@ class HardcoverSyncClient(SyncClient):
     # ── Edition Selection ─────────────────────────────────────────────
 
     def select_edition_id(self, book, hardcover_details):
-        """Select the appropriate edition based on sync source.
+        """Select the appropriate edition based on sync mode.
 
         Delegates to HardcoverService if available, otherwise uses local logic.
         """
         if self.hardcover_service:
             return self.hardcover_service.select_edition_id(book, hardcover_details)
-        sync_source = getattr(book, "sync_source", None)
-        if sync_source == "audiobook" and hardcover_details.hardcover_audio_edition_id:
+        if uses_hardcover_audio_progress(book) and hardcover_details.hardcover_audio_edition_id:
             return hardcover_details.hardcover_audio_edition_id
         return hardcover_details.hardcover_edition_id
 
@@ -178,13 +178,24 @@ class HardcoverSyncClient(SyncClient):
         if not ub:
             return SyncResult(None, False)
 
+        is_audiobook = uses_hardcover_audio_progress(book)
         audio_seconds = hardcover_details.hardcover_audio_seconds or 0
-        is_audiobook = getattr(book, "sync_source", None) == "audiobook"
+        if is_audiobook and audio_seconds <= 0 and self.hardcover_service:
+            logger.info(f"Hardcover: Audio duration missing for {sanitize_log_data(book.title)}, resolving editions...")
+            self.hardcover_service.resolve_editions(hardcover_details)
+            audio_seconds = hardcover_details.hardcover_audio_seconds or 0
 
         edition_id = self.select_edition_id(book, hardcover_details)
 
         if is_audiobook and audio_seconds > 0:
             return self._update_audiobook_progress(book, hardcover_details, ub, percentage, audio_seconds, edition_id)
+
+        if is_audiobook:
+            logger.info(
+                f"Hardcover: '{sanitize_log_data(book.title)}' has audiobook sync mode but no audio edition; "
+                "skipping progress push"
+            )
+            return SyncResult(None, False)
 
         # --- PAGE-BASED PATH ---
         total_pages = hardcover_details.hardcover_pages or 0
@@ -200,7 +211,7 @@ class HardcoverSyncClient(SyncClient):
                 total_pages = hardcover_details.hardcover_pages or 0
                 audio_seconds = hardcover_details.hardcover_audio_seconds or 0
                 edition_id = self.select_edition_id(book, hardcover_details)
-                if total_pages == -1 and audio_seconds > 0:
+                if is_audiobook and total_pages == -1 and audio_seconds > 0:
                     return self._update_audiobook_progress(
                         book, hardcover_details, ub, percentage, audio_seconds, edition_id
                     )

--- a/src/sync_clients/hardcover_sync_client.py
+++ b/src/sync_clients/hardcover_sync_client.py
@@ -179,11 +179,12 @@ class HardcoverSyncClient(SyncClient):
             return SyncResult(None, False)
 
         is_audiobook = uses_hardcover_audio_progress(book)
-        audio_seconds = hardcover_details.hardcover_audio_seconds or 0
-        if is_audiobook and audio_seconds <= 0 and self.hardcover_service:
+        audio_seconds = hardcover_details.hardcover_audio_seconds
+        if is_audiobook and audio_seconds is None and self.hardcover_service:
             logger.info(f"Hardcover: Audio duration missing for {sanitize_log_data(book.title)}, resolving editions...")
             self.hardcover_service.resolve_editions(hardcover_details)
-            audio_seconds = hardcover_details.hardcover_audio_seconds or 0
+            audio_seconds = hardcover_details.hardcover_audio_seconds
+        audio_seconds = audio_seconds or 0
 
         edition_id = self.select_edition_id(book, hardcover_details)
 

--- a/tests/test_hardcover_sync_client.py
+++ b/tests/test_hardcover_sync_client.py
@@ -68,6 +68,11 @@ class TestHardcoverSyncClient(unittest.TestCase):
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def _set_test_book_sync_mode(self, sync_mode, kosync_doc_id=None):
+        self.test_book.sync_mode = sync_mode
+        self.test_book.kosync_doc_id = kosync_doc_id
+        self.test_book = self.database_service.save_book(self.test_book)
+
     def test_basic_interface_compliance(self):
         self.assertTrue(self.hardcover_sync_client.is_configured())
         self.assertFalse(self.hardcover_sync_client.can_be_leader())
@@ -110,6 +115,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_update_progress_calls_hardcover_api(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -144,7 +150,180 @@ class TestHardcoverSyncClient(unittest.TestCase):
         self.assertTrue(result.success)
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_audio_only_update_progress_uses_audio_edition_and_seconds(self, mock_record_write):
+        self._set_test_book_sync_mode("audiobook")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=300,
+            hardcover_audio_edition_id="654",
+            hardcover_audio_seconds=7200,
+            matched_by="test",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_WANT_TO_READ,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.25))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.mock_hardcover_client.update_status.assert_called_with(123, HC_CURRENTLY_READING, 654)
+        self.mock_hardcover_client.update_progress.assert_called_with(
+            789,
+            0,
+            edition_id="654",
+            is_finished=False,
+            current_percentage=0.25,
+            audio_seconds=7200,
+            started_at=None,
+            finished_at=None,
+            cached_read_id=None,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_state["progress_seconds"], 1800)
+        self.assertNotIn("pages", result.updated_state)
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_linked_audiobook_ebook_update_progress_uses_audio_edition(self, mock_record_write):
+        self._set_test_book_sync_mode("audiobook", kosync_doc_id="linked-ebook-doc")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=300,
+            hardcover_audio_edition_id="654",
+            hardcover_audio_seconds=7200,
+            matched_by="test",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_CURRENTLY_READING,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.mock_hardcover_client.update_status.assert_not_called()
+        self.mock_hardcover_client.update_progress.assert_called_with(
+            789,
+            0,
+            edition_id="654",
+            is_finished=False,
+            current_percentage=0.5,
+            audio_seconds=7200,
+            started_at=None,
+            finished_at=None,
+            cached_read_id=None,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_state["progress_seconds"], 3600)
+        self.assertNotIn("pages", result.updated_state)
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_ebook_only_update_progress_uses_page_edition_even_when_audio_exists(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only", kosync_doc_id="ebook-doc")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=200,
+            hardcover_audio_edition_id="654",
+            hardcover_audio_seconds=7200,
+            matched_by="test",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_WANT_TO_READ,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.25))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.mock_hardcover_client.update_status.assert_called_with(123, HC_CURRENTLY_READING, 456)
+        self.mock_hardcover_client.update_progress.assert_called_with(
+            789,
+            50,
+            edition_id="456",
+            is_finished=False,
+            current_percentage=0.25,
+            started_at=None,
+            finished_at=None,
+            cached_read_id=None,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_state["pages"], 50)
+        self.assertNotIn("progress_seconds", result.updated_state)
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_audio_only_without_audio_edition_does_not_push_page_progress(self, mock_record_write):
+        self._set_test_book_sync_mode("audiobook")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=300,
+            matched_by="test",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_CURRENTLY_READING,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+        self.mock_hardcover_client.get_all_editions.return_value = {"ebook": {"id": 456, "pages": 300}}
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.25))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.assertFalse(result.success)
+        self.mock_hardcover_client.update_progress.assert_not_called()
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_audio_progress_lazy_resolves_audio_edition_for_older_page_match(self, mock_record_write):
+        self._set_test_book_sync_mode("audiobook")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=300,
+            matched_by="legacy",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_CURRENTLY_READING,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+        self.mock_hardcover_client.get_all_editions.return_value = {
+            "ebook": {"id": 456, "pages": 300},
+            "audio": {"id": 654, "audio_seconds": 7200},
+        }
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.mock_hardcover_client.update_progress.assert_called_with(
+            789,
+            0,
+            edition_id="654",
+            is_finished=False,
+            current_percentage=0.5,
+            audio_seconds=7200,
+            started_at=None,
+            finished_at=None,
+            cached_read_id=None,
+        )
+        self.assertTrue(result.success)
+        saved = self.database_service.get_hardcover_details(self.test_book.id)
+        self.assertEqual(saved.hardcover_audio_edition_id, "654")
+        self.assertEqual(saved.hardcover_audio_seconds, 7200)
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_finished_book_status_promotion(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -179,6 +358,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_automatch_skip_when_already_matched(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only")
         existing_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -201,6 +381,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_zero_pages_edge_case(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -234,6 +415,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_api_error_handling(self, mock_record_write):
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -282,6 +464,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_dnf_status_not_auto_resumed(self, mock_record_write):
         """Test that DNF books are not auto-resumed by progress updates."""
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,
@@ -369,6 +552,7 @@ class TestHardcoverSyncClient(unittest.TestCase):
     @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_completed_book_forwards_historical_dates(self, mock_record_write):
         """Test that a completed book's started_at/finished_at are forwarded to the API."""
+        self._set_test_book_sync_mode("ebook_only")
         hardcover_details = HardcoverDetails(
             abs_id="test-hardcover-book",
             book_id=self.test_book.id,

--- a/tests/test_hardcover_sync_client.py
+++ b/tests/test_hardcover_sync_client.py
@@ -283,6 +283,30 @@ class TestHardcoverSyncClient(unittest.TestCase):
         self.mock_hardcover_client.update_progress.assert_not_called()
 
     @patch("src.sync_clients.hardcover_sync_client.record_write")
+    def test_audio_only_with_resolved_no_audio_edition_does_not_re_resolve(self, mock_record_write):
+        self._set_test_book_sync_mode("audiobook")
+        hardcover_details = HardcoverDetails(
+            abs_id="test-hardcover-book",
+            book_id=self.test_book.id,
+            hardcover_book_id="123",
+            hardcover_edition_id="456",
+            hardcover_pages=300,
+            hardcover_audio_seconds=0,
+            matched_by="test",
+            hardcover_user_book_id=789,
+            hardcover_status_id=HC_CURRENTLY_READING,
+        )
+        self.database_service.save_hardcover_details(hardcover_details)
+
+        update_request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.25))
+
+        result = self.hardcover_sync_client.update_progress(self.test_book, update_request)
+
+        self.assertFalse(result.success)
+        self.mock_hardcover_client.get_all_editions.assert_not_called()
+        self.mock_hardcover_client.update_progress.assert_not_called()
+
+    @patch("src.sync_clients.hardcover_sync_client.record_write")
     def test_audio_progress_lazy_resolves_audio_edition_for_older_page_match(self, mock_record_write):
         self._set_test_book_sync_mode("audiobook")
         hardcover_details = HardcoverDetails(


### PR DESCRIPTION
## Summary
- Use Book.sync_mode to route Hardcover audio-mode books to audio editions and progress_seconds
- Preserve ebook_only page-edition/page progress behavior
- Add focused coverage for audio-only, linked audiobook+ebook, ebook-only, and lazy audio edition resolution

## Tests
- UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uvx ruff check src/services/hardcover_service.py src/sync_clients/hardcover_sync_client.py tests/test_hardcover_sync_client.py
- docker compose -f docker-compose.test.yml run --rm --entrypoint sh test -lc 'python -m pytest tests/test_hardcover_sync_client.py'

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Hardcover audiobook progress edition selection based on sync mode
> - Adds `uses_hardcover_audio_progress(book)` helper that returns `True` when `sync_mode` is not `'ebook_only'`, used to decide whether to track progress as audio seconds or pages.
> - Updates `HardcoverService.select_edition_id` and `HardcoverSyncClient.select_edition_id` to prefer the audio edition when audio progress is active, rather than using the raw matched edition ID.
> - Fixes `HardcoverService.resolve_editions` to persist `hardcover_audio_seconds=0` when no audio edition exists, preventing repeated re-resolution and correctly treating pages-only matches as resolved.
> - Updates automatch and manual match flows to derive the edition via `select_edition_id` (sync-mode-aware) instead of passing the edition ID directly from the match result.
> - Behavioral Change: books in non-ebook-only sync mode without a resolved audio edition will now block progress pushes until resolution completes, rather than falling through to page-based updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b630e15. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->