### PR TITLE
chore: document local test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ For larger changes, please open an issue first so we can discuss the approach be
 
 ### Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) (required for both running and testing)
+- [Docker](https://docs.docker.com/get-docker/) or [OrbStack](https://orbstack.dev/) (required for full app runs and Docker test parity)
+- [uv](https://docs.astral.sh/uv/) (recommended for a local Python environment)
 - [Git](https://git-scm.com/)
 
 ### Getting Started
@@ -34,7 +35,40 @@ docker compose -f docker-compose.dev.yml up --build -d
 
 The dev dashboard is available at `http://localhost:4478` (port 4478, not 4477 — this avoids conflicts if you're also running a production instance). The dev compose file also sets `PAGEKEEPER_ENV=dev`, which turns on the in-app `DEV` badge, `[DEV]` browser-tab prefix, and dev-specific startup messaging. This flag is only for visual/runtime identification and should stay out of production compose files. All settings — integrations, API keys, sync configuration — are managed through the web dashboard.
 
-## Running Tests
+If another PageKeeper dev worktree is already using ports 4478/5759, choose alternate host ports:
+
+```bash
+PAGEKEEPER_DEV_WEB_PORT=4480 PAGEKEEPER_DEV_KOSYNC_PORT=5761 docker compose -f docker-compose.dev.yml up --build -d
+```
+
+### Optional Local Python Environment
+
+Docker is still the most production-like test path, but a local venv is useful for Ruff and fast targeted tests:
+
+```bash
+uv venv --python 3.13 .venv
+VIRTUAL_ENV= uv pip install --python .venv/bin/python -r requirements.txt pytest ruff
+```
+
+The explicit `--python .venv/bin/python` keeps installs inside the project venv even if your shell already has another virtualenv active.
+
+## Running Tests and Checks
+
+### Ruff
+
+```bash
+./.venv/bin/ruff check --no-cache src tests alembic scripts
+```
+
+### Targeted Tests on macOS
+
+Use a temp data directory so local pytest does not touch real PageKeeper data:
+
+```bash
+DATA_DIR="$PWD/.tmp/test-data" ./.venv/bin/python -m pytest tests/test_app_runtime.py
+```
+
+### Docker Tests
 
 Tests run inside Docker. From the project root:
 
@@ -50,6 +84,25 @@ Tests run inside Docker. From the project root:
 ```
 
 The test container handles all dependencies (epubcfi, ffmpeg, etc.), so there's nothing extra to install locally.
+
+For a direct Docker compose invocation:
+
+```bash
+docker compose -f docker-compose.test.yml run --rm test tests/test_app_runtime.py
+```
+
+### Dev App Smoke Test
+
+```bash
+docker compose -f docker-compose.dev.yml up --build -d
+docker compose -f docker-compose.dev.yml ps
+curl -fsS http://localhost:4478/healthcheck
+curl -fsS -I http://localhost:4478/
+```
+
+If you used alternate ports, replace `4478` with your `PAGEKEEPER_DEV_WEB_PORT`.
+
+The dev compose file stores app state under the ignored local `data/` directory. Do not copy production databases or secrets into a branch unless the task explicitly needs them.
 
 ## Branching & Pull Requests
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,10 +2,13 @@
 #
 # Usage:
 #   docker compose -f docker-compose.dev.yml up --build -d
+#   PAGEKEEPER_DEV_WEB_PORT=4480 PAGEKEEPER_DEV_KOSYNC_PORT=5761 docker compose -f docker-compose.dev.yml up --build -d
 #   docker compose -f docker-compose.dev.yml logs -f
 #   docker compose -f docker-compose.dev.yml down
 #
 # Ports: 4478 (web), 5759 (sync) — different from prod to allow simultaneous use.
+# Override PAGEKEEPER_DEV_WEB_PORT and PAGEKEEPER_DEV_KOSYNC_PORT when another
+# PageKeeper dev worktree is already using those host ports.
 # Source is mounted from host, so code changes take effect on container restart.
 
 services:
@@ -13,15 +16,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: pagekeeper-dev
     restart: unless-stopped
 
     environment:
       - TZ=America/New_York
       - PAGEKEEPER_ENV=dev
       - LOG_LEVEL=DEBUG
-      - HOST_WEB_URL=http://localhost:4478
-      - HOST_KOSYNC_PORT=5759
+      - HOST_WEB_URL=http://localhost:${PAGEKEEPER_DEV_WEB_PORT:-4478}
+      - HOST_KOSYNC_PORT=${PAGEKEEPER_DEV_KOSYNC_PORT:-5759}
       - KOSYNC_PORT=5758
 
     volumes:
@@ -36,5 +38,5 @@ services:
       - ./scripts:/app/scripts:ro
 
     ports:
-      - "4478:4477"   # Dev web UI
-      - "5759:5758"   # Dev sync protocol
+      - "${PAGEKEEPER_DEV_WEB_PORT:-4478}:4477"      # Dev web UI
+      - "${PAGEKEEPER_DEV_KOSYNC_PORT:-5759}:5758"   # Dev sync protocol

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,9 +5,10 @@ services:
       dockerfile: Dockerfile
     platform: linux/amd64
     user: root
-    entrypoint: ["sh", "-c", "pip install -q pytest && python -m pytest tests/ \"$@\"", "--"]
+    entrypoint: ["sh", "-c", "pip install -q pytest && python -m pytest \"$@\"", "--"]
     volumes:
       - ./src:/app/src:ro
       - ./tests:/app/tests:ro
       - ./templates:/app/templates:ro
       - ./static:/app/static:ro
+      - ./pyproject.toml:/app/pyproject.toml:ro

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ if docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/nul
         docker exec "$CONTAINER_NAME" pip install -q pytest
     fi
 
-    docker exec -w /app "$CONTAINER_NAME" python -m pytest tests/ "$@"
+    docker exec -w /app "$CONTAINER_NAME" python -m pytest "$@"
 else
     echo "==> Container '$CONTAINER_NAME' is not running. Using docker compose..."
     docker compose -f "$COMPOSE_TEST_FILE" run --rm test "$@"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ if docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/nul
         docker exec "$CONTAINER_NAME" pip install -q pytest
     fi
 
-    docker exec -w /app "$CONTAINER_NAME" python -m pytest "$@"
+    docker exec -w /app "$CONTAINER_NAME" python -m pytest "${@:-tests/}"
 else
     echo "==> Container '$CONTAINER_NAME' is not running. Using docker compose..."
     docker compose -f "$COMPOSE_TEST_FILE" run --rm test "$@"


### PR DESCRIPTION
## Summary
- document local uv, Ruff, pytest, Docker, and dev smoke-test commands
- make Docker test targets pass through correctly for focused pytest runs
- allow dev compose ports to be overridden for parallel worktrees

## Verification
- `./.venv/bin/ruff check --no-cache src tests alembic scripts`
- `DATA_DIR="$PWD/.tmp/test-data" ./.venv/bin/python -m pytest tests/test_app_runtime.py`
- `./run-tests.sh tests/test_app_runtime.py`
- `PAGEKEEPER_DEV_WEB_PORT=4480 PAGEKEEPER_DEV_KOSYNC_PORT=5761 docker compose -f docker-compose.dev.yml up --build -d`
- `curl -fsS http://localhost:4480/healthcheck`
- `curl -fsS -I http://localhost:4480/`

## Caveat
- Full Docker suite currently reports 842 passed, 2 skipped, 2 failed in existing product tests: `tests/test_clear_progress.py::TestClearProgressMethod::test_clear_progress_success` and `tests/test_webserver.py::CleanFlaskIntegrationTest::test_dependency_injection_works`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document local test setup and add configurable dev ports
> - Expands [CONTRIBUTING.md](https://github.com/serabi/pagekeeper/pull/67/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) with prerequisites, alternate dev port configuration, optional local Python environment setup via `uv`, and split test sections covering Ruff, local pytest, Docker tests, and a dev app smoke test.
> - Adds `PAGEKEEPER_DEV_WEB_PORT` and `PAGEKEEPER_DEV_KOSYNC_PORT` env vars to [docker-compose.dev.yml](https://github.com/serabi/pagekeeper/pull/67/files#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1), defaulting to `4478` and `5759`, so host ports can be overridden when already in use.
> - Updates [docker-compose.test.yml](https://github.com/serabi/pagekeeper/pull/67/files#diff-f4824493351fb6e294d8fcc9cd83a3d4536b8b0539a0c957afc94fa18a45ab3a) to pass CLI args directly to pytest and mounts `pyproject.toml` so pytest config is visible inside the container.
> - Fixes [run-tests.sh](https://github.com/serabi/pagekeeper/pull/67/files#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228c) so supplied args replace the default `tests/` target instead of being appended to it.
> - Behavioral Change: the dev container no longer has an explicit `container_name` of `pagekeeper-dev`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf78d92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->