### PR TITLE
fix(grimmory): reload book cache on settings save

### DIFF
--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -37,10 +37,23 @@ class GrimmoryClient:
             self._load_cache()
 
     def reload_from_env(self):
-        """Re-read configuration from os.environ so settings changes take effect without restart."""
+        """Re-read configuration from os.environ so settings changes take effect without restart.
+
+        Config (base_url/username/password/etc.) is read lazily via properties, but the
+        book cache is only populated in __init__ when the client starts configured. A client
+        constructed while unconfigured therefore never loads its cache, and a later Settings
+        save must re-run the cache load so the singleton becomes usable without a restart.
+        """
         self._token = None
         self._token_timestamp = 0
         self.session.headers.clear()
+
+        if self.is_configured():
+            self._load_cache()
+        else:
+            self._book_cache = {}
+            self._book_id_cache = {}
+            self._cache_timestamp = 0
 
     @property
     def base_url(self) -> str:

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -286,3 +286,85 @@ def test_fetch_bulk_state():
     assert "book1.epub" in bulk
     assert "book2.pdf" in bulk
     assert bulk["book1.epub"]["id"] == 1
+
+
+def _make_db_book(book_id, filename, title, authors):
+    book = MagicMock()
+    book.filename = filename
+    book.title = title
+    book.authors = authors
+    book.raw_metadata_dict = {"id": book_id, "fileName": filename, "title": title, "authors": authors}
+    return book
+
+
+def test_reload_from_env_loads_cache_when_started_unconfigured(mock_db):
+    """A client constructed while unconfigured becomes configured and loads its
+    cache after a Settings save calls reload_from_env (issues #62/#76)."""
+    mock_db.get_all_grimmory_books.return_value = [_make_db_book("123", "late_book.epub", "Late Book", "Author")]
+
+    # Start unconfigured: __init__ must not load the cache.
+    with patch.dict(os.environ, {"DATA_DIR": "/tmp/nonexistent-grimmory-data"}, clear=True):
+        client = GrimmoryClient(database_service=mock_db)
+        assert client._book_cache == {}
+
+        # Settings save populates env + DB, then reloads the singleton.
+        os.environ.update(
+            {"GRIMMORY_SERVER": "http://mock", "GRIMMORY_USER": "u", "GRIMMORY_PASSWORD": "p"}
+        )
+        client.reload_from_env()
+
+        assert client.is_configured()
+        assert "late_book.epub" in client._book_cache
+        assert client._book_id_cache["123"]["title"] == "Late Book"
+
+
+def test_reload_from_env_clears_token_and_headers(mock_db):
+    """reload_from_env invalidates any cached auth token and session headers."""
+    mock_db.get_all_grimmory_books.return_value = []
+
+    with patch.dict(
+        os.environ,
+        {
+            "GRIMMORY_SERVER": "http://mock",
+            "GRIMMORY_USER": "u",
+            "GRIMMORY_PASSWORD": "p",
+            "DATA_DIR": "/tmp/nonexistent-grimmory-data",
+        },
+        clear=True,
+    ):
+        client = GrimmoryClient(database_service=mock_db)
+        client._token = "stale-token"
+        client._token_timestamp = 12345
+        client.session.headers["Authorization"] = "Bearer stale-token"
+
+        client.reload_from_env()
+
+        assert client._token is None
+        assert client._token_timestamp == 0
+        assert "Authorization" not in client.session.headers
+
+
+def test_reload_from_env_clears_cache_when_unconfigured(mock_db):
+    """A client that loses its configuration drops its cache on reload."""
+    mock_db.get_all_grimmory_books.return_value = [_make_db_book("123", "book.epub", "Book", "Author")]
+
+    with patch.dict(
+        os.environ,
+        {
+            "GRIMMORY_SERVER": "http://mock",
+            "GRIMMORY_USER": "u",
+            "GRIMMORY_PASSWORD": "p",
+            "DATA_DIR": "/tmp/nonexistent-grimmory-data",
+        },
+        clear=True,
+    ):
+        client = GrimmoryClient(database_service=mock_db)
+        assert "book.epub" in client._book_cache
+
+        # Configuration removed via Settings save.
+        del os.environ["GRIMMORY_SERVER"]
+        client.reload_from_env()
+
+        assert not client.is_configured()
+        assert client._book_cache == {}
+        assert client._book_id_cache == {}


### PR DESCRIPTION
## Root cause

`GrimmoryClient.reload_from_env()` only cleared the auth token and session headers. The book cache is populated **only** in `__init__`, and only when the client starts configured. Because the DI container holds each `GrimmoryClient` as a `providers.Singleton`, a client constructed while unconfigured (config missing or arriving late at startup) never loaded its cache.

A later Settings save called `reload_from_env()` on the singletons, but since that method never re-ran the cache load, the stale singleton stayed unusable until a container restart. This is why:

- **#62**: Settings saved in the UI wrote to the SQLite `settings` table and `os.environ`, but the running singletons didn't pick up the change.
- **#76**: After a container update, a signed-in user saw "Grimmory not configured" in logs; clicking **Test** appeared to fix it because the Test path (`_test_grimmory_instance`) bypasses the singleton entirely and hits Grimmory directly with form creds.

## Fix

`reload_from_env()` now fully re-syncs to current configuration:

- still clears the cached token and session headers, and
- re-evaluates `is_configured()` and re-runs `_load_cache()` so a client that started unconfigured becomes usable after a Settings save without a restart; it drops the cache when configuration is removed.

`_reload_integration_clients()` already reaches both Grimmory singletons (`grimmory_client` and `grimmory_client_2`), so no DI changes were needed. `ABSClient`/`KoSyncClient` were left untouched since they read config via dynamic properties and their `reload_from_env()` was already sufficient.

## Test coverage

Added three tests to `tests/test_grimmory_client.py` (TDD):

- `test_reload_from_env_loads_cache_when_started_unconfigured` — reproduces the bug: a client built while unconfigured loads its cache after env/DB update + `reload_from_env()`.
- `test_reload_from_env_clears_token_and_headers` — token/header invalidation preserved.
- `test_reload_from_env_clears_cache_when_unconfigured` — losing config drops the cache.

Grimmory and settings suites pass (`test_grimmory_client.py`, `test_grimmory_unittest.py`, `test_settings_comprehensive.py`). No ABS/KoSync reload regressions.

Closes #76
Closes #62

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reload book cache on settings save in `GrimmoryClient.reload_from_env`
> - `reload_from_env` now calls `_load_cache()` after clearing auth state when the client is configured, and clears `_book_cache`, `_book_id_cache`, and `_cache_timestamp` when it is not configured.
> - Three new tests in [test_grimmory_client.py](https://github.com/serabi/pagekeeper/pull/78/files#diff-fccf783b2fdaf43eef4909404eeccf5ee813085531a07a85c543d51733b42d23) cover cache loading on late configuration, token/header invalidation, and cache clearing on deconfiguration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef26433.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->