### PR TITLE
chore(ci): bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -129,7 +129,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Sync PR size label

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -33,11 +33,11 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What

Bumps the Node-based GitHub Actions in our workflows to their latest major versions, all of which ship a Node 24 runtime.

**publish.yml** (the six actions flagged in the v0.1.11 release run's deprecation annotation):
- actions/checkout v4 -> v7
- docker/login-action v3 -> v4
- docker/metadata-action v5 -> v6
- docker/setup-qemu-action v3 -> v4
- docker/setup-buildx-action v3 -> v4
- docker/build-push-action v6 -> v7

**pr-size.yml** (for consistency):
- actions/checkout v4 -> v7

## Why

GitHub is deprecating the Node 20 runtime on Actions runners. The flagged actions targeted Node 20 and were being force-run on Node 24 with a warning. Bumping to majors that natively target Node 24 clears the warning before the forced fallback is withdrawn.

## Not changed

- `lint.yml` ruff-action: Docker-based action, no Node runtime, unaffected.
- `pr-size.yml` github-script@v8: already runs on Node 24.

## Verification note

The publish workflow only triggers on a published release, so this PR's CI (lint + pr-size) does not exercise it. The docker action major bumps will be validated on the next release cut. Lint and PR-size run here and should pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump GitHub Actions to Node 24-compatible major versions
> Updates action versions across CI workflows to use Node 24-based runtimes. `actions/checkout` moves from v4 to v7 in both [pr-size.yml](.github/workflows/pr-size.yml) and [publish.yml](.github/workflows/publish.yml), and all Docker-related actions in the publish workflow are bumped one major version each (`login-action` v4, `metadata-action` v6, `setup-qemu-action` v4, `setup-buildx-action` v4, `build-push-action` v7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5462137.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->