### PR TITLE
feat(security): encrypt API secrets at rest in settings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ docker compose up -d
 
 4. Open the dashboard at `http://localhost:4477` and configure your integrations in **Settings**.
 
+### Securing API secrets at rest
+
+PageKeeper encrypts API keys, tokens, and passwords (e.g. `HARDCOVER_TOKEN`,
+`BOOKFUSION_API_KEY`, `KOSYNC_KEY`) before storing them in the SQLite database.
+Encryption uses Fernet with a key derived from a master secret that is **never
+written to the database**.
+
+The master secret is discovered in this order:
+
+1. `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY` — the recommended, dedicated secret.
+2. The persistent Flask secret (`FLASK_SECRET_KEY`, or the auto-generated
+   `/data/.flask_secret_key` file) as a fallback.
+
+To set a dedicated key, generate a strong value and pass it as an environment
+variable:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+```yaml
+environment:
+  - PAGEKEEPER_SETTINGS_ENCRYPTION_KEY=your-generated-secret
+```
+
+Existing plaintext secrets are migrated to encrypted form automatically on the
+next startup — no manual steps are needed, and the migration is idempotent.
+
+**Key loss is unrecoverable.** If you lose the master secret, encrypted secrets
+cannot be decrypted and must be re-entered in **Settings**. Back the key up
+alongside your `data/` directory.
+
+**Key rotation:** to rotate the master secret, move the old value to
+`PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS` and set the new value in
+`PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`. PageKeeper keeps decrypting with the
+previous key while re-encrypting writes under the new key. Remove the previous
+key once all secrets have been re-saved.
+
 ### Updating
 
 ```bash

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -15,6 +15,13 @@ services:
       - TZ=America/New_York
       # - LOG_LEVEL=INFO
       # - KOSYNC_PORT=5758 # Enable Split-Port Mode (Safe for Internet Exposure)
+      # Encrypts API secrets at rest in the database. Generate with:
+      #   python -c "import secrets; print(secrets.token_urlsafe(32))"
+      # Losing this key makes stored secrets unrecoverable (re-enter them in Settings).
+      # If unset, the persistent Flask secret in /data is used as a fallback.
+      # - PAGEKEEPER_SETTINGS_ENCRYPTION_KEY=replace-with-a-strong-random-secret
+      # For key rotation, keep the old value here while setting a new key above:
+      # - PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS=previous-secret
 
     volumes:
       # === REQUIRED ===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "nh3==0.3.1",
     "lxml==5.4.0",
     "defusedxml==0.7.1",
+    "cryptography==46.0.3",
     "dependency-injector==4.48.3",
     "sqlalchemy==2.0.48",
     "alembic==1.18.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "nh3==0.3.1",
     "lxml==5.4.0",
     "defusedxml==0.7.1",
-    "cryptography==46.0.3",
+    "cryptography==48.0.1",
     "dependency-injector==4.48.3",
     "sqlalchemy==2.0.48",
     "alembic==1.18.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ flask==3.1.3
 nh3==0.3.1
 lxml==5.4.0
 defusedxml==0.7.1
-cryptography==46.0.3
+cryptography==48.0.1
 dependency-injector==4.48.3
 sqlalchemy==2.0.48
 alembic==1.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ flask==3.1.3
 nh3==0.3.1
 lxml==5.4.0
 defusedxml==0.7.1
+cryptography==46.0.3
 dependency-injector==4.48.3
 sqlalchemy==2.0.48
 alembic==1.18.4

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -187,8 +187,23 @@ def start_sync_daemon_thread(sync_manager, sync_period_mins):
     return thread
 
 
-def get_or_create_secret_key() -> str:
-    """Return a persistent random secret key, falling back to ephemeral."""
+class EphemeralSecretKeyError(RuntimeError):
+    """Raised when a persistent secret key is required but cannot be persisted."""
+
+
+def get_or_create_secret_key(persist_only: bool = False) -> str:
+    """Return a persistent random secret key.
+
+    On read/write failure (missing or read-only ``DATA_DIR``) the default
+    behaviour falls back to a fresh ephemeral key — acceptable for the
+    Flask session secret, which only invalidates sessions on restart.
+
+    When *persist_only* is True the function raises
+    :class:`EphemeralSecretKeyError` instead of returning a non-persistent
+    key. Callers that use this value to encrypt data at rest must set this,
+    so they never derive an encryption key that vanishes on restart and
+    strands previously encrypted data.
+    """
     data_dir = Path(get_str("DATA_DIR", "/data"))
     key_file = data_dir / ".flask_secret_key"
     try:
@@ -201,7 +216,11 @@ def get_or_create_secret_key() -> str:
         key_file.write_text(key)
         key_file.chmod(0o600)
         return key
-    except Exception:
+    except Exception as exc:
+        if persist_only:
+            raise EphemeralSecretKeyError(
+                f"Could not persist a secret key under {data_dir} ({exc})."
+            ) from exc
         logger.warning("Could not persist Flask secret key — using ephemeral key")
         return secrets.token_hex(32)
 
@@ -217,6 +236,13 @@ def get_settings_master_secret() -> str:
        ``/data/.flask_secret_key`` file via :func:`get_or_create_secret_key`).
 
     The master secret is never written to the database.
+
+    Unlike the Flask session secret, this value encrypts data at rest, so
+    an ephemeral key is never acceptable: encrypting with a key that is
+    regenerated on the next restart would permanently strand stored
+    secrets. When falling back to :func:`get_or_create_secret_key` the
+    key must be persistable; if it cannot be, this raises
+    :class:`EphemeralSecretKeyError`.
     """
     explicit = get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "").strip()
     if explicit:
@@ -224,7 +250,17 @@ def get_settings_master_secret() -> str:
     flask_secret = get_str("FLASK_SECRET_KEY", "").strip()
     if flask_secret:
         return flask_secret
-    return get_or_create_secret_key()
+    try:
+        return get_or_create_secret_key(persist_only=True)
+    except EphemeralSecretKeyError as exc:
+        raise EphemeralSecretKeyError(
+            "Cannot derive a stable settings-encryption key: no "
+            "PAGEKEEPER_SETTINGS_ENCRYPTION_KEY or FLASK_SECRET_KEY is set "
+            "and the data directory is not writable. Set "
+            "PAGEKEEPER_SETTINGS_ENCRYPTION_KEY (recommended) or "
+            "FLASK_SECRET_KEY, or make DATA_DIR writable, before storing "
+            "secrets. " + str(exc)
+        ) from exc
 
 
 def get_settings_previous_secret() -> str:

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -221,6 +221,9 @@ def get_settings_master_secret() -> str:
     explicit = get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "").strip()
     if explicit:
         return explicit
+    flask_secret = get_str("FLASK_SECRET_KEY", "").strip()
+    if flask_secret:
+        return flask_secret
     return get_or_create_secret_key()
 
 

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -206,6 +206,29 @@ def get_or_create_secret_key() -> str:
         return secrets.token_hex(32)
 
 
+def get_settings_master_secret() -> str:
+    """Return the master secret used to derive the settings-encryption key.
+
+    Discovery order:
+
+    1. ``PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`` env var (preferred — keep
+       this separate from the Flask session secret).
+    2. The persistent Flask secret key (env ``FLASK_SECRET_KEY`` or the
+       ``/data/.flask_secret_key`` file via :func:`get_or_create_secret_key`).
+
+    The master secret is never written to the database.
+    """
+    explicit = get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "").strip()
+    if explicit:
+        return explicit
+    return get_or_create_secret_key()
+
+
+def get_settings_previous_secret() -> str:
+    """Return the optional previous master secret used for key rotation."""
+    return get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", "").strip()
+
+
 def log_security_warnings():
     """Log warnings for common security misconfigurations at startup."""
     kosync_user = get_str("KOSYNC_USER", "")

--- a/src/app_setup.py
+++ b/src/app_setup.py
@@ -51,6 +51,7 @@ def setup_dependencies(app, test_container=None, logging_reconfigure=None):
 
     if database_service:
         ConfigLoader.bootstrap_config(database_service)
+        ConfigLoader.migrate_secrets_encryption(database_service)
         ConfigLoader.load_settings(database_service)
         logger.info("Settings loaded into environment variables")
         _migrate_abs_library_ids(database_service)

--- a/src/blueprints/settings_bp.py
+++ b/src/blueprints/settings_bp.py
@@ -9,6 +9,7 @@ from flask import Blueprint, current_app, jsonify, redirect, render_template, re
 from src.blueprints.helpers import get_container, get_database_service
 from src.utils.config_loader import load_settings
 from src.utils.logging_utils import sanitize_log_data
+from src.utils.secret_settings import SECRET_SETTING_KEYS
 from src.version import APP_VERSION, get_update_status
 
 logger = logging.getLogger(__name__)
@@ -41,22 +42,6 @@ URL_SETTING_KEYS = {
     "HARDCOVER_WEB_URL_EXTERNAL",
     "KOSYNC_PUBLIC_URL",
 }
-
-SECRET_SETTING_KEYS = {
-    "ABS_KEY",
-    "STORYTELLER_PASSWORD",
-    "GRIMMORY_PASSWORD",
-    "GRIMMORY_2_PASSWORD",
-    "CWA_PASSWORD",
-    "KOSYNC_KEY",
-    "KOSYNC_SERVER_KEY",
-    "TELEGRAM_BOT_TOKEN",
-    "HARDCOVER_TOKEN",
-    "DEEPGRAM_API_KEY",
-    "BOOKFUSION_API_KEY",
-    "BOOKFUSION_UPLOAD_API_KEY",
-}
-
 
 def _is_secret_request_authorized() -> bool:
     """Authorize secret reveal requests via admin session or service token."""

--- a/src/db/settings_repository.py
+++ b/src/db/settings_repository.py
@@ -2,9 +2,16 @@
 
 All values are stored and returned as strings (or None).
 Callers are responsible for type conversion.
+
+Secret settings (see ``SECRET_SETTING_KEYS``) are encrypted at rest:
+encrypted on save and decrypted on read. Non-secret settings are stored
+and returned verbatim.
 """
 
 from sqlalchemy.dialects.sqlite import insert
+
+from src.utils.secret_settings import is_secret_setting
+from src.utils.settings_crypto import get_settings_crypto
 
 from .base_repository import BaseRepository
 from .models import Setting
@@ -18,22 +25,39 @@ class SettingsRepository(BaseRepository):
         session.refresh(obj)
         session.expunge(obj)
 
+    @staticmethod
+    def _encrypt_for_storage(key, value):
+        """Encrypt *value* if *key* is a secret setting; else return as-is."""
+        if value is None or not is_secret_setting(key):
+            return value
+        return get_settings_crypto().encrypt_value(key, value)
+
+    @staticmethod
+    def _decrypt_from_storage(key, value):
+        """Decrypt *value* if *key* is a secret setting; else return as-is."""
+        if value is None or not is_secret_setting(key):
+            return value
+        return get_settings_crypto().decrypt_value(key, value)
+
     def get_setting(self, key, default=None):
         """Get a setting value by key. Returns a string or *default*."""
         with self.get_session() as session:
             setting = session.query(Setting).filter(Setting.key == key).first()
-            return setting.value if setting else default
+            if not setting:
+                return default
+            return self._decrypt_from_storage(key, setting.value)
 
     def set_setting(self, key, value):
         """Set a setting value. *value* is coerced to str (None stays None)."""
         with self.get_session() as session:
             str_value = str(value) if value is not None else None
+            stored_value = self._encrypt_for_storage(key, str_value)
             stmt = (
                 insert(Setting)
-                .values(key=key, value=str_value)
+                .values(key=key, value=stored_value)
                 .on_conflict_do_update(
                     index_elements=[Setting.key],
-                    set_={"value": str_value},
+                    set_={"value": stored_value},
                 )
             )
             session.execute(stmt)
@@ -45,8 +69,30 @@ class SettingsRepository(BaseRepository):
         """Get all settings as a dictionary."""
         with self.get_session() as session:
             settings = session.query(Setting).all()
-            return {s.key: s.value for s in settings}
+            return {s.key: self._decrypt_from_storage(s.key, s.value) for s in settings}
 
     def delete_setting(self, key):
         """Delete a setting by key."""
         return self._delete_one(Setting, Setting.key == key)
+
+    def encrypt_plaintext_secrets(self):
+        """Encrypt any plaintext secret values stored in the table.
+
+        Idempotent: values already in the encrypted envelope format and
+        empty/None values are skipped, so this is safe to run on every
+        startup and never double-encrypts. Returns the number of values
+        newly encrypted.
+        """
+        from src.utils.secret_settings import SECRET_SETTING_KEYS
+        from src.utils.settings_crypto import SettingsCrypto
+
+        crypto = get_settings_crypto()
+        migrated = 0
+        with self.get_session() as session:
+            rows = session.query(Setting).filter(Setting.key.in_(SECRET_SETTING_KEYS)).all()
+            for row in rows:
+                if not row.value or SettingsCrypto.is_encrypted(row.value):
+                    continue
+                row.value = crypto.encrypt_value(row.key, row.value)
+                migrated += 1
+        return migrated

--- a/src/db/settings_repository.py
+++ b/src/db/settings_repository.py
@@ -8,13 +8,17 @@ encrypted on save and decrypted on read. Non-secret settings are stored
 and returned verbatim.
 """
 
+import logging
+
 from sqlalchemy.dialects.sqlite import insert
 
 from src.utils.secret_settings import is_secret_setting
-from src.utils.settings_crypto import get_settings_crypto
+from src.utils.settings_crypto import SettingsCryptoError, get_settings_crypto
 
 from .base_repository import BaseRepository
 from .models import Setting
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsRepository(BaseRepository):
@@ -66,10 +70,22 @@ class SettingsRepository(BaseRepository):
             return setting
 
     def get_all_settings(self):
-        """Get all settings as a dictionary."""
+        """Get all settings as a dictionary.
+
+        Decryption is isolated per row: a single corrupt secret or wrong
+        encryption key fails closed for that key only (it is logged and
+        omitted) instead of aborting the whole read, so the remaining
+        secret and non-secret settings still load.
+        """
         with self.get_session() as session:
             settings = session.query(Setting).all()
-            return {s.key: self._decrypt_from_storage(s.key, s.value) for s in settings}
+            result = {}
+            for s in settings:
+                try:
+                    result[s.key] = self._decrypt_from_storage(s.key, s.value)
+                except SettingsCryptoError as e:
+                    logger.error("Skipping secret setting '%s': %s", s.key, e)
+            return result
 
     def delete_setting(self, key):
         """Delete a setting by key."""

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -222,6 +222,23 @@ class ConfigLoader:
             logger.error(f"Error bootstrapping config: {e}")
 
     @staticmethod
+    def migrate_secrets_encryption(db_service: DatabaseService):
+        """Encrypt any plaintext secret settings at rest.
+
+        Runs before ``load_settings`` so env sync always works on
+        decrypted values. Idempotent and non-breaking: already-encrypted
+        and empty secrets are left untouched, so existing installs and
+        fresh installs both converge to encrypted-at-rest storage without
+        manual steps.
+        """
+        try:
+            migrated = db_service.encrypt_plaintext_secrets()
+            if migrated:
+                logger.info("Encrypted %d plaintext secret setting(s) at rest", migrated)
+        except Exception as e:
+            logger.error("Error encrypting plaintext secrets: %s", e)
+
+    @staticmethod
     def load_settings(db_service: DatabaseService):
         """
         Load all settings from database and update os.environ.

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import requests
 
+from src.utils.secret_settings import SECRET_SETTING_KEYS
+
 logger = logging.getLogger(__name__)
 
 
@@ -180,20 +182,8 @@ def reconcile_telegram_logging():
     return telegram_log_handler
 
 
-_SECRET_ENV_VARS = (
-    "ABS_KEY",
-    "KOSYNC_KEY",
-    "KOSYNC_SERVER_KEY",
-    "HARDCOVER_TOKEN",
-    "TELEGRAM_BOT_TOKEN",
-    "STORYTELLER_PASSWORD",
-    "GRIMMORY_PASSWORD",
-    "GRIMMORY_2_PASSWORD",
-    "CWA_PASSWORD",
-    "DEEPGRAM_API_KEY",
-    "BOOKFUSION_API_KEY",
-    "BOOKFUSION_UPLOAD_API_KEY",
-)
+# Backwards-compatible alias for the centralized secret-key list.
+_SECRET_ENV_VARS = SECRET_SETTING_KEYS
 
 
 def sanitize_exception(exc: Exception) -> str:

--- a/src/utils/secret_settings.py
+++ b/src/utils/secret_settings.py
@@ -1,0 +1,28 @@
+"""Canonical list of setting keys whose values are sensitive secrets.
+
+This is the single source of truth for which settings hold API keys,
+tokens, and passwords. Encryption at rest, log redaction, and the
+settings UI all reference this list so they never drift apart.
+"""
+
+SECRET_SETTING_KEYS = frozenset(
+    {
+        "ABS_KEY",
+        "STORYTELLER_PASSWORD",
+        "GRIMMORY_PASSWORD",
+        "GRIMMORY_2_PASSWORD",
+        "CWA_PASSWORD",
+        "KOSYNC_KEY",
+        "KOSYNC_SERVER_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "HARDCOVER_TOKEN",
+        "DEEPGRAM_API_KEY",
+        "BOOKFUSION_API_KEY",
+        "BOOKFUSION_UPLOAD_API_KEY",
+    }
+)
+
+
+def is_secret_setting(key: str) -> bool:
+    """Return True if *key* names a setting whose value is a secret."""
+    return key in SECRET_SETTING_KEYS

--- a/src/utils/settings_crypto.py
+++ b/src/utils/settings_crypto.py
@@ -1,0 +1,162 @@
+"""Encryption of sensitive settings at rest.
+
+Secrets stored in the SQLite ``settings`` table are encrypted with
+Fernet (authenticated symmetric encryption from the ``cryptography``
+library). The encryption key is derived from a master secret via
+HKDF-SHA256 and is never stored in the database.
+
+Envelope format::
+
+    pkenc:v1:fernet:<urlsafe-base64-fernet-token>
+
+The plaintext sealed inside the token binds the setting name, so a
+ciphertext copied from one setting key cannot be decrypted under a
+different key name (defends against copy-paste/confused-deputy attacks).
+
+Design guarantees:
+
+- Idempotent: already-encrypted values pass through ``encrypt_value``
+  unchanged; plaintext values pass through ``decrypt_value`` unchanged
+  so the system keeps working during the plaintext-to-encrypted
+  transition.
+- Fail closed: a wrong key, tampered ciphertext, or name mismatch
+  raises :class:`SettingsDecryptionError` rather than returning
+  corrupted or partial data.
+- Rotation: a previous key is accepted for decryption via
+  :class:`~cryptography.fernet.MultiFernet`, while new writes always use
+  the current (primary) key.
+"""
+
+import base64
+import logging
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+logger = logging.getLogger(__name__)
+
+ENVELOPE_PREFIX = "pkenc:v1:fernet:"
+
+_HKDF_INFO = b"pagekeeper-settings-encryption-v1"
+_HKDF_LENGTH = 32
+
+# Separates the bound setting name from its value inside the sealed
+# plaintext. A NUL byte cannot appear in a setting key, so the split is
+# unambiguous.
+_NAME_SEPARATOR = b"\x00"
+
+
+class SettingsCryptoError(Exception):
+    """Base class for settings-encryption errors."""
+
+
+class SettingsDecryptionError(SettingsCryptoError):
+    """Raised when a value cannot be decrypted (wrong key, tamper, mismatch)."""
+
+
+def _derive_fernet_key(master_secret: str) -> bytes:
+    """Derive a urlsafe-base64 Fernet key from *master_secret* via HKDF."""
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_HKDF_LENGTH,
+        salt=None,
+        info=_HKDF_INFO,
+    )
+    derived = hkdf.derive(master_secret.encode("utf-8"))
+    return base64.urlsafe_b64encode(derived)
+
+
+class SettingsCrypto:
+    """Encrypt and decrypt secret setting values.
+
+    *master_secret* is the primary key material. *previous_secret* is an
+    optional retired key kept available for decryption during rotation.
+    """
+
+    def __init__(self, master_secret: str, previous_secret: str | None = None):
+        if not master_secret:
+            raise SettingsCryptoError("master_secret must be a non-empty string")
+
+        primary = Fernet(_derive_fernet_key(master_secret))
+        self._primary = primary
+
+        fernets = [primary]
+        if previous_secret:
+            fernets.append(Fernet(_derive_fernet_key(previous_secret)))
+        self._multi = MultiFernet(fernets)
+
+    @staticmethod
+    def is_encrypted(value: str | None) -> bool:
+        """Return True if *value* is in the encrypted envelope format."""
+        return isinstance(value, str) and value.startswith(ENVELOPE_PREFIX)
+
+    def encrypt_value(self, name: str, value: str | None) -> str | None:
+        """Encrypt *value* for setting *name*, binding the name into the payload.
+
+        ``None`` passes through unchanged. Already-encrypted values pass
+        through unchanged so encryption is idempotent.
+        """
+        if value is None:
+            return None
+        if self.is_encrypted(value):
+            return value
+
+        payload = name.encode("utf-8") + _NAME_SEPARATOR + value.encode("utf-8")
+        token = self._primary.encrypt(payload).decode("ascii")
+        return ENVELOPE_PREFIX + token
+
+    def decrypt_value(self, name: str, value: str | None) -> str | None:
+        """Decrypt *value* for setting *name*.
+
+        ``None`` and plaintext (non-enveloped) values pass through
+        unchanged to support the migration transition. A wrong key,
+        tampered token, or name mismatch raises
+        :class:`SettingsDecryptionError`.
+        """
+        if value is None:
+            return None
+        if not self.is_encrypted(value):
+            return value
+
+        token = value[len(ENVELOPE_PREFIX) :].encode("ascii")
+        try:
+            payload = self._multi.decrypt(token)
+        except InvalidToken as exc:
+            raise SettingsDecryptionError(
+                f"Could not decrypt setting '{name}': wrong encryption key or tampered value. "
+                "Verify PAGEKEEPER_SETTINGS_ENCRYPTION_KEY (and *_PREVIOUS for rotation)."
+            ) from exc
+
+        bound_name, separator, plaintext = payload.partition(_NAME_SEPARATOR)
+        if separator != _NAME_SEPARATOR or bound_name.decode("utf-8") != name:
+            raise SettingsDecryptionError(
+                f"Decrypted setting '{name}' is bound to a different name; refusing to return it."
+            )
+        return plaintext.decode("utf-8")
+
+
+_crypto_cache: SettingsCrypto | None = None
+
+
+def get_settings_crypto() -> SettingsCrypto:
+    """Return a process-wide :class:`SettingsCrypto` built from discovered keys.
+
+    The instance is cached after first construction. Tests and key
+    rotation can call :func:`reset_settings_crypto` to force rebuilding.
+    """
+    global _crypto_cache
+    if _crypto_cache is None:
+        from src.app_runtime import get_settings_master_secret, get_settings_previous_secret
+
+        _crypto_cache = SettingsCrypto(
+            get_settings_master_secret(),
+            get_settings_previous_secret() or None,
+        )
+    return _crypto_cache
+
+
+def reset_settings_crypto() -> None:
+    """Clear the cached :class:`SettingsCrypto` (key rotation / tests)."""
+    global _crypto_cache
+    _crypto_cache = None

--- a/tests/test_settings_crypto.py
+++ b/tests/test_settings_crypto.py
@@ -1,0 +1,104 @@
+"""Tests for settings encryption: crypto primitives, key rotation, fail-closed."""
+
+import pytest
+
+from src.utils.settings_crypto import (
+    ENVELOPE_PREFIX,
+    SettingsCrypto,
+    SettingsCryptoError,
+    SettingsDecryptionError,
+)
+
+DUMMY_KEY = "dummy-master-secret-aaaaaaaaaaaaaaaaaaaa"
+OTHER_KEY = "dummy-other-secret-bbbbbbbbbbbbbbbbbbbb"
+
+
+class TestRoundTrip:
+    def test_encrypt_then_decrypt_recovers_value(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        token = crypto.encrypt_value("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        assert token.startswith(ENVELOPE_PREFIX)
+        assert "dummy-hardcover-token" not in token
+        assert crypto.decrypt_value("HARDCOVER_TOKEN", token) == "dummy-hardcover-token"
+
+    def test_none_passes_through(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        assert crypto.encrypt_value("HARDCOVER_TOKEN", None) is None
+        assert crypto.decrypt_value("HARDCOVER_TOKEN", None) is None
+
+    def test_empty_string_round_trips(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        token = crypto.encrypt_value("HARDCOVER_TOKEN", "")
+        assert crypto.decrypt_value("HARDCOVER_TOKEN", token) == ""
+
+    def test_is_encrypted_detection(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        token = crypto.encrypt_value("ABS_KEY", "dummy-abs-key")
+        assert SettingsCrypto.is_encrypted(token)
+        assert not SettingsCrypto.is_encrypted("dummy-abs-key")
+        assert not SettingsCrypto.is_encrypted(None)
+
+
+class TestIdempotence:
+    def test_encrypt_does_not_double_encrypt(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        once = crypto.encrypt_value("KOSYNC_KEY", "dummy-kosync-key")
+        twice = crypto.encrypt_value("KOSYNC_KEY", once)
+        assert once == twice
+        assert crypto.decrypt_value("KOSYNC_KEY", twice) == "dummy-kosync-key"
+
+    def test_decrypt_passes_plaintext_through(self):
+        """Plaintext (non-enveloped) values pass through during transition."""
+        crypto = SettingsCrypto(DUMMY_KEY)
+        assert crypto.decrypt_value("KOSYNC_KEY", "dummy-plaintext") == "dummy-plaintext"
+
+
+class TestFailClosed:
+    def test_wrong_key_raises(self):
+        good = SettingsCrypto(DUMMY_KEY)
+        bad = SettingsCrypto(OTHER_KEY)
+        token = good.encrypt_value("ABS_KEY", "dummy-abs-key")
+        with pytest.raises(SettingsDecryptionError):
+            bad.decrypt_value("ABS_KEY", token)
+
+    def test_tampered_token_raises(self):
+        crypto = SettingsCrypto(DUMMY_KEY)
+        token = crypto.encrypt_value("ABS_KEY", "dummy-abs-key")
+        tampered = token[:-2] + ("AA" if not token.endswith("AA") else "BB")
+        with pytest.raises(SettingsDecryptionError):
+            crypto.decrypt_value("ABS_KEY", tampered)
+
+    def test_name_binding_mismatch_rejected(self):
+        """A token encrypted for one key must not decrypt under another."""
+        crypto = SettingsCrypto(DUMMY_KEY)
+        token = crypto.encrypt_value("ABS_KEY", "dummy-abs-key")
+        with pytest.raises(SettingsDecryptionError):
+            crypto.decrypt_value("KOSYNC_KEY", token)
+
+    def test_empty_master_secret_rejected(self):
+        with pytest.raises(SettingsCryptoError):
+            SettingsCrypto("")
+
+
+class TestKeyRotation:
+    def test_previous_key_still_decrypts(self):
+        old = SettingsCrypto(OTHER_KEY)
+        token = old.encrypt_value("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        rotated = SettingsCrypto(DUMMY_KEY, previous_secret=OTHER_KEY)
+        assert rotated.decrypt_value("HARDCOVER_TOKEN", token) == "dummy-hardcover-token"
+
+    def test_new_writes_use_primary_key(self):
+        rotated = SettingsCrypto(DUMMY_KEY, previous_secret=OTHER_KEY)
+        token = rotated.encrypt_value("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        primary_only = SettingsCrypto(DUMMY_KEY)
+        assert primary_only.decrypt_value("HARDCOVER_TOKEN", token) == "dummy-hardcover-token"
+
+    def test_without_previous_old_token_fails_closed(self):
+        old = SettingsCrypto(OTHER_KEY)
+        token = old.encrypt_value("HARDCOVER_TOKEN", "dummy-hardcover-token")
+        current = SettingsCrypto(DUMMY_KEY)
+        with pytest.raises(SettingsDecryptionError):
+            current.decrypt_value("HARDCOVER_TOKEN", token)

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -10,6 +10,7 @@ import pytest
 from src.db.database_service import DatabaseService
 from src.db.models import Setting
 from src.utils.settings_crypto import (
+    ENVELOPE_PREFIX,
     SettingsCrypto,
     SettingsDecryptionError,
     reset_settings_crypto,
@@ -69,14 +70,12 @@ class TestEncryptOnSaveDecryptOnRead:
 
     def test_resave_does_not_double_encrypt(self, encryption_key, db_service):
         db_service.set_setting("KOSYNC_KEY", "dummy-kosync-key")
-        first = _raw_value(db_service, "KOSYNC_KEY")
         # Round-trip the decrypted value back through set_setting.
         db_service.set_setting("KOSYNC_KEY", db_service.get_setting("KOSYNC_KEY"))
         second = _raw_value(db_service, "KOSYNC_KEY")
-        assert SettingsCrypto.is_encrypted(second)
+        # A single envelope prefix (not nested) and the value still decrypts.
+        assert second.count(ENVELOPE_PREFIX) == 1
         assert db_service.get_setting("KOSYNC_KEY") == "dummy-kosync-key"
-        # Both ciphertexts decrypt to the same plaintext.
-        assert first != second or first == second  # ciphertext may differ; value matches
 
 
 class TestMigration:

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -1,0 +1,212 @@
+"""Tests for encrypt-on-save / decrypt-on-read in SettingsRepository and
+the startup plaintext-to-encrypted migration."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.db.database_service import DatabaseService
+from src.db.models import Setting
+from src.utils.settings_crypto import (
+    SettingsCrypto,
+    SettingsDecryptionError,
+    reset_settings_crypto,
+)
+
+DUMMY_KEY = "dummy-master-secret-aaaaaaaaaaaaaaaaaaaa"
+
+
+@pytest.fixture()
+def encryption_key(monkeypatch):
+    monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", DUMMY_KEY)
+    monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", raising=False)
+    reset_settings_crypto()
+    yield DUMMY_KEY
+    reset_settings_crypto()
+
+
+@pytest.fixture()
+def db_service():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield DatabaseService(str(Path(temp_dir) / "settings_enc.db"))
+
+
+def _raw_value(db_service, key):
+    """Read the on-disk (possibly encrypted) value, bypassing decryption."""
+    with db_service.get_session() as session:
+        row = session.query(Setting).filter(Setting.key == key).first()
+        return row.value if row else None
+
+
+class TestEncryptOnSaveDecryptOnRead:
+    def test_secret_is_encrypted_at_rest(self, encryption_key, db_service):
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        stored = _raw_value(db_service, "HARDCOVER_TOKEN")
+        assert SettingsCrypto.is_encrypted(stored)
+        assert "dummy-hardcover-token" not in stored
+
+        assert db_service.get_setting("HARDCOVER_TOKEN") == "dummy-hardcover-token"
+
+    def test_get_all_settings_decrypts_secrets(self, encryption_key, db_service):
+        db_service.set_setting("ABS_KEY", "dummy-abs-key")
+        db_service.set_setting("ABS_SERVER", "https://abs.example")
+
+        all_settings = db_service.get_all_settings()
+        assert all_settings["ABS_KEY"] == "dummy-abs-key"
+        assert all_settings["ABS_SERVER"] == "https://abs.example"
+
+    def test_non_secret_stored_plaintext(self, encryption_key, db_service):
+        db_service.set_setting("ABS_SERVER", "https://abs.example")
+        assert _raw_value(db_service, "ABS_SERVER") == "https://abs.example"
+
+    def test_none_value_not_encrypted(self, encryption_key, db_service):
+        db_service.set_setting("HARDCOVER_TOKEN", None)
+        assert _raw_value(db_service, "HARDCOVER_TOKEN") is None
+        assert db_service.get_setting("HARDCOVER_TOKEN") is None
+
+    def test_resave_does_not_double_encrypt(self, encryption_key, db_service):
+        db_service.set_setting("KOSYNC_KEY", "dummy-kosync-key")
+        first = _raw_value(db_service, "KOSYNC_KEY")
+        # Round-trip the decrypted value back through set_setting.
+        db_service.set_setting("KOSYNC_KEY", db_service.get_setting("KOSYNC_KEY"))
+        second = _raw_value(db_service, "KOSYNC_KEY")
+        assert SettingsCrypto.is_encrypted(second)
+        assert db_service.get_setting("KOSYNC_KEY") == "dummy-kosync-key"
+        # Both ciphertexts decrypt to the same plaintext.
+        assert first != second or first == second  # ciphertext may differ; value matches
+
+
+class TestMigration:
+    def _seed_plaintext(self, db_service, key, value):
+        """Write a plaintext value directly, simulating a pre-encryption DB."""
+        with db_service.get_session() as session:
+            session.add(Setting(key=key, value=value))
+
+    def test_plaintext_secret_gets_encrypted(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        migrated = db_service.encrypt_plaintext_secrets()
+
+        assert migrated == 1
+        assert SettingsCrypto.is_encrypted(_raw_value(db_service, "HARDCOVER_TOKEN"))
+        assert db_service.get_setting("HARDCOVER_TOKEN") == "dummy-hardcover-token"
+
+    def test_migration_is_idempotent(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "ABS_KEY", "dummy-abs-key")
+
+        assert db_service.encrypt_plaintext_secrets() == 1
+        first = _raw_value(db_service, "ABS_KEY")
+        assert db_service.encrypt_plaintext_secrets() == 0
+        assert _raw_value(db_service, "ABS_KEY") == first
+
+    def test_mixed_state_only_migrates_plaintext(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "ABS_KEY", "dummy-abs-key")
+        db_service.set_setting("KOSYNC_KEY", "dummy-kosync-key")  # already encrypted
+
+        migrated = db_service.encrypt_plaintext_secrets()
+
+        assert migrated == 1
+        assert db_service.get_setting("ABS_KEY") == "dummy-abs-key"
+        assert db_service.get_setting("KOSYNC_KEY") == "dummy-kosync-key"
+
+    def test_empty_secret_not_migrated(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "ABS_KEY", "")
+        assert db_service.encrypt_plaintext_secrets() == 0
+        assert not SettingsCrypto.is_encrypted(_raw_value(db_service, "ABS_KEY") or "")
+
+    def test_non_secret_not_migrated(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "ABS_SERVER", "https://abs.example")
+        assert db_service.encrypt_plaintext_secrets() == 0
+        assert _raw_value(db_service, "ABS_SERVER") == "https://abs.example"
+
+
+class TestWrongKeyFailsClosed:
+    def test_read_with_wrong_key_raises(self, encryption_key, db_service, monkeypatch):
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "dummy-wrong-secret-cccccccccccccc")
+        reset_settings_crypto()
+
+        with pytest.raises(SettingsDecryptionError):
+            db_service.get_setting("HARDCOVER_TOKEN")
+
+
+class TestKeyRotationThroughRepository:
+    def test_previous_key_decrypts_after_rotation(self, db_service, monkeypatch):
+        old_key = "dummy-old-secret-dddddddddddddddddddd"
+        new_key = "dummy-new-secret-eeeeeeeeeeeeeeeeeeee"
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", old_key)
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", raising=False)
+        reset_settings_crypto()
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", new_key)
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", old_key)
+        reset_settings_crypto()
+
+        assert db_service.get_setting("HARDCOVER_TOKEN") == "dummy-hardcover-token"
+        reset_settings_crypto()
+
+
+class TestMasterSecretDiscovery:
+    def test_explicit_env_var_preferred(self, monkeypatch):
+        from src.app_runtime import get_settings_master_secret
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "dummy-explicit-key")
+        assert get_settings_master_secret() == "dummy-explicit-key"
+
+    def test_falls_back_to_flask_secret(self, monkeypatch, tmp_path):
+        from src import app_runtime
+
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+        secret = app_runtime.get_settings_master_secret()
+        assert secret
+        # Stable across calls — persisted to the data dir.
+        assert app_runtime.get_settings_master_secret() == secret
+
+    def test_previous_secret_read_from_env(self, monkeypatch):
+        from src.app_runtime import get_settings_previous_secret
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", "dummy-prev-key")
+        assert get_settings_previous_secret() == "dummy-prev-key"
+
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", raising=False)
+        assert get_settings_previous_secret() == ""
+
+
+class TestEnvSyncAfterEncryption:
+    """The settings save/load cycle must expose decrypted secrets to env."""
+
+    def test_load_settings_syncs_decrypted_secret_to_env(self, encryption_key, db_service, monkeypatch):
+        from src.utils.config_loader import load_settings
+
+        monkeypatch.delenv("HARDCOVER_TOKEN", raising=False)
+
+        # Mimic the settings route: save then sync to os.environ.
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+        assert SettingsCrypto.is_encrypted(_raw_value(db_service, "HARDCOVER_TOKEN"))
+
+        load_settings(db_service)
+        assert os.environ["HARDCOVER_TOKEN"] == "dummy-hardcover-token"
+
+    def test_startup_migration_then_env_sync(self, encryption_key, db_service, monkeypatch):
+        from src.utils.config_loader import ConfigLoader
+
+        monkeypatch.delenv("ABS_KEY", raising=False)
+
+        # Seed a legacy plaintext secret directly.
+        with db_service.get_session() as session:
+            session.add(Setting(key="ABS_KEY", value="dummy-abs-key"))
+
+        ConfigLoader.migrate_secrets_encryption(db_service)
+        assert SettingsCrypto.is_encrypted(_raw_value(db_service, "ABS_KEY"))
+
+        ConfigLoader.load_settings(db_service)
+        assert os.environ["ABS_KEY"] == "dummy-abs-key"

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -200,6 +200,43 @@ class TestMasterSecretDiscovery:
         monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", raising=False)
         assert get_settings_previous_secret() == ""
 
+    def test_raises_when_no_key_and_data_dir_unwritable(self, monkeypatch, tmp_path):
+        """An unwritable data dir with no key env vars must fail closed.
+
+        Returning an ephemeral key here would let the startup migration
+        encrypt secrets with a key that vanishes on the next restart,
+        permanently stranding them.
+        """
+        from src.app_runtime import EphemeralSecretKeyError, get_settings_master_secret
+
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+
+        unwritable = tmp_path / "readonly"
+        unwritable.mkdir()
+        unwritable.chmod(0o500)
+        monkeypatch.setenv("DATA_DIR", str(unwritable / "data"))
+
+        try:
+            with pytest.raises(EphemeralSecretKeyError):
+                get_settings_master_secret()
+        finally:
+            unwritable.chmod(0o700)
+
+    def test_flask_session_secret_still_falls_back_to_ephemeral(self, monkeypatch, tmp_path):
+        """The Flask session secret keeps the lenient ephemeral fallback."""
+        from src.app_runtime import get_or_create_secret_key
+
+        unwritable = tmp_path / "readonly"
+        unwritable.mkdir()
+        unwritable.chmod(0o500)
+        monkeypatch.setenv("DATA_DIR", str(unwritable / "data"))
+
+        try:
+            assert get_or_create_secret_key()  # no raise: ephemeral is acceptable here
+        finally:
+            unwritable.chmod(0o700)
+
 
 class TestEnvSyncAfterEncryption:
     """The settings save/load cycle must expose decrypted secrets to env."""

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -132,6 +132,27 @@ class TestWrongKeyFailsClosed:
         with pytest.raises(SettingsDecryptionError):
             db_service.get_setting("HARDCOVER_TOKEN")
 
+    def test_get_all_isolates_undecryptable_secret(self, encryption_key, db_service, monkeypatch):
+        # An undecryptable secret must not drop the other settings.
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+        db_service.set_setting("ABS_KEY", "dummy-abs-key")
+        db_service.set_setting("ABS_SERVER", "https://abs.example")  # non-secret
+
+        # Corrupt only one secret's ciphertext, leaving the rest valid.
+        with db_service.get_session() as session:
+            row = session.query(Setting).filter(Setting.key == "HARDCOVER_TOKEN").one()
+            row.value = row.value + "tampered"
+
+        all_settings = db_service.get_all_settings()
+
+        assert "HARDCOVER_TOKEN" not in all_settings  # failed closed, omitted
+        assert all_settings["ABS_KEY"] == "dummy-abs-key"  # healthy secret still loads
+        assert all_settings["ABS_SERVER"] == "https://abs.example"  # non-secret unaffected
+
+        # Targeted reads still fail closed for the bad key.
+        with pytest.raises(SettingsDecryptionError):
+            db_service.get_setting("HARDCOVER_TOKEN")
+
 
 class TestKeyRotationThroughRepository:
     def test_previous_key_decrypts_after_rotation(self, db_service, monkeypatch):


### PR DESCRIPTION
## What & why

All API secrets (`HARDCOVER_TOKEN`, `BOOKFUSION_API_KEY`, `KOSYNC_KEY`,
etc.) were stored as plaintext in the SQLite `settings` table — anyone
with file/volume/backup access to the DB got every key. This PR encrypts
those secrets at rest with Fernet, transparently to all callers.

## Key management

- **Master secret discovery:** `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`
  (recommended, dedicated) → fallback to the persistent Flask secret
  (`FLASK_SECRET_KEY` / `/data/.flask_secret_key`).
- The key is **derived via HKDF-SHA256** into a 32-byte Fernet key and is
  **never stored in the database**.
- **Envelope format:** `pkenc:v1:fernet:<token>`. The sealed plaintext
  binds the setting name, so a ciphertext cannot be decrypted under a
  different key name (defends against copy-paste/confused-deputy).
- **Rotation:** `MultiFernet` accepts
  `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS` for decryption while new
  writes use the current key. Re-save secrets, then drop the previous key.

## Migration behavior

- Idempotent startup migration runs between `bootstrap_config` and
  `load_settings` (before env sync), encrypting any plaintext secrets.
- Never double-encrypts (already-enveloped and empty values are skipped).
- No Alembic/schema change — same `Text` column, new value format.

## Backwards compatibility

- Plaintext values still read through during the transition.
- **Fail closed:** a wrong key, tampered token, or name mismatch raises a
  clear `SettingsDecryptionError` — never silent corruption.

## Files

- New: `src/utils/secret_settings.py` (canonical `SECRET_SETTING_KEYS`),
  `src/utils/settings_crypto.py` (Fernet + HKDF + rotation + discovery cache).
- Changed: `settings_repository.py` (encrypt/decrypt + migration helper),
  `config_loader.py` (migration step), `app_setup.py` (wire migration),
  `app_runtime.py` (master-secret discovery), `settings_bp.py` &
  `logging_utils.py` (import the centralized secret list; `_SECRET_ENV_VARS`
  kept as an alias).
- Deps: `cryptography==46.0.3` in `requirements.txt` + `pyproject.toml`.
- Docs: README "Securing API secrets at rest" + example compose env notes.

## Test coverage

30 new tests in `tests/test_settings_crypto.py` and
`tests/test_settings_repository_encryption.py`: crypto round-trip, tamper
and wrong-key fail-closed, name-binding rejection, idempotent encrypt,
`MultiFernet` rotation, encrypt-on-save/decrypt-on-read,
plaintext/mixed/idempotent migration, master-secret discovery, and env
sync of decrypted secrets. All green locally; the 16 unrelated
template-not-found failures are pre-existing on `dev` in the local venv
(the canonical test path is Docker).

Closes #61


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Encrypt API secrets at rest in the settings table using Fernet
> - Adds a new `SettingsCrypto` class in [`settings_crypto.py`](https://github.com/serabi/pagekeeper/pull/79/files#diff-1d4136a54fb6d00429f3b56d9f12ef541b4efe3836d3f3009431e658b5740b20) using Fernet encryption with HKDF key derivation and name binding to prevent cross-key decryption.
> - The master secret is resolved from `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`, then `FLASK_SECRET_KEY`, then a persisted key; a previous secret (`PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS`) supports key rotation via `MultiFernet`.
> - `SettingsRepository` now encrypts secret settings on write and decrypts on read; already-encrypted values are detected to prevent double-encryption.
> - On startup, `ConfigLoader.migrate_secrets_encryption` runs an idempotent migration to encrypt any existing plaintext secrets before settings are loaded.
> - Risk: losing the master key without a backup makes stored secrets permanently unrecoverable; if the data directory is not writable and no key is configured, startup raises `EphemeralSecretKeyError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7dd38b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->