### PR TITLE
Fix book identity merge preservation

### DIFF
--- a/src/blueprints/matching_bp.py
+++ b/src/blueprints/matching_bp.py
@@ -190,7 +190,6 @@ def _create_book_mapping(
     if migration_source_id:
         try:
             database_service.migrate_book_data(migration_source_id, abs_id)
-            database_service.delete_book(existing_book.id)
             abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
             logger.info(f"Successfully merged {migration_source_id} into {abs_id}")
         except Exception as e:
@@ -454,8 +453,7 @@ def match():
             database_service.save_book(new_book)
             ensure_kosync_document(new_book, database_service)
             try:
-                database_service.migrate_book_data(link_book_id, abs_id)
-                database_service.delete_book(book.id)
+                database_service.migrate_book_data(book.abs_id or link_book_id, abs_id)
                 abs_service.add_to_collection(abs_id, current_app.config["ABS_COLLECTION_NAME"])
                 logger.info(f"Successfully merged {link_book_id} into {abs_id}")
             except Exception as e:

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -2,20 +2,48 @@
 
 import logging
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 
 from .base_repository import BaseRepository
 from .models import (
     Book,
+    BookAlignment,
+    BookfusionBook,
+    BookfusionHighlight,
+    HardcoverDetails,
+    HardcoverSyncLog,
     Job,
     KosyncDocument,
     ReadingJournal,
     State,
     StorytellerSubmission,
+    TbrItem,
 )
 
 logger = logging.getLogger(__name__)
 _UNSET = object()
+
+_BOOK_MERGE_METADATA_ATTRS = (
+    "title",
+    "author",
+    "subtitle",
+    "ebook_filename",
+    "original_ebook_filename",
+    "kosync_doc_id",
+    "transcript_file",
+    "status",
+    "duration",
+    "sync_mode",
+    "storyteller_uuid",
+    "abs_ebook_item_id",
+    "ebook_item_id",
+    "activity_flag",
+    "custom_cover_url",
+    "started_at",
+    "finished_at",
+    "rating",
+    "read_count",
+)
 
 
 class BookRepository(BaseRepository):
@@ -143,30 +171,79 @@ class BookRepository(BaseRepository):
             return False
 
     def migrate_book_data(self, old_abs_id, new_abs_id):
-        """Migrate book identity: update abs_id and resolve state conflicts.
+        """Migrate a book identity while preserving the source Book row.
 
-        With book_id as FK, child rows follow the book automatically —
-        only abs_id and state dedup need updating.
+        The existing book is the canonical row because child state, journals,
+        jobs, and external links already point at its primary key.  If a target
+        ABS row was pre-created to hold fresh metadata, fold that metadata into
+        the source row, move any target-only children, then delete only the
+        temporary target row.
         """
         with self.get_session() as session:
             try:
                 book = session.query(Book).filter(Book.abs_id == old_abs_id).first()
+                if not book and old_abs_id is not None:
+                    old_ref = str(old_abs_id).strip()
+                    if old_ref.isdigit():
+                        book = session.query(Book).filter(Book.id == int(old_ref)).first()
                 if not book:
                     logger.warning(f"migrate_book_data: book '{old_abs_id}' not found")
                     return
 
-                # Delete states for the new abs_id that would conflict
+                canonical_book_id = book.id
+                previous_abs_id = book.abs_id
                 incoming_clients = {
-                    r[0] for r in session.query(State.client_name).filter(State.book_id == book.id).all()
+                    r[0] for r in session.query(State.client_name).filter(State.book_id == canonical_book_id).all()
                 }
                 target_book = session.query(Book).filter(Book.abs_id == new_abs_id).first()
-                if target_book:
+                target_book_id = target_book.id if target_book else None
+
+                if target_book and target_book_id != canonical_book_id:
+                    for attr in _BOOK_MERGE_METADATA_ATTRS:
+                        setattr(book, attr, getattr(target_book, attr))
+
                     if incoming_clients:
                         session.query(State).filter(
-                            State.book_id == target_book.id,
+                            State.book_id == target_book_id,
                             State.client_name.in_(incoming_clients),
                         ).delete(synchronize_session=False)
-                    # Delete the target book so we can reuse its abs_id
+
+                    session.query(State).filter(State.book_id == target_book_id).update(
+                        {State.book_id: canonical_book_id, State.abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+                    session.query(Job).filter(Job.book_id == target_book_id).update(
+                        {Job.book_id: canonical_book_id, Job.abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+                    session.query(ReadingJournal).filter(ReadingJournal.book_id == target_book_id).update(
+                        {ReadingJournal.book_id: canonical_book_id, ReadingJournal.abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+                    session.query(StorytellerSubmission).filter(StorytellerSubmission.book_id == target_book_id).update(
+                        {StorytellerSubmission.book_id: canonical_book_id, StorytellerSubmission.abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+
+                    self._move_unique_child(session, HardcoverDetails, canonical_book_id, target_book_id, new_abs_id)
+                    self._move_unique_child(session, BookAlignment, canonical_book_id, target_book_id, new_abs_id)
+
+                    session.query(HardcoverSyncLog).filter(HardcoverSyncLog.book_id == target_book_id).update(
+                        {HardcoverSyncLog.book_id: canonical_book_id, HardcoverSyncLog.abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+                    session.query(BookfusionHighlight).filter(
+                        BookfusionHighlight.matched_book_id == target_book_id
+                    ).update({BookfusionHighlight.matched_book_id: canonical_book_id}, synchronize_session=False)
+                    session.query(BookfusionBook).filter(BookfusionBook.matched_book_id == target_book_id).update(
+                        {BookfusionBook.matched_book_id: canonical_book_id},
+                        synchronize_session=False,
+                    )
+                    session.query(TbrItem).filter(TbrItem.book_id == target_book_id).update(
+                        {TbrItem.book_id: canonical_book_id, TbrItem.book_abs_id: new_abs_id},
+                        synchronize_session=False,
+                    )
+
                     session.delete(target_book)
                     session.flush()
 
@@ -174,27 +251,59 @@ class BookRepository(BaseRepository):
                 book.abs_id = new_abs_id
 
                 # Update denormalized abs_id on child rows
-                session.query(State).filter(State.book_id == book.id).update(
+                session.query(State).filter(State.book_id == canonical_book_id).update(
                     {State.abs_id: new_abs_id}, synchronize_session=False
                 )
-                session.query(Job).filter(Job.book_id == book.id).update(
+                session.query(Job).filter(Job.book_id == canonical_book_id).update(
                     {Job.abs_id: new_abs_id}, synchronize_session=False
                 )
-                session.query(ReadingJournal).filter(ReadingJournal.book_id == book.id).update(
+                session.query(ReadingJournal).filter(ReadingJournal.book_id == canonical_book_id).update(
                     {ReadingJournal.abs_id: new_abs_id}, synchronize_session=False
                 )
-                session.query(StorytellerSubmission).filter(StorytellerSubmission.book_id == book.id).update(
+                session.query(StorytellerSubmission).filter(StorytellerSubmission.book_id == canonical_book_id).update(
                     {StorytellerSubmission.abs_id: new_abs_id}, synchronize_session=False
                 )
+                session.query(HardcoverDetails).filter(HardcoverDetails.book_id == canonical_book_id).update(
+                    {HardcoverDetails.abs_id: new_abs_id}, synchronize_session=False
+                )
+                session.query(BookAlignment).filter(BookAlignment.book_id == canonical_book_id).update(
+                    {BookAlignment.abs_id: new_abs_id}, synchronize_session=False
+                )
+                session.query(HardcoverSyncLog).filter(HardcoverSyncLog.book_id == canonical_book_id).update(
+                    {HardcoverSyncLog.abs_id: new_abs_id}, synchronize_session=False
+                )
+                session.query(TbrItem).filter(TbrItem.book_id == canonical_book_id).update(
+                    {TbrItem.book_abs_id: new_abs_id}, synchronize_session=False
+                )
 
-                session.query(KosyncDocument).filter(KosyncDocument.linked_abs_id == old_abs_id).update(
-                    {KosyncDocument.linked_abs_id: new_abs_id}, synchronize_session=False
+                session.query(KosyncDocument).filter(
+                    or_(
+                        KosyncDocument.linked_book_id.in_([canonical_book_id, target_book_id]),
+                        KosyncDocument.linked_abs_id.in_([old_abs_id, previous_abs_id, new_abs_id]),
+                    )
+                ).update(
+                    {KosyncDocument.linked_book_id: canonical_book_id, KosyncDocument.linked_abs_id: new_abs_id},
+                    synchronize_session=False,
                 )
 
                 logger.info(f"Migrated book identity from '{old_abs_id}' to '{new_abs_id}'")
             except Exception as e:
                 logger.error(f"Failed to migrate book data: {e}")
                 raise
+
+    def _move_unique_child(self, session, model, canonical_book_id, target_book_id, new_abs_id):
+        target_child = session.query(model).filter(model.book_id == target_book_id).first()
+        if not target_child:
+            return
+
+        canonical_child = session.query(model).filter(model.book_id == canonical_book_id).first()
+        if canonical_child:
+            session.delete(target_child)
+            return
+
+        target_child.book_id = canonical_book_id
+        if hasattr(target_child, "abs_id"):
+            target_child.abs_id = new_abs_id
 
     # ── State CRUD ──
 

--- a/tests/test_book_identity_merge.py
+++ b/tests/test_book_identity_merge.py
@@ -1,0 +1,265 @@
+"""Regression coverage for preserving canonical Book rows during identity merges."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.db.database_service import DatabaseService
+from src.db.models import Book, Job, KosyncDocument, ReadingJournal, State, StorytellerSubmission
+
+sys.modules.setdefault("nh3", SimpleNamespace(clean=lambda value, tags=None, attributes=None: value))
+
+
+class _RouteContainer:
+    def __init__(self, db, temp_dir):
+        self._db = db
+        self._temp_dir = Path(temp_dir)
+        self._abs_client = Mock()
+        self._abs_client.is_configured.return_value = True
+        self._abs_client.get_all_audiobooks.return_value = [
+            {
+                "id": "abs-route-audiobook",
+                "media": {
+                    "metadata": {"title": "Route ABS Audiobook", "authorName": "Route Author"},
+                    "duration": 5400,
+                },
+            }
+        ]
+        self._abs_client.add_to_collection.return_value = True
+
+        self._sync_manager = Mock()
+        self._sync_manager.abs_client = self._abs_client
+        self._sync_manager.get_audiobook_title.side_effect = lambda item: item["media"]["metadata"]["title"]
+        self._sync_manager.get_duration.side_effect = lambda item: item["media"]["duration"]
+
+        self._grimmory_client = Mock()
+        self._grimmory_client.is_configured.return_value = False
+        self._storyteller_client = Mock()
+        self._storyteller_client.is_configured.return_value = False
+        self._bookfusion_client = Mock()
+        self._bookfusion_client.is_configured.return_value = False
+        self._hardcover_service = Mock()
+        self._hardcover_service.is_configured.return_value = False
+        self._hardcover_sync_client = Mock()
+        self._reading_date_service = Mock()
+        self._reading_date_service.pull_reading_dates.return_value = {}
+        self._ebook_parser = Mock()
+
+    def sync_manager(self):
+        return self._sync_manager
+
+    def abs_client(self):
+        return self._abs_client
+
+    def grimmory_client(self):
+        return self._grimmory_client
+
+    def grimmory_client_group(self):
+        return self._grimmory_client
+
+    def storyteller_client(self):
+        return self._storyteller_client
+
+    def bookfusion_client(self):
+        return self._bookfusion_client
+
+    def hardcover_service(self):
+        return self._hardcover_service
+
+    def hardcover_sync_client(self):
+        return self._hardcover_sync_client
+
+    def reading_date_service(self):
+        return self._reading_date_service
+
+    def ebook_parser(self):
+        return self._ebook_parser
+
+    def database_service(self):
+        return self._db
+
+    def data_dir(self):
+        return self._temp_dir
+
+    def books_dir(self):
+        return self._temp_dir
+
+    def epub_cache_dir(self):
+        return self._temp_dir / "epub_cache"
+
+    def sync_clients(self):
+        return {}
+
+
+class TestBookIdentityMerge(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        os.environ["DATA_DIR"] = self.temp_dir
+        os.environ["BOOKS_DIR"] = self.temp_dir
+        self.db = DatabaseService(str(Path(self.temp_dir) / "identity_merge.db"))
+
+    def tearDown(self):
+        if hasattr(self, "db") and hasattr(self.db, "db_manager"):
+            self.db.db_manager.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_attaching_abs_audiobook_preserves_source_book_and_children(self):
+        source = self.db.save_book(
+            Book(
+                abs_id="ebook-local-1",
+                title="Local EPUB",
+                ebook_filename="local.epub",
+                kosync_doc_id="a" * 32,
+                status="active",
+                sync_mode="ebook_only",
+                read_count=2,
+            )
+        )
+        self.db.save_state(
+            State(
+                abs_id=source.abs_id,
+                book_id=source.id,
+                client_name="KOReader",
+                percentage=0.42,
+                timestamp=120,
+            )
+        )
+        self.db.save_job(Job(abs_id=source.abs_id, book_id=source.id, last_attempt=100, progress=0.5))
+        self.db.add_reading_journal(source.id, event="note", entry="keep me", abs_id=source.abs_id)
+        self.db.save_storyteller_submission(
+            StorytellerSubmission(
+                abs_id=source.abs_id,
+                book_id=source.id,
+                status="processing",
+                storyteller_uuid="storyteller-source",
+            )
+        )
+        self.db.save_kosync_document(
+            KosyncDocument(
+                document_hash=source.kosync_doc_id,
+                progress="/body/source",
+                percentage=0.42,
+                linked_abs_id=source.abs_id,
+                linked_book_id=source.id,
+                filename=source.ebook_filename,
+            )
+        )
+
+        target = self.db.save_book(
+            Book(
+                abs_id="abs-audiobook-1",
+                title="ABS Audiobook",
+                author="Audio Author",
+                ebook_filename=source.ebook_filename,
+                kosync_doc_id=source.kosync_doc_id,
+                status="active",
+                duration=3600,
+                sync_mode="audiobook",
+                read_count=source.read_count,
+            )
+        )
+        self.db.save_state(
+            State(
+                abs_id=target.abs_id,
+                book_id=target.id,
+                client_name="KOReader",
+                percentage=0.99,
+                timestamp=999,
+            )
+        )
+        self.db.save_state(
+            State(abs_id=target.abs_id, book_id=target.id, client_name="Audiobookshelf", percentage=0.05)
+        )
+
+        self.db.migrate_book_data(source.abs_id, target.abs_id)
+
+        with self.db.get_session() as session:
+            books = session.query(Book).all()
+            self.assertEqual(len(books), 1)
+
+            survivor = books[0]
+            self.assertEqual(survivor.id, source.id)
+            self.assertEqual(survivor.abs_id, "abs-audiobook-1")
+            self.assertEqual(survivor.title, "ABS Audiobook")
+            self.assertEqual(survivor.duration, 3600)
+            self.assertEqual(survivor.sync_mode, "audiobook")
+
+            states = session.query(State).order_by(State.client_name).all()
+            self.assertEqual([state.client_name for state in states], ["Audiobookshelf", "KOReader"])
+            self.assertTrue(all(state.book_id == source.id for state in states))
+            self.assertTrue(all(state.abs_id == survivor.abs_id for state in states))
+            self.assertEqual(next(state for state in states if state.client_name == "KOReader").percentage, 0.42)
+
+            job = session.query(Job).one()
+            self.assertEqual(job.book_id, source.id)
+            self.assertEqual(job.abs_id, survivor.abs_id)
+
+            journal = session.query(ReadingJournal).one()
+            self.assertEqual(journal.book_id, source.id)
+            self.assertEqual(journal.abs_id, survivor.abs_id)
+
+            submission = session.query(StorytellerSubmission).one()
+            self.assertEqual(submission.book_id, source.id)
+            self.assertEqual(submission.abs_id, survivor.abs_id)
+
+            kosync_doc = session.query(KosyncDocument).filter_by(document_hash=source.kosync_doc_id).one()
+            self.assertEqual(kosync_doc.linked_book_id, source.id)
+            self.assertEqual(kosync_doc.linked_abs_id, survivor.abs_id)
+
+    def test_attach_audiobook_route_merges_when_link_book_id_is_numeric(self):
+        import src.db.migration_utils
+
+        original_initialize_database = src.db.migration_utils.initialize_database
+        src.db.migration_utils.initialize_database = lambda data_dir: self.db
+        try:
+            from src.web_server import create_app
+
+            source = self.db.save_book(
+                Book(
+                    abs_id="route-ebook-1",
+                    title="Route EPUB",
+                    ebook_filename="route.epub",
+                    kosync_doc_id="b" * 32,
+                    status="active",
+                    sync_mode="ebook_only",
+                )
+            )
+            self.db.save_state(
+                State(abs_id=source.abs_id, book_id=source.id, client_name="KOReader", percentage=0.25)
+            )
+
+            app, _ = create_app(test_container=_RouteContainer(self.db, self.temp_dir))
+            app.config["TESTING"] = True
+
+            response = app.test_client().post(
+                "/match",
+                data={
+                    "action": "attach_audiobook",
+                    "link_book_id": str(source.id),
+                    "audiobook_id": "abs-route-audiobook",
+                },
+            )
+
+            self.assertEqual(response.status_code, 302)
+            with self.db.get_session() as session:
+                books = session.query(Book).all()
+                self.assertEqual(len(books), 1)
+                survivor = books[0]
+                self.assertEqual(survivor.id, source.id)
+                self.assertEqual(survivor.abs_id, "abs-route-audiobook")
+                self.assertEqual(survivor.title, "Route ABS Audiobook")
+
+                state = session.query(State).one()
+                self.assertEqual(state.book_id, source.id)
+                self.assertEqual(state.abs_id, "abs-route-audiobook")
+        finally:
+            src.db.migration_utils.initialize_database = original_initialize_database
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -715,6 +715,7 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
             status="active",
             sync_mode="ebook_only",
         )
+        ebook_book.id = 42
         self.mock_database_service.get_book_by_abs_id.return_value = ebook_book
         self.mock_database_service.get_book_by_ref.return_value = ebook_book
 
@@ -732,7 +733,7 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         response = self.client.post(
             "/match",
             data={
-                "link_book_id": "ebook-abc123",
+                "link_book_id": "42",
                 "audiobook_id": "real-audiobook-789",
                 "action": "attach_audiobook",
             },
@@ -749,7 +750,7 @@ class CleanFlaskIntegrationTest(unittest.TestCase):
         self.assertEqual(saved_book.sync_mode, "audiobook")
 
         self.mock_database_service.migrate_book_data.assert_called_once_with("ebook-abc123", "real-audiobook-789")
-        self.mock_database_service.delete_book.assert_called_once_with(None)
+        self.mock_database_service.delete_book.assert_not_called()
         self.mock_abs_client.add_to_collection.assert_called_once()
 
         print("[OK] Attach audiobook test passed")


### PR DESCRIPTION
## Summary
- Preserve the existing canonical Book row when mapping or attaching an audiobook to an ebook/local/KOSync book.
- Fold target audiobook metadata into the canonical row, reparent target-only child rows, and refresh denormalized abs_id references transactionally.
- Stop route-level cleanup from deleting the survivor row, and cover numeric link_book_id attach flow with real SQLite regression tests.

## Tests
- python3 -m compileall src/db/book_repository.py src/blueprints/matching_bp.py tests/test_book_identity_merge.py tests/test_webserver.py
- UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uvx ruff check src/db/book_repository.py src/blueprints/matching_bp.py tests/test_book_identity_merge.py tests/test_webserver.py
- git diff --check
- docker compose -f docker-compose.test.yml run --rm --entrypoint sh test -lc 'python -m pytest tests/test_book_identity_merge.py tests/test_webserver.py::CleanFlaskIntegrationTest::test_attach_audiobook_to_ebook_only tests/test_reading_tracker.py::TestReadingTrackerModels::test_migrate_book_data_includes_journals'\n- docker compose -f docker-compose.test.yml run --rm --entrypoint sh test -lc 'python -m pytest' (fails in unrelated existing tests: test_clear_progress_success, three test_grimmory_client tests, test_dependency_injection_works)\n\n## Risks\n- Unique one-to-one target child rows are discarded if the canonical source already has that child; source remains authoritative.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `migrate_book_data` to preserve the source book row during identity merge
> - `BookRepository.migrate_book_data` previously deleted the source book after migrating data to the target; it now keeps the source row as the canonical record, updates it to the new `abs_id`, folds in target metadata, re-associates child rows, and only deletes the temporary target row.
> - The `/match` attach-audiobook route in [matching_bp.py](https://github.com/serabi/pagekeeper/pull/66/files#diff-f5d2e619420610f4d9c08a5dc3aa96feb0b874563513f646a632a8f8a4ae5eed) now passes `book.abs_id` (when available) instead of `link_book_id` to `migrate_book_data`, and no longer calls `delete_book` after migration.
> - Regression tests in [test_book_identity_merge.py](https://github.com/serabi/pagekeeper/pull/66/files#diff-c0313ee9da7eb434fb5c1e28d6806b92727f6869d89589f288bfff1fbbf7682d) cover both the repository merge behavior and the `/match` route integration path.
> - Behavioral Change: identity merges now consolidate onto the source book's primary key rather than the target's, which changes which row survives after a merge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3210b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->