### PR TITLE
Fix duplicate reading state upserts

### DIFF
--- a/alembic/versions/w3x4y5z6a7b8_add_unique_state_book_client_index.py
+++ b/alembic/versions/w3x4y5z6a7b8_add_unique_state_book_client_index.py
@@ -1,0 +1,136 @@
+"""add unique index for state book/client pairs
+
+Revision ID: w3x4y5z6a7b8
+Revises: v2w3x4y5z6a7
+Create Date: 2026-06-23
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "w3x4y5z6a7b8"
+down_revision: str | Sequence[str] | None = "v2w3x4y5z6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+UNIQUE_INDEX = "uq_states_book_id_client_name"
+
+
+def _table_exists(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _index_exists(inspector: sa.Inspector, table_name: str, index_name: str) -> bool:
+    return any(index["name"] == index_name for index in inspector.get_indexes(table_name))
+
+
+def _has_columns(inspector: sa.Inspector, table_name: str, *column_names: str) -> bool:
+    existing = {column["name"] for column in inspector.get_columns(table_name)}
+    return set(column_names).issubset(existing)
+
+
+def _relax_states_book_id_nullability(bind) -> None:
+    bind.execute(sa.text("DROP TABLE IF EXISTS _states_nullable_new"))
+    bind.execute(sa.text("""
+        CREATE TABLE _states_nullable_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            abs_id VARCHAR(255) NOT NULL,
+            book_id INTEGER,
+            client_name VARCHAR(50) NOT NULL,
+            last_updated FLOAT,
+            percentage FLOAT,
+            timestamp FLOAT,
+            xpath TEXT,
+            cfi TEXT,
+            FOREIGN KEY(book_id) REFERENCES books(id) ON DELETE CASCADE
+        )
+    """))
+    bind.execute(sa.text("""
+        INSERT INTO _states_nullable_new (id, abs_id, book_id, client_name, last_updated, percentage, timestamp, xpath, cfi)
+        SELECT id, abs_id, book_id, client_name, last_updated, percentage, timestamp, xpath, cfi
+        FROM states
+    """))
+    bind.execute(sa.text("DROP TABLE states"))
+    bind.execute(sa.text("ALTER TABLE _states_nullable_new RENAME TO states"))
+    bind.execute(sa.text("CREATE INDEX IF NOT EXISTS ix_states_book_id ON states (book_id)"))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _table_exists(inspector, "states"):
+        return
+
+    if _table_exists(inspector, "books") and _has_columns(
+        inspector,
+        "states",
+        "id",
+        "abs_id",
+        "book_id",
+        "client_name",
+        "last_updated",
+        "percentage",
+        "timestamp",
+        "xpath",
+        "cfi",
+    ):
+        _relax_states_book_id_nullability(bind)
+        inspector = sa.inspect(bind)
+
+    if _table_exists(inspector, "books") and _has_columns(inspector, "states", "book_id", "abs_id"):
+        bind.execute(sa.text("""
+            UPDATE states
+            SET book_id = (
+                SELECT books.id
+                FROM books
+                WHERE books.abs_id = states.abs_id
+            )
+            WHERE book_id IS NULL
+              AND abs_id IS NOT NULL
+              AND EXISTS (
+                  SELECT 1
+                  FROM books
+                  WHERE books.abs_id = states.abs_id
+              )
+        """))
+
+    if _has_columns(inspector, "states", "book_id", "client_name", "last_updated", "id"):
+        bind.execute(sa.text("""
+            DELETE FROM states
+            WHERE book_id IS NOT NULL
+              AND EXISTS (
+                  SELECT 1
+                  FROM states AS keep
+                  WHERE keep.book_id = states.book_id
+                    AND keep.client_name = states.client_name
+                    AND (
+                        COALESCE(keep.last_updated, -1) > COALESCE(states.last_updated, -1)
+                        OR (
+                            COALESCE(keep.last_updated, -1) = COALESCE(states.last_updated, -1)
+                            AND keep.id > states.id
+                        )
+                    )
+              )
+        """))
+
+    inspector = sa.inspect(bind)
+    if _has_columns(inspector, "states", "book_id", "client_name") and not _index_exists(inspector, "states", UNIQUE_INDEX):
+        op.create_index(
+            UNIQUE_INDEX,
+            "states",
+            ["book_id", "client_name"],
+            unique=True,
+            sqlite_where=sa.text("book_id IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _table_exists(inspector, "states") and _index_exists(inspector, "states", UNIQUE_INDEX):
+        op.drop_index(UNIQUE_INDEX, table_name="states")

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -3,6 +3,7 @@
 import logging
 
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 
 from .base_repository import BaseRepository
 from .models import (
@@ -211,17 +212,94 @@ class BookRepository(BaseRepository):
         if not state.book_id and not state.abs_id:
             logger.error("save_state called without book_id or abs_id — skipping")
             return None
-        # Prefer book_id for upsert lookup; fall back to abs_id for backward compat
+
+        update_attrs = ["last_updated", "percentage", "timestamp", "xpath", "cfi", "abs_id", "book_id"]
+        with self.get_session() as session:
+            self._hydrate_state_book_reference(session, state)
+            if not state.book_id:
+                logger.warning("save_state could not resolve abs_id '%s' to a book — skipping", state.abs_id)
+                return None
+
+            lookup = self._state_lookup_filters(state)
+            existing = self._dedupe_existing_states(session, lookup)
+
+            if existing:
+                self._apply_state_attrs(existing, state, update_attrs)
+                session.flush()
+                session.refresh(existing)
+                session.expunge(existing)
+                return existing
+
+            try:
+                session.add(state)
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                self._hydrate_state_book_reference(session, state)
+                if not state.book_id:
+                    logger.warning("save_state could not resolve abs_id '%s' to a book after conflict — skipping", state.abs_id)
+                    return None
+
+                lookup = self._state_lookup_filters(state)
+                existing = self._dedupe_existing_states(session, lookup)
+                if not existing:
+                    raise
+                self._apply_state_attrs(existing, state, update_attrs)
+                session.flush()
+                session.refresh(existing)
+                session.expunge(existing)
+                return existing
+
+            session.refresh(state)
+            session.expunge(state)
+            return state
+
+    def _hydrate_state_book_reference(self, session, state):
+        """Resolve legacy abs_id-only saves to the canonical book_id."""
         if state.book_id:
-            lookup = [State.book_id == state.book_id, State.client_name == state.client_name]
-        else:
-            lookup = [State.abs_id == state.abs_id, State.client_name == state.client_name]
-        return self._upsert(
-            State,
-            lookup,
-            state,
-            ["last_updated", "percentage", "timestamp", "xpath", "cfi", "abs_id", "book_id"],
+            if not state.abs_id:
+                book = session.query(Book).filter(Book.id == state.book_id).first()
+                if book:
+                    state.abs_id = book.abs_id or ""
+            return
+
+        if state.abs_id:
+            book = session.query(Book).filter(Book.abs_id == state.abs_id).first()
+            if book:
+                state.book_id = book.id
+
+    @staticmethod
+    def _state_lookup_filters(state):
+        if state.book_id:
+            return [State.book_id == state.book_id, State.client_name == state.client_name]
+        return [State.abs_id == state.abs_id, State.client_name == state.client_name]
+
+    @staticmethod
+    def _dedupe_existing_states(session, lookup_filters):
+        matches = (
+            session.query(State)
+            .filter(*lookup_filters)
+            .order_by(func.coalesce(State.last_updated, -1).desc(), State.id.desc())
+            .all()
         )
+        if not matches:
+            return None
+
+        keeper = matches[0]
+        for duplicate in matches[1:]:
+            session.delete(duplicate)
+        return keeper
+
+    @staticmethod
+    def _apply_state_attrs(existing, incoming, update_attrs):
+        for attr in update_attrs:
+            if hasattr(incoming, attr):
+                value = getattr(incoming, attr)
+                if attr == "book_id" and value is None:
+                    continue
+                if attr == "abs_id" and not value:
+                    continue
+                setattr(existing, attr, value)
 
     def delete_states_for_book(self, book_id):
         with self.get_session() as session:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -412,10 +412,19 @@ class State(Base):
     """
 
     __tablename__ = "states"
+    __table_args__ = (
+        sa.Index(
+            "uq_states_book_id_client_name",
+            "book_id",
+            "client_name",
+            unique=True,
+            sqlite_where=sa.text("book_id IS NOT NULL"),
+        ),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     abs_id = Column(String(255), nullable=False)
-    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=True, index=True)
     client_name = Column(String(50), nullable=False)
     last_updated = Column(Float)
     percentage = Column(Float)

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -229,6 +229,142 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertIn("grimmory", state_by_client)
         self.assertEqual(state_by_client["grimmory"].cfi, "epubcfi(/6/4[chapter2]!/4/2/6/1:15)")
 
+    def test_save_state_updates_existing_book_client_pair(self):
+        """save_state updates a book/client state instead of inserting duplicates."""
+        book = self.db_service.save_book(self.Book(abs_id="state-upsert-book", title="State Upsert"))
+
+        first = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=100.0,
+                percentage=0.25,
+            )
+        )
+        second = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=200.0,
+                percentage=0.75,
+                xpath="/updated",
+            )
+        )
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(first.id, second.id)
+        self.assertEqual(states[0].percentage, 0.75)
+        self.assertEqual(states[0].xpath, "/updated")
+
+    def test_save_state_dedupes_existing_duplicate_book_client_rows(self):
+        """save_state collapses dirty pre-existing duplicates before updating."""
+        import sqlite3
+
+        book = self.db_service.save_book(self.Book(abs_id="dirty-state-book", title="Dirty State"))
+        self.db_service.db_manager.close()
+
+        conn = sqlite3.connect(self.test_db_path)
+        conn.execute("DROP INDEX IF EXISTS uq_states_book_id_client_name")
+        conn.executemany("""
+            INSERT INTO states (abs_id, book_id, client_name, last_updated, percentage)
+            VALUES (?, ?, ?, ?, ?)
+        """, [
+            (book.abs_id, book.id, "kosync", 100.0, 0.10),
+            (book.abs_id, book.id, "kosync", 200.0, 0.20),
+        ])
+        conn.commit()
+        conn.close()
+
+        self.db_service = self.DatabaseService(self.test_db_path)
+        saved = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=300.0,
+                percentage=0.90,
+            )
+        )
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(saved.id, states[0].id)
+        self.assertEqual(states[0].percentage, 0.90)
+
+    def test_save_state_retries_after_unique_conflict(self):
+        """save_state recovers when a unique conflict appears after lookup."""
+        book = self.db_service.save_book(self.Book(abs_id="state-race-book", title="State Race"))
+        existing = self.db_service.save_state(
+            self.State(
+                abs_id=book.abs_id,
+                book_id=book.id,
+                client_name="kosync",
+                last_updated=100.0,
+                percentage=0.10,
+            )
+        )
+
+        repo = self.db_service._books
+        original_dedupe = repo._dedupe_existing_states
+        calls = 0
+
+        def miss_once(session, lookup_filters):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None
+            return original_dedupe(session, lookup_filters)
+
+        repo._dedupe_existing_states = miss_once
+        try:
+            saved = self.db_service.save_state(
+                self.State(
+                    abs_id=book.abs_id,
+                    book_id=book.id,
+                    client_name="kosync",
+                    last_updated=250.0,
+                    percentage=0.65,
+                )
+            )
+        finally:
+            repo._dedupe_existing_states = original_dedupe
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertGreaterEqual(calls, 2)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(saved.id, existing.id)
+        self.assertEqual(states[0].percentage, 0.65)
+
+    def test_save_state_resolves_legacy_abs_id_only_input(self):
+        """Legacy callers that only pass abs_id still update the canonical book state."""
+        book = self.db_service.save_book(self.Book(abs_id="legacy-abs-state", title="Legacy State"))
+
+        first = self.db_service.save_state(
+            self.State(abs_id=book.abs_id, client_name="kosync", last_updated=100.0, percentage=0.10)
+        )
+        second = self.db_service.save_state(
+            self.State(abs_id=book.abs_id, client_name="kosync", last_updated=200.0, percentage=0.55)
+        )
+
+        states = self.db_service.get_states_for_book(book.id)
+        self.assertEqual(len(states), 1)
+        self.assertEqual(first.id, second.id)
+        self.assertEqual(states[0].book_id, book.id)
+        self.assertEqual(states[0].percentage, 0.55)
+
+    def test_save_state_skips_unresolvable_abs_id_only_input(self):
+        """Legacy abs_id-only saves skip cleanly when no book can be resolved."""
+        saved = self.db_service.save_state(
+            self.State(abs_id="missing-book", client_name="kosync", last_updated=100.0, percentage=0.10)
+        )
+
+        self.assertIsNone(saved)
+        matching = [state for state in self.db_service.get_all_states() if state.abs_id == "missing-book"]
+        self.assertEqual(matching, [])
+
     def test_get_books_by_status(self):
         """Test querying books by status."""
         # Create books with different statuses
@@ -855,6 +991,16 @@ class TestLegacyDatabaseMigration(unittest.TestCase):
         conn.commit()
         conn.close()
 
+    def _alembic_config(self, db_path: str):
+        from alembic.config import Config
+
+        alembic_dir = Path(__file__).parent.parent / "alembic"
+        alembic_ini = alembic_dir.parent / "alembic.ini"
+        alembic_cfg = Config(str(alembic_ini))
+        alembic_cfg.set_main_option("script_location", str(alembic_dir))
+        alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+        return alembic_cfg
+
     def test_legacy_db_does_not_crash_on_startup(self):
         """
         Scenario: legacy database with 'books' but no 'alembic_version'.
@@ -1074,6 +1220,58 @@ class TestLegacyDatabaseMigration(unittest.TestCase):
             self.assertIsNotNone(state, "Test state was lost during migration")
             self.assertIsNotNone(state[0], "states.book_id was not populated")
 
+            conn.close()
+
+    def test_state_uniqueness_migration_dedupes_before_index(self):
+        """Duplicate states from the previous head are collapsed before adding uniqueness."""
+        import sqlite3
+
+        from alembic import command
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "state_dedupe.db")
+            alembic_cfg = self._alembic_config(db_path)
+
+            command.upgrade(alembic_cfg, "v2w3x4y5z6a7")
+
+            conn = sqlite3.connect(db_path)
+            cursor = conn.execute("""
+                INSERT INTO books (abs_id, title, status)
+                VALUES ('dedupe-book', 'Dedupe Book', 'active')
+            """)
+            book_id = cursor.lastrowid
+            conn.executescript(f"""
+                INSERT INTO states (abs_id, book_id, client_name, last_updated, percentage)
+                VALUES
+                    ('dedupe-book', {book_id}, 'kosync', 100.0, 0.10),
+                    ('dedupe-book', {book_id}, 'kosync', 300.0, 0.30),
+                    ('dedupe-book', {book_id}, 'kosync', 200.0, 0.20),
+                    ('dedupe-book', {book_id}, 'abs', 50.0, 0.05);
+            """)
+            conn.commit()
+            conn.close()
+
+            command.upgrade(alembic_cfg, "head")
+
+            conn = sqlite3.connect(db_path)
+            rows = conn.execute("""
+                SELECT client_name, percentage
+                FROM states
+                WHERE book_id = ?
+                ORDER BY client_name
+            """, (book_id,)).fetchall()
+            index_names = {row[1] for row in conn.execute("PRAGMA index_list(states)").fetchall()}
+            state_columns = {row[1]: row for row in conn.execute("PRAGMA table_info(states)").fetchall()}
+            self.assertIn("uq_states_book_id_client_name", index_names)
+            self.assertEqual(state_columns["book_id"][3], 0)
+            self.assertEqual(rows, [("abs", 0.05), ("kosync", 0.30)])
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("""
+                    INSERT INTO states (abs_id, book_id, client_name, percentage)
+                    VALUES ('dedupe-book', ?, 'kosync', 0.99)
+                """, (book_id,))
+                conn.commit()
             conn.close()
 
     def test_fresh_db_still_initializes_correctly(self):


### PR DESCRIPTION
## Summary
- Add a SQLite migration that relaxes `states.book_id`, backfills legacy rows, dedupes duplicate `(book_id, client_name)` states, and adds a partial unique index.
- Make `save_state` deterministic: resolve legacy `abs_id` inputs, collapse dirty duplicates, and retry cleanly on unique conflicts.
- Add regression coverage for migration dedupe, update-in-place behavior, legacy fallback, unresolvable legacy input, and conflict retry.

## Tests
- `python3 -m compileall src/db/book_repository.py src/db/models.py alembic/versions/w3x4y5z6a7b8_add_unique_state_book_client_index.py tests/test_database_service_integration.py`
- `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uvx ruff check src/db/book_repository.py src/db/models.py alembic/versions/w3x4y5z6a7b8_add_unique_state_book_client_index.py tests/test_database_service_integration.py`
- `git diff --check`
- `docker compose -f docker-compose.test.yml run --build --rm --entrypoint sh test -lc 'pip install -q pytest && python -m pytest tests/test_database_service_integration.py -k "state or legacy or intermediate or fresh"'`
- `docker compose -f docker-compose.test.yml run --rm --entrypoint sh test -lc 'pip install -q pytest && python -m pytest tests/test_kosync_progress_service.py tests/test_kosync_service.py tests/test_sync_concurrency.py'`

## Risk
- Migration rebuilds the SQLite `states` table to dedupe data and add the partial unique index.
- Covered by a base-to-head migration test with duplicate state rows.