### PR TITLE
chore: add PR size labeling workflow

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,341 @@
+name: PR Size
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  push:
+    branches: [main, dev]
+    paths:
+      - .github/workflows/pr-size.yml
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-config:
+    name: Prepare PR size config
+    runs-on: ubuntu-latest
+    outputs:
+      labels_json: ${{ steps.config.outputs.labels_json }}
+    steps:
+      - id: config
+        name: Build PR size label config
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            const managedLabels = [
+              {
+                name: "size:XS",
+                color: "0e8a16",
+                description: "0-9 effective changed lines (test files excluded in mixed PRs).",
+              },
+              {
+                name: "size:S",
+                color: "5ebd3e",
+                description: "10-29 effective changed lines (test files excluded in mixed PRs).",
+              },
+              {
+                name: "size:M",
+                color: "fbca04",
+                description: "30-99 effective changed lines (test files excluded in mixed PRs).",
+              },
+              {
+                name: "size:L",
+                color: "fe7d37",
+                description: "100-499 effective changed lines (test files excluded in mixed PRs).",
+              },
+              {
+                name: "size:XL",
+                color: "d93f0b",
+                description: "500-999 effective changed lines (test files excluded in mixed PRs).",
+              },
+              {
+                name: "size:XXL",
+                color: "b60205",
+                description: "1,000+ effective changed lines (test files excluded in mixed PRs).",
+              },
+            ];
+
+            core.setOutput("labels_json", JSON.stringify(managedLabels));
+  sync-label-definitions:
+    name: Sync PR size label definitions
+    needs: prepare-config
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Ensure PR size labels exist
+        uses: actions/github-script@v8
+        env:
+          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
+        with:
+          script: |
+            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
+
+            for (const label of managedLabels) {
+              try {
+                const { data: existing } = await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+
+                if (
+                  existing.color !== label.color ||
+                  (existing.description ?? "") !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                }
+              }
+            }
+  label:
+    name: Label PR size
+    needs: prepare-config
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: pr-size-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Sync PR size label
+        uses: actions/github-script@v8
+        env:
+          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
+        with:
+          script: |
+            const { execFileSync } = require("node:child_process");
+
+            const issueNumber = context.payload.pull_request.number;
+            const baseSha = context.payload.pull_request.base.sha;
+            const headSha = context.payload.pull_request.head.sha;
+            const headTrackingRef = `refs/remotes/pr-size/${issueNumber}`;
+            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
+            const managedLabelNames = new Set(managedLabels.map((label) => label.name));
+            const managedLabelByName = new Map(
+              managedLabels.map((label) => [label.name, label]),
+            );
+            // Keep this aligned with the repo's test entrypoints and test-only support files.
+            const testExcludePathspecs = [
+              ":(glob,exclude)tests/**",
+              ":(glob,exclude)**/test_*.py",
+              ":(glob,exclude)**/*_test.py",
+              ":(glob,exclude)**/conftest.py",
+              ":(glob,exclude)docker-compose.test.yml",
+            ];
+
+            const sumNumstat = (text) =>
+              text
+                .split("\n")
+                .filter(Boolean)
+                .reduce((total, line) => {
+                  const [insertionsRaw = "0", deletionsRaw = "0"] = line.split("\t");
+                  const additions =
+                    insertionsRaw === "-" ? 0 : Number.parseInt(insertionsRaw, 10) || 0;
+                  const deletions =
+                    deletionsRaw === "-" ? 0 : Number.parseInt(deletionsRaw, 10) || 0;
+
+                  return total + additions + deletions;
+                }, 0);
+
+            const resolveSizeLabel = (totalChangedLines) => {
+              if (totalChangedLines < 10) {
+                return "size:XS";
+              }
+
+              if (totalChangedLines < 30) {
+                return "size:S";
+              }
+
+              if (totalChangedLines < 100) {
+                return "size:M";
+              }
+
+              if (totalChangedLines < 500) {
+                return "size:L";
+              }
+
+              if (totalChangedLines < 1000) {
+                return "size:XL";
+              }
+
+              return "size:XXL";
+            };
+
+            execFileSync("git", ["fetch", "--no-tags", "origin", baseSha], {
+              stdio: "inherit",
+            });
+
+            execFileSync(
+              "git",
+              ["fetch", "--no-tags", "origin", `+refs/pull/${issueNumber}/head:${headTrackingRef}`],
+              {
+                stdio: "inherit",
+              },
+            );
+
+            const resolvedHeadSha = execFileSync("git", ["rev-parse", headTrackingRef], {
+              encoding: "utf8",
+            }).trim();
+
+            if (resolvedHeadSha !== headSha) {
+              core.warning(
+                `Fetched head SHA ${resolvedHeadSha} does not match pull request head SHA ${headSha}; using fetched ref for sizing.`,
+              );
+            }
+
+            execFileSync("git", ["cat-file", "-e", `${baseSha}^{commit}`], {
+              stdio: "inherit",
+            });
+
+            const diffArgs = [
+              "diff",
+              "--numstat",
+              "--ignore-all-space",
+              "--ignore-blank-lines",
+              `${baseSha}...${resolvedHeadSha}`,
+            ];
+
+            const totalChangedLines = sumNumstat(
+              execFileSync(
+                "git",
+                diffArgs,
+                { encoding: "utf8" },
+              ),
+            );
+            const nonTestChangedLines = sumNumstat(
+              execFileSync("git", [...diffArgs, "--", ".", ...testExcludePathspecs], {
+                encoding: "utf8",
+              }),
+            );
+            const testChangedLines = Math.max(0, totalChangedLines - nonTestChangedLines);
+
+            const changedLines = nonTestChangedLines === 0 ? testChangedLines : nonTestChangedLines;
+            const nextLabelName = resolveSizeLabel(changedLines);
+
+            // Ensure the label we are about to apply exists with the managed
+            // color/description before adding it. This keeps PR labeling correct
+            // even if the sync-label-definitions job has not run yet.
+            const nextLabel = managedLabelByName.get(nextLabelName);
+            if (nextLabel) {
+              try {
+                const { data: existing } = await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: nextLabel.name,
+                });
+
+                if (
+                  existing.color !== nextLabel.color ||
+                  (existing.description ?? "") !== nextLabel.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: nextLabel.name,
+                    color: nextLabel.color,
+                    description: nextLabel.description,
+                  });
+                }
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: nextLabel.name,
+                    color: nextLabel.color,
+                    description: nextLabel.description,
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                }
+              }
+            }
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            for (const label of currentLabels) {
+              if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name,
+                });
+              } catch (removeError) {
+                if (removeError.status !== 404) {
+                  throw removeError;
+                }
+              }
+            }
+
+            if (!currentLabels.some((label) => label.name === nextLabelName)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [nextLabelName],
+              });
+            }
+
+            const classification =
+              nonTestChangedLines === 0
+                ? testChangedLines > 0
+                  ? "test-only PR"
+                  : "no line changes"
+                : testChangedLines > 0
+                  ? "test lines excluded"
+                  : "all non-test changes";
+
+            core.info(
+              `PR #${issueNumber}: ${nonTestChangedLines} non-test lines, ${testChangedLines} test lines, ${changedLines} effective lines -> ${nextLabelName} (${classification})`,
+            );


### PR DESCRIPTION
## Summary

Adds an automated PR size labeling workflow, borrowed from [the t3code setup](https://github.com/pingdotgg/t3code) and adapted for this repo's Python layout.

On every PR event, it computes effective changed lines via `git diff --numstat` (whitespace/blank lines ignored) and applies one of six labels, swapping out any stale size label:

| Label | Effective lines |
|-------|-----------------|
| `size:XS` | 0–9 |
| `size:S` | 10–29 |
| `size:M` | 30–99 |
| `size:L` | 100–499 |
| `size:XL` | 500–999 |
| `size:XXL` | 1,000+ |

Test files are excluded from the count in mixed PRs; a test-only PR falls back to counting just the test lines, so it is never `size:XS` purely from exclusion.

## Adaptations to Initial Setup 

- **Test pathspecs → Python.** Swapped the JS/monorepo excludes for this repo's layout: `tests/**`, `**/test_*.py`, `**/*_test.py`, `**/conftest.py`, `docker-compose.test.yml`.
- **`runs-on`** set to `ubuntu-latest` to match the existing `lint.yml` / `publish.yml`.
- **Label definitions always sync.** Added a `push` trigger (scoped to this workflow file) so the definition-sync job actually runs, plus an inline label upsert in the labeling job so each label is created with its proper color/description before being applied. 

## Validation

- YAML parses cleanly.
- All three embedded `github-script` blocks pass `node --check`.
- Size-bucket boundaries unit-tested (all 12 boundary cases pass).
- No shell injection surface: untrusted values flow through `github-script` JS vars and `execFileSync` (no shell interpolation); the PR number is always an integer from the event payload.