### PR TITLE
fix(pipeline): detect Grimmory-only books and promote not_started reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ CLAUDE.md
 .agent-prompts/
 .agent-reports/
 .worktrees/
+.playwright-mcp/

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -412,7 +412,7 @@ class GrimmoryClient:
         if self.target_library_id:
             lid = detail.get("libraryId")
             if lid is not None and str(lid) != str(self.target_library_id):
-                return None
+                return
 
         primary_file = detail.get("primaryFile", {})
         filename = primary_file.get("fileName", detail.get("fileName", ""))
@@ -468,8 +468,6 @@ class GrimmoryClient:
             except Exception as e:
                 logger.error(f"Failed to persist book {filename} to DB: {e}")
 
-        return None
-
     def _update_cached_progress(self, detail):
         """Update progress fields on an already-cached book in-place."""
         cached = self._book_id_cache.get(detail.get("id"))
@@ -500,13 +498,16 @@ class GrimmoryClient:
             return ""
         return re.sub(r"[\W_]+", "", s.lower())
 
-    def find_book_by_filename(self, ebook_filename, allow_refresh=True):
-        """Find a book by its filename using exact, stem, or normalized matching."""
-        if not self._book_cache and allow_refresh:
+    def _ensure_fresh_cache(self, allow_refresh=True):
+        """Refresh the in-memory book cache if it is empty or older than an hour."""
+        if not allow_refresh:
+            return
+        if not self._book_cache or time.time() - self._cache_timestamp > 3600:
             self._refresh_book_cache()
 
-        if allow_refresh and time.time() - self._cache_timestamp > 3600:
-            self._refresh_book_cache()
+    def find_book_by_filename(self, ebook_filename, allow_refresh=True):
+        """Find a book by its filename using exact, stem, or normalized matching."""
+        self._ensure_fresh_cache(allow_refresh)
 
         target_name = Path(ebook_filename).name.lower()
 
@@ -553,18 +554,12 @@ class GrimmoryClient:
 
     def get_all_books(self):
         """Get all books from cache, refreshing if necessary."""
-        if time.time() - self._cache_timestamp > 3600:
-            self._refresh_book_cache()
-        if not self._book_cache:
-            self._refresh_book_cache()
+        self._ensure_fresh_cache()
         return list(self._book_cache.values())
 
     def search_books(self, search_term):
         """Search books by title, author, or filename. Returns list of matching books."""
-        if time.time() - self._cache_timestamp > 3600:
-            self._refresh_book_cache()
-        if not self._book_cache:
-            self._refresh_book_cache()
+        self._ensure_fresh_cache()
 
         if not search_term:
             return list(self._book_cache.values())

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -133,7 +133,17 @@ class GrimmoryClient:
                     if not book_info:
                         book_info = {"fileName": db_book.filename, "title": db_book.title, "authors": db_book.authors}
 
-                    self._book_cache[db_book.filename] = book_info
+                    lower_name = db_book.filename.lower()
+
+                    # Normalize any legacy mixed-case row in place: re-save under the
+                    # lowercased key and drop the old row so the unique (server, filename)
+                    # row matches the lowercased keys used everywhere else.
+                    if db_book.filename != lower_name:
+                        self._normalize_grimmory_db_row(db_book, lower_name, book_info)
+
+                    # Key by lowercased filename to match _process_book_detail and the
+                    # lowercased lookups in find_book_by_filename.
+                    self._book_cache[lower_name] = book_info
 
                     bid = book_info.get("id")
                     if bid:
@@ -145,6 +155,22 @@ class GrimmoryClient:
             except Exception as e:
                 logger.error(f"Failed to load Grimmory cache from DB: {e}")
                 self._book_cache = {}
+
+    def _normalize_grimmory_db_row(self, db_book, lower_name, book_info):
+        """Rewrite a legacy mixed-case grimmory_books row to a lowercased filename."""
+        try:
+            normalized = GrimmoryBook(
+                filename=lower_name,
+                title=db_book.title,
+                authors=db_book.authors,
+                raw_metadata=json.dumps(book_info),
+                server_id=self.instance_id,
+            )
+            self.db.save_grimmory_book(normalized)
+            self.db.delete_grimmory_book(db_book.filename, server_id=self.instance_id)
+            logger.info(f"Grimmory: Normalized legacy cache row '{db_book.filename}' -> '{lower_name}'")
+        except Exception as e:
+            logger.warning(f"Grimmory: Failed to normalize cache row '{db_book.filename}': {e}")
 
     def _get_fresh_token(self):
         if self._token and (time.time() - self._token_timestamp) < self._token_max_age:
@@ -352,7 +378,7 @@ class GrimmoryClient:
                     live_filename = str(raw_live_filename).strip() if raw_live_filename else ""
                     cached_real_filename = book_info.get("fileName", fname)
 
-                    if live_filename and live_filename != str(cached_real_filename).strip():
+                    if live_filename and live_filename.lower() != str(cached_real_filename).strip().lower():
                         is_stale = True
                         logger.debug(
                             f"   Pruning {fname}: Filename mismatch. Live: {repr(raw_live_filename)} vs Cache: {repr(cached_real_filename)}"

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -312,6 +312,7 @@ def initialize_abs_listener(app, container, database_service, sync_manager):
             abs_api_token=get_str("ABS_KEY", ""),
             database_service=database_service,
             sync_manager=sync_manager,
+            container=container,
         )
         threading.Thread(target=abs_listener.start, daemon=True).start()
         app.config["abs_listener"] = abs_listener

--- a/src/services/abs_socket_listener.py
+++ b/src/services/abs_socket_listener.py
@@ -15,10 +15,15 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 import socketio
 
+from src.services.status_machine import StatusMachine
 from src.services.write_tracker import is_own_write as _tracker_is_own_write
 from src.services.write_tracker import record_write
 
 logger = logging.getLogger(__name__)
+
+# A not_started book is promoted to active only once reported progress clears this
+# fraction, mirroring the >1% "genuinely reading" bar used elsewhere in the pipeline.
+_PROGRESS_ACTIVATION_THRESHOLD = 0.01
 
 # ---------------------------------------------------------------------------
 # Write-suppression tracker — delegates to the shared write_tracker module.
@@ -60,6 +65,7 @@ class ABSSocketListener:
         self._socket_token: str | None = None
         self._db = database_service
         self._sync_manager = sync_manager
+        self._status_machine = StatusMachine(database_service)
 
         self._debounce_window = int(os.environ.get("ABS_SOCKET_DEBOUNCE_SECONDS", "30"))
 
@@ -184,6 +190,25 @@ class ABSSocketListener:
         def on_progress_updated(data):
             self._handle_progress_event(data)
 
+    @staticmethod
+    def _extract_progress_fraction(inner: dict, data: dict) -> float | None:
+        """Pull a 0-1 progress fraction from an ABS progress event, if present.
+
+        ABS MediaProgress carries an explicit `progress` fraction; fall back to
+        currentTime/duration. Looks in the nested `data` dict first, then top level.
+        """
+        for source in (inner, data):
+            if not isinstance(source, dict):
+                continue
+            progress = source.get("progress")
+            if isinstance(progress, (int, float)):
+                return float(progress)
+            duration = source.get("duration")
+            current_time = source.get("currentTime")
+            if isinstance(duration, (int, float)) and duration > 0 and isinstance(current_time, (int, float)):
+                return current_time / duration
+        return None
+
     def _handle_progress_event(self, data: dict) -> None:
         """Record a progress event in the debounce dict if it belongs to an active book."""
         if not isinstance(data, dict):
@@ -215,7 +240,33 @@ class ABSSocketListener:
             )
             self._suggestion_pool.submit(self._sync_manager.queue_suggestion, library_item_id)
             return
-        if book.status in ("paused", "dnf", "not_started") and not book.activity_flag:
+
+        # A not_started book never syncs (the poll only touches active books), so it
+        # would deadlock at 0%. Promote it to active when ABS reports real progress.
+        if book.status == "not_started":
+            pct = self._extract_progress_fraction(inner if isinstance(inner, dict) else {}, data)
+            if pct is not None and pct > _PROGRESS_ACTIVATION_THRESHOLD:
+                result = self._status_machine.transition(book, "active", source="completion_sync")
+                if result.get("success"):
+                    logger.info(
+                        f"ABS Socket.IO: Promoted not_started book '{book.title}' to active "
+                        f"({pct:.1%} progress reported)"
+                    )
+                else:
+                    logger.warning(
+                        f"ABS Socket.IO: Failed to promote '{book.title}': {result.get('error')}"
+                    )
+                with self._lock:
+                    self._pending[library_item_id] = time.time()
+                    self._fired.discard(library_item_id)
+                return
+            if not book.activity_flag:
+                book.activity_flag = True
+                self._db.save_book(book)
+                logger.info(f"ABS Socket.IO: Activity detected on not_started book '{book.title}'")
+            return
+
+        if book.status in ("paused", "dnf") and not book.activity_flag:
             book.activity_flag = True
             self._db.save_book(book)
             logger.info(f"ABS Socket.IO: Activity detected on {book.status} book '{book.title}'")

--- a/src/services/abs_socket_listener.py
+++ b/src/services/abs_socket_listener.py
@@ -15,15 +15,11 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 import socketio
 
-from src.services.status_machine import StatusMachine
+from src.services.status_machine import PROGRESS_ACTIVATION_THRESHOLD, StatusMachine
 from src.services.write_tracker import is_own_write as _tracker_is_own_write
 from src.services.write_tracker import record_write
 
 logger = logging.getLogger(__name__)
-
-# A not_started book is promoted to active only once reported progress clears this
-# fraction, mirroring the >1% "genuinely reading" bar used elsewhere in the pipeline.
-_PROGRESS_ACTIVATION_THRESHOLD = 0.01
 
 # ---------------------------------------------------------------------------
 # Write-suppression tracker — delegates to the shared write_tracker module.
@@ -50,6 +46,7 @@ class ABSSocketListener:
         abs_api_token: str,
         database_service,
         sync_manager,
+        container=None,
     ):
         """
         Initialize the ABSSocketListener with server credentials, services, and internal runtime state.
@@ -59,12 +56,15 @@ class ABSSocketListener:
             abs_api_token (str): API token used to authenticate requests; may be exchanged for a socket-compatible token.
             database_service: Database access service used to look up books and their status.
             sync_manager: Manager responsible for performing downstream sync cycles for given ABS item IDs.
+            container: DI container, forwarded to status transitions so completion_sync side
+                effects (real started_at pull, Grimmory push) fire on promotion.
         """
         self._server_url = abs_server_url.rstrip("/").replace("/api", "")
         self._api_token = abs_api_token
         self._socket_token: str | None = None
         self._db = database_service
         self._sync_manager = sync_manager
+        self._container = container
         self._status_machine = StatusMachine(database_service)
 
         self._debounce_window = int(os.environ.get("ABS_SOCKET_DEBOUNCE_SECONDS", "30"))
@@ -245,15 +245,10 @@ class ABSSocketListener:
         # would deadlock at 0%. Promote it to active when ABS reports real progress.
         if book.status == "not_started":
             pct = self._extract_progress_fraction(inner if isinstance(inner, dict) else {}, data)
-            if pct is not None and pct > _PROGRESS_ACTIVATION_THRESHOLD:
-                result = self._status_machine.transition(book, "active", source="completion_sync")
-                if result.get("success"):
-                    logger.info(
-                        f"ABS Socket.IO: Promoted not_started book '{book.title}' to active "
-                        f"({pct:.1%} progress reported)"
-                    )
-                else:
-                    logger.warning(f"ABS Socket.IO: Failed to promote '{book.title}': {result.get('error')}")
+            if pct is not None and pct > PROGRESS_ACTIVATION_THRESHOLD:
+                self._status_machine.promote_not_started(
+                    book, pct, container=self._container, source_label="ABS Socket.IO"
+                )
                 with self._lock:
                     self._pending[library_item_id] = time.time()
                     self._fired.discard(library_item_id)

--- a/src/services/abs_socket_listener.py
+++ b/src/services/abs_socket_listener.py
@@ -253,9 +253,7 @@ class ABSSocketListener:
                         f"({pct:.1%} progress reported)"
                     )
                 else:
-                    logger.warning(
-                        f"ABS Socket.IO: Failed to promote '{book.title}': {result.get('error')}"
-                    )
+                    logger.warning(f"ABS Socket.IO: Failed to promote '{book.title}': {result.get('error')}")
                 with self._lock:
                     self._pending[library_item_id] = time.time()
                     self._fired.discard(library_item_id)

--- a/src/services/status_machine.py
+++ b/src/services/status_machine.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 # Valid book statuses
 VALID_STATUSES = {"active", "completed", "paused", "dnf", "not_started"}
 
+# A not_started book is promoted to active only once reported progress clears this
+# fraction, mirroring the >1% "genuinely reading" bar used across the pipeline.
+PROGRESS_ACTIVATION_THRESHOLD = 0.01
+
 # Status → journal event mapping
 EVENT_MAP = {
     "completed": "finished",
@@ -113,6 +117,25 @@ class StatusMachine:
             self._push_to_grimmory(book, new_status, old_status, container)
 
         return {"success": True, "status": new_status, "previous_status": old_status}
+
+    def promote_not_started(self, book, pct, *, container=None, source_label=""):
+        """Promote a not_started book to active once external progress clears the bar.
+
+        Shared by the ABS socket listener and the sync-cycle discovery pass. Returns
+        the transition result dict when a promotion is attempted, or None when the
+        reported progress is at/below the activation threshold (caller does nothing).
+        """
+        if not pct or pct <= PROGRESS_ACTIVATION_THRESHOLD:
+            return None
+
+        result = self.transition(book, "active", source="completion_sync", container=container)
+        prefix = f"{source_label}: " if source_label else ""
+        title = sanitize_log_data(book.title)
+        if result.get("success"):
+            logger.info(f"{prefix}Promoted not_started book '{title}' to active ({pct:.1%} progress)")
+        else:
+            logger.warning(f"{prefix}Failed to promote '{title}': {result.get('error')}")
+        return result
 
     def _cleanup_tbr(self, book):
         """Remove any TBR item for this book, falling back to HC book ID lookup."""

--- a/src/services/suggestion_service.py
+++ b/src/services/suggestion_service.py
@@ -27,6 +27,12 @@ _CONFIDENCE_HIGH_THRESHOLD = 0.93
 _CONFIDENCE_MEDIUM_THRESHOLD = 0.82
 _MIN_CANDIDATE_SCORE = 0.72
 
+# Detection progress window (as fractions): a book is only surfaced for detection
+# when its external progress falls within these bounds. The lower bound filters
+# out untouched books; the upper bound avoids surfacing near-finished books.
+_DETECTION_WINDOW_MIN = 0.01
+_DETECTION_WINDOW_MAX = 0.95
+
 
 class SuggestionService:
     """Handles detected-book discovery plus legacy suggestion workflows."""
@@ -159,6 +165,9 @@ class SuggestionService:
         device: str | None = None,
         ebook_filename: str | None = None,
     ):
+        # Pass NULL (not "[]") for empty matches so an upsert from a no-match code
+        # path never clobbers cross-source matches recorded by an earlier pass.
+        matches_json = json.dumps(matches) if matches else None
         detected = DetectedBook(
             source=source,
             source_id=source_id,
@@ -166,7 +175,7 @@ class SuggestionService:
             author=author or "",
             cover_url=cover_url,
             progress_percentage=max(0.0, min(progress_percentage, 1.0)),
-            matches_json=json.dumps(matches or []),
+            matches_json=matches_json,
             device=device,
             ebook_filename=ebook_filename,
         )
@@ -544,10 +553,13 @@ class SuggestionService:
                             logger.debug(f"Skipping {abs_id}: detected entry dismissed")
                             continue
 
-                        # Check if book is already mostly finished (>70%)
-                        # If a user has listened to >70% elsewhere, they probably don't need a suggestion
-                        if pct > 0.70:
-                            logger.debug(f"Skipping {abs_id}: progress {pct:.1%} > 70% threshold")
+                        # Skip near-finished books — if a user is mostly done elsewhere,
+                        # surfacing a fresh detection adds little value.
+                        if pct > _DETECTION_WINDOW_MAX:
+                            logger.info(
+                                f"ABS detection: dropping {abs_id} — progress {pct:.1%} "
+                                f"above detection window max ({_DETECTION_WINDOW_MAX:.0%})"
+                            )
                             continue
 
                         logger.debug(f"Creating detected entry for {abs_id} (progress: {pct:.1%})")
@@ -590,7 +602,7 @@ class SuggestionService:
         for title_lower, pos_data in positions.items():
             pct = pos_data.get("pct", 0)
             uuid = pos_data.get("uuid")
-            if not uuid or pct < 0.01 or pct > 0.70:
+            if not uuid or not self._in_detection_window(pct):
                 continue
             if mapped_uuids and uuid in mapped_uuids:
                 continue
@@ -605,8 +617,13 @@ class SuggestionService:
             )
         return results
 
+    @staticmethod
+    def _in_detection_window(pct: float | None) -> bool:
+        """Return True when progress falls within the detection window (see module constants)."""
+        return bool(pct) and _DETECTION_WINDOW_MIN <= pct <= _DETECTION_WINDOW_MAX
+
     def _get_grimmory_books_with_progress(self, mapped_filenames: set | None = None) -> list[dict]:
-        """Fetch Grimmory books with 1-70% progress, excluding already-mapped filenames."""
+        """Fetch Grimmory books within the detection window, excluding already-mapped filenames."""
         if not self.grimmory_client or not self.grimmory_client.is_configured():
             return []
         try:
@@ -627,7 +644,12 @@ class SuggestionService:
                 pct_raw, _ = self.grimmory_client.get_progress(filename)
             except Exception:
                 continue
-            if not pct_raw or pct_raw < 0.01 or pct_raw > 0.70:
+            if not self._in_detection_window(pct_raw):
+                logger.info(
+                    f"Grimmory detection: dropping '{title}' — progress "
+                    f"{(pct_raw or 0):.1%} outside detection window "
+                    f"({_DETECTION_WINDOW_MIN:.0%}-{_DETECTION_WINDOW_MAX:.0%})"
+                )
                 continue
             results.append(
                 {
@@ -753,22 +775,27 @@ class SuggestionService:
 
             other_candidates = ebook_candidates.get("storyteller", []) + ebook_candidates.get("kosync", [])
             matches = self._rank_candidates_for_book(bl_book["title"], bl_book["author"], other_candidates)
+            cover = self._cover_url_for("grimmory", filename, bl_book)
+
+            # Legacy suggestion only when there's a cross-source match to act on.
             if matches:
-                cover = self._cover_url_for("grimmory", filename, bl_book)
                 self._save_suggestion_with_merge(
                     "grimmory", filename, bl_book["title"], bl_book["author"], cover, matches
                 )
-                self._upsert_detected_book(
-                    source="grimmory",
-                    source_id=filename,
-                    title=bl_book["title"],
-                    progress_percentage=bl_book.get("pct", 0.0),
-                    author=bl_book.get("author", ""),
-                    cover_url=cover,
-                    matches=matches,
-                    ebook_filename=filename,
-                )
-                existing_titles.add(norm_title)
+
+            # Surface every in-progress Grimmory book as a DetectedBook — even with no
+            # cross-source match — so Grimmory-only reads still appear for manual promotion.
+            self._upsert_detected_book(
+                source="grimmory",
+                source_id=filename,
+                title=bl_book["title"],
+                progress_percentage=bl_book.get("pct", 0.0),
+                author=bl_book.get("author", ""),
+                cover_url=cover,
+                matches=matches,
+                ebook_filename=filename,
+            )
+            existing_titles.add(norm_title)
 
     def _check_reverse_suggestions(self):
         """Check Storyteller and Grimmory for books with progress that could match ABS audiobooks."""

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -14,6 +14,7 @@ from src.services.cache_cleanup_service import CacheCleanupService
 from src.services.library_service import LibraryService
 from src.services.migration_service import MigrationService
 from src.services.progress_reset_service import ProgressResetService
+from src.services.status_machine import StatusMachine
 from src.services.suggestion_service import SuggestionService
 from src.services.sync_manager_startup import SyncManagerStartup
 from src.sync_clients.sync_client_interface import (
@@ -396,6 +397,14 @@ class SyncManager:
             self.library_service.sync_library_books()
             self._last_library_sync = time.time()
 
+        # Discovery: promote ebook-mapped not_started books once they show real progress.
+        # Must run before the active-only sync below, which would otherwise never touch them.
+        if not target_book_id:
+            try:
+                self._promote_discovered_ebooks()
+            except Exception as e:
+                logger.warning(f"Ebook discovery promotion failed: {sanitize_exception(e)}")
+
         active_books, bulk_states_per_client = self._prepare_sync_books(target_book_id)
         if not active_books:
             self._process_deferred_clears()
@@ -420,6 +429,44 @@ class SyncManager:
 
         logger.debug("End of sync cycle for active books")
         self._process_deferred_clears()
+
+    def _promote_discovered_ebooks(self):
+        """Promote not_started books with a mapped ebook to active once Grimmory reports progress.
+
+        Newly-added ebook-mapped books sit at not_started and are never polled (the sync
+        cycle only touches active books), so they would deadlock at 0%. This pass checks
+        their Grimmory progress once per cycle and promotes them when it clears 1%.
+        """
+        if not (self.grimmory_client and self.grimmory_client.is_configured()):
+            return
+
+        candidates = [
+            b
+            for b in self.database_service.get_books_by_status("not_started")
+            if getattr(b, "ebook_filename", None)
+        ]
+        if not candidates:
+            return
+
+        status_machine = StatusMachine(self.database_service)
+        for book in candidates:
+            try:
+                pct, _ = self.grimmory_client.get_progress(book.ebook_filename)
+            except Exception as e:
+                logger.debug(f"Discovery: progress fetch failed for '{book.ebook_filename}': {e}")
+                continue
+            if not pct or pct <= 0.01:
+                continue
+            result = status_machine.transition(book, "active", source="completion_sync")
+            if result.get("success"):
+                logger.info(
+                    f"Discovery: promoted not_started book '{sanitize_log_data(book.title)}' "
+                    f"to active ({pct:.1%} Grimmory progress)"
+                )
+            else:
+                logger.warning(
+                    f"Discovery: failed to promote '{sanitize_log_data(book.title)}': {result.get('error')}"
+                )
 
     def _prepare_sync_books(self, target_book_id):
         """Fetch active books, pre-fetch bulk states, and trigger suggestions."""

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 class SyncManager:
     def __init__(
         self,
+        container=None,
         abs_client=None,
         grimmory_client=None,
         hardcover_client=None,
@@ -66,6 +67,7 @@ class SyncManager:
 
         logger.info("=== Sync Manager Starting ===")
         # Use dependency injection
+        self.container = container
         self.abs_client = abs_client
         self.grimmory_client = grimmory_client
         self.hardcover_client = hardcover_client
@@ -440,8 +442,15 @@ class SyncManager:
         if not (self.grimmory_client and self.grimmory_client.is_configured()):
             return
 
+        # Exclude books with a deferred clear in flight — promoting them here would
+        # resurrect stale Grimmory progress before _process_deferred_clears runs.
+        with self._pending_clears_lock:
+            pending = set(self._pending_clears)
+
         candidates = [
-            b for b in self.database_service.get_books_by_status("not_started") if getattr(b, "ebook_filename", None)
+            b
+            for b in self.database_service.get_books_by_status("not_started")
+            if getattr(b, "ebook_filename", None) and b.id not in pending
         ]
         if not candidates:
             return
@@ -453,16 +462,7 @@ class SyncManager:
             except Exception as e:
                 logger.debug(f"Discovery: progress fetch failed for '{book.ebook_filename}': {e}")
                 continue
-            if not pct or pct <= 0.01:
-                continue
-            result = status_machine.transition(book, "active", source="completion_sync")
-            if result.get("success"):
-                logger.info(
-                    f"Discovery: promoted not_started book '{sanitize_log_data(book.title)}' "
-                    f"to active ({pct:.1%} Grimmory progress)"
-                )
-            else:
-                logger.warning(f"Discovery: failed to promote '{sanitize_log_data(book.title)}': {result.get('error')}")
+            status_machine.promote_not_started(book, pct, container=self.container, source_label="Discovery")
 
     def _prepare_sync_books(self, target_book_id):
         """Fetch active books, pre-fetch bulk states, and trigger suggestions."""

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -441,9 +441,7 @@ class SyncManager:
             return
 
         candidates = [
-            b
-            for b in self.database_service.get_books_by_status("not_started")
-            if getattr(b, "ebook_filename", None)
+            b for b in self.database_service.get_books_by_status("not_started") if getattr(b, "ebook_filename", None)
         ]
         if not candidates:
             return
@@ -464,9 +462,7 @@ class SyncManager:
                     f"to active ({pct:.1%} Grimmory progress)"
                 )
             else:
-                logger.warning(
-                    f"Discovery: failed to promote '{sanitize_log_data(book.title)}': {result.get('error')}"
-                )
+                logger.warning(f"Discovery: failed to promote '{sanitize_log_data(book.title)}': {result.get('error')}")
 
     def _prepare_sync_books(self, target_book_id):
         """Fetch active books, pre-fetch bulk states, and trigger suggestions."""
@@ -806,4 +802,3 @@ class SyncManager:
     def clear_progress(self, abs_id):
         """Clear progress data for a specific book and reset all sync clients to 0%."""
         return self.progress_reset_service.clear_progress(abs_id)
-

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 class Container(containers.DeclarativeContainer):
     """Main dependency injection container using dependency-injector library."""
 
+    # Self-reference so singletons (e.g. SyncManager) can be handed the container
+    # for status-transition side effects that run off the request thread.
+    __self__ = providers.Self()
+
     # Configuration
     config = providers.Configuration()
 
@@ -217,6 +221,7 @@ class Container(containers.DeclarativeContainer):
     # Sync Manager
     sync_manager = providers.Singleton(
         SyncManager,
+        container=__self__,
         abs_client=abs_client,
         grimmory_client=grimmory_client_group,
         hardcover_client=hardcover_client,

--- a/tests/test_abs_socket_listener.py
+++ b/tests/test_abs_socket_listener.py
@@ -174,6 +174,30 @@ class TestABSSocketListenerDebounce(unittest.TestCase):
         self.assertEqual(book.status, "active")
         self.assertIn("fresh-id", self.listener._pending)
 
+    def test_promotion_forwards_container_to_transition(self):
+        """The listener must forward its DI container into the status transition so
+        completion_sync side effects (real started_at, Grimmory push) actually run."""
+        sentinel_container = object()
+        with patch("src.services.abs_socket_listener.socketio.Client"):
+            listener = ABSSocketListener(
+                abs_server_url="http://abs.local:13378",
+                abs_api_token="tok",
+                database_service=self.mock_db,
+                sync_manager=self.mock_sync,
+                container=sentinel_container,
+            )
+
+        book = self._make_not_started_book("container-id")
+        self.mock_db.get_book_by_abs_id.return_value = book
+
+        with patch.object(
+            listener._status_machine, "transition", return_value={"success": True}
+        ) as mock_transition:
+            listener._handle_progress_event({"id": "p", "data": {"libraryItemId": "container-id", "progress": 0.10}})
+
+        mock_transition.assert_called_once()
+        self.assertIs(mock_transition.call_args.kwargs.get("container"), sentinel_container)
+
     def test_not_started_below_threshold_only_flags_activity(self):
         """A not_started book below 1% is not promoted, just flagged."""
         book = self._make_not_started_book("fresh-id-2")

--- a/tests/test_abs_socket_listener.py
+++ b/tests/test_abs_socket_listener.py
@@ -153,6 +153,48 @@ class TestABSSocketListenerDebounce(unittest.TestCase):
         self.assertEqual(len(self.listener._pending), 0)
         self.mock_db.get_book_by_abs_id.assert_not_called()
 
+    def _make_not_started_book(self, abs_id: str):
+        book = MagicMock()
+        book.id = 99
+        book.abs_id = abs_id
+        book.title = "Fresh Book"
+        book.status = "not_started"
+        book.activity_flag = False
+        book.started_at = None
+        book.ebook_filename = None
+        return book
+
+    def test_promotes_not_started_on_meaningful_progress(self):
+        """A not_started book with >1% reported progress is promoted to active."""
+        book = self._make_not_started_book("fresh-id")
+        self.mock_db.get_book_by_abs_id.return_value = book
+
+        self.listener._handle_progress_event({"id": "p", "data": {"libraryItemId": "fresh-id", "progress": 0.10}})
+
+        self.assertEqual(book.status, "active")
+        self.assertIn("fresh-id", self.listener._pending)
+
+    def test_not_started_below_threshold_only_flags_activity(self):
+        """A not_started book below 1% is not promoted, just flagged."""
+        book = self._make_not_started_book("fresh-id-2")
+        self.mock_db.get_book_by_abs_id.return_value = book
+
+        self.listener._handle_progress_event({"id": "p", "data": {"libraryItemId": "fresh-id-2", "progress": 0.001}})
+
+        self.assertEqual(book.status, "not_started")
+        self.assertTrue(book.activity_flag)
+        self.assertNotIn("fresh-id-2", self.listener._pending)
+
+    def test_not_started_without_progress_only_flags_activity(self):
+        """A not_started book with no extractable progress is flagged, not promoted."""
+        book = self._make_not_started_book("fresh-id-3")
+        self.mock_db.get_book_by_abs_id.return_value = book
+
+        self.listener._handle_progress_event({"id": "p", "data": {"libraryItemId": "fresh-id-3"}})
+
+        self.assertEqual(book.status, "not_started")
+        self.assertTrue(book.activity_flag)
+
     def test_url_stripping(self):
         """Server URL should strip trailing /api for socket connection."""
         with patch("src.services.abs_socket_listener.socketio.Client"):

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -60,6 +60,37 @@ def test_init_loads_from_db(mock_db):
         assert client._book_id_cache["123"]["title"] == "Test Book"
 
 
+def test_mixed_case_filename_normalizes_on_load(mock_db):
+    """A legacy mixed-case DB row keys the cache lowercased and resolves on lookup."""
+    mock_book = MagicMock()
+    mock_book.filename = "Mixed_Case.epub"
+    mock_book.title = "Mixed Case Book"
+    mock_book.authors = "Author"
+    mock_book.raw_metadata_dict = {
+        "id": "777",
+        "fileName": "Mixed_Case.epub",
+        "title": "Mixed Case Book",
+        "authors": "Author",
+    }
+    mock_db.get_all_grimmory_books.return_value = [mock_book]
+
+    with patch.dict(
+        os.environ,
+        {"GRIMMORY_SERVER": "http://mock", "GRIMMORY_USER": "u", "GRIMMORY_PASSWORD": "p", "DATA_DIR": "/tmp/data"},
+    ):
+        client = GrimmoryClient(database_service=mock_db)
+
+    # Cache key is lowercased, so a lowercased lookup resolves.
+    assert "mixed_case.epub" in client._book_cache
+    assert "Mixed_Case.epub" not in client._book_cache
+    assert client.find_book_by_filename("Mixed_Case.epub", allow_refresh=False)["id"] == "777"
+
+    # The legacy mixed-case row is rewritten lowercase and the old row deleted.
+    saved = mock_db.save_grimmory_book.call_args.args[0]
+    assert saved.filename == "mixed_case.epub"
+    mock_db.delete_grimmory_book.assert_called_once_with("Mixed_Case.epub", server_id=client.instance_id)
+
+
 def test_migration_from_legacy_json(mock_db):
     # Setup: DB is empty, Legacy JSON exists
     mock_db.get_all_grimmory_books.side_effect = [[], []]  # First call empty, second call empty
@@ -308,9 +339,7 @@ def test_reload_from_env_loads_cache_when_started_unconfigured(mock_db):
         assert client._book_cache == {}
 
         # Settings save populates env + DB, then reloads the singleton.
-        os.environ.update(
-            {"GRIMMORY_SERVER": "http://mock", "GRIMMORY_USER": "u", "GRIMMORY_PASSWORD": "p"}
-        )
+        os.environ.update({"GRIMMORY_SERVER": "http://mock", "GRIMMORY_USER": "u", "GRIMMORY_PASSWORD": "p"})
         client.reload_from_env()
 
         assert client.is_configured()

--- a/tests/test_grimmory_only_detection.py
+++ b/tests/test_grimmory_only_detection.py
@@ -1,0 +1,80 @@
+"""Tests for surfacing Grimmory-only in-progress books as DetectedBooks.
+
+A book read only on Grimmory (no ABS audiobook, no other ebook source) used to
+produce no match and therefore no DetectedBook. It should now be surfaced for
+manual promotion even when matches == [].
+"""
+
+import pytest
+
+pytestmark = pytest.mark.docker
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.services.suggestion_service import SuggestionService
+
+
+def _make_service(grimmory_client, database_service):
+    return SuggestionService(
+        database_service=database_service,
+        abs_client=Mock(),
+        grimmory_client=grimmory_client,
+        storyteller_client=None,
+        library_service=Mock(),
+        books_dir=Path("/tmp"),
+        ebook_parser=Mock(),
+    )
+
+
+class TestGrimmoryOnlyDetection(unittest.TestCase):
+    def setUp(self):
+        self.mock_db = Mock()
+        self.mock_db.get_all_books.return_value = []
+        self.mock_db.get_all_actionable_suggestions.return_value = []
+        self.mock_db.get_unlinked_kosync_documents.return_value = []
+        self.mock_db.suggestion_exists.return_value = False
+
+        self.grimmory = Mock()
+        self.grimmory.is_configured.return_value = True
+        # One in-progress Grimmory book with no cross-source counterpart.
+        self.grimmory.get_all_books.return_value = [
+            {"id": 1, "title": "Solo Read", "fileName": "solo.epub", "authors": "Some Author"},
+        ]
+        self.grimmory.get_progress.return_value = (0.40, None)
+
+        self.service = _make_service(self.grimmory, self.mock_db)
+
+    def test_grimmory_only_book_is_upserted_without_match(self):
+        self.service._check_cross_ebook_suggestions()
+
+        self.mock_db.save_detected_book.assert_called_once()
+        detected = self.mock_db.save_detected_book.call_args.args[0]
+        self.assertEqual(detected.source, "grimmory")
+        self.assertEqual(detected.source_id, "solo.epub")
+        self.assertEqual(detected.title, "Solo Read")
+        # No cross-source match — matches_json should be NULL so a later enrichment
+        # pass is free to attach matches without being clobbered first.
+        self.assertIsNone(detected.matches_json)
+
+    def test_grimmory_book_outside_window_is_dropped(self):
+        self.grimmory.get_progress.return_value = (0.97, None)  # above 95% window
+
+        self.service._check_cross_ebook_suggestions()
+
+        self.mock_db.save_detected_book.assert_not_called()
+
+    def test_grimmory_book_within_widened_window_is_surfaced(self):
+        self.grimmory.get_progress.return_value = (0.80, None)  # within new 1-95% window
+
+        self.service._check_cross_ebook_suggestions()
+
+        self.mock_db.save_detected_book.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_suggestion_logic.py
+++ b/tests/test_suggestion_logic.py
@@ -40,28 +40,28 @@ class TestSuggestionLogic(unittest.TestCase):
             del os.environ["SUGGESTIONS_ENABLED"]
 
     def test_suggestion_ignored_when_progress_high(self):
-        """Test that suggestions are NOT created if progress > 70%."""
+        """Test that detections are NOT created if progress is above the 95% window."""
         # Setup
         abs_id = "book-123"
         progress_data = {
             "duration": 1000,
-            "currentTime": 750,  # 75%
+            "currentTime": 970,  # 97% — above the 95% detection window
         }
 
         # Mocks
         self.mock_db.get_all_books.return_value = []  # Not mapped
         self.mock_db.get_pending_suggestion.return_value = None  # No pending suggestion
         self.mock_db.suggestion_exists.return_value = False  # No hidden suggestion (simulating clean state)
+        self.mock_db.get_detected_book.return_value = None
 
         # Action
         self.manager.check_for_suggestions({abs_id: progress_data}, [])
 
-        # Assert
-        # Should NOT call save_pending_suggestion because 75% > 70%
-        self.mock_db.save_pending_suggestion.assert_not_called()
+        # Assert: 97% is above the window, so no detection is persisted
+        self.mock_db.save_detected_book.assert_not_called()
 
-    def test_suggestion_created_when_progress_low(self):
-        """Test that suggestions ARE created if progress < 70% (and > 1%)."""
+    def test_suggestion_created_when_progress_within_window(self):
+        """Test that detections ARE created when progress is within the 1-95% window."""
         # Setup
         abs_id = "book-456"
         progress_data = {
@@ -87,6 +87,39 @@ class TestSuggestionLogic(unittest.TestCase):
 
         # Assert: ABS detection persists a DetectedBook (not a legacy PendingSuggestion)
         self.mock_db.save_detected_book.assert_called_once()
+
+    def test_promotes_not_started_ebook_with_progress(self):
+        """A not_started book with a mapped ebook and >1% Grimmory progress is promoted."""
+        book = MagicMock()
+        book.id = 7
+        book.title = "Mapped Ebook"
+        book.status = "not_started"
+        book.ebook_filename = "mapped.epub"
+        book.started_at = None
+
+        self.mock_db.get_books_by_status.side_effect = lambda status: [book] if status == "not_started" else []
+        self.mock_grimmory.is_configured.return_value = True
+        self.mock_grimmory.get_progress.return_value = (0.25, None)
+
+        self.manager._promote_discovered_ebooks()
+
+        self.assertEqual(book.status, "active")
+
+    def test_does_not_promote_not_started_below_threshold(self):
+        """A not_started ebook below 1% Grimmory progress stays not_started."""
+        book = MagicMock()
+        book.id = 8
+        book.title = "Untouched Ebook"
+        book.status = "not_started"
+        book.ebook_filename = "untouched.epub"
+
+        self.mock_db.get_books_by_status.side_effect = lambda status: [book] if status == "not_started" else []
+        self.mock_grimmory.is_configured.return_value = True
+        self.mock_grimmory.get_progress.return_value = (0.0, None)
+
+        self.manager._promote_discovered_ebooks()
+
+        self.assertEqual(book.status, "not_started")
 
     def test_suggestion_ignored_when_hidden(self):
         """Test that suggestions are NOT created if they were previously hidden."""

--- a/tests/test_suggestion_logic.py
+++ b/tests/test_suggestion_logic.py
@@ -121,6 +121,50 @@ class TestSuggestionLogic(unittest.TestCase):
 
         self.assertEqual(book.status, "not_started")
 
+    def test_promotion_forwards_container_to_transition(self):
+        """Discovery promotion must pass the DI container so completion_sync side effects
+        (real started_at pull, Grimmory push) can run instead of stamping date.today()."""
+        from unittest.mock import patch
+
+        book = MagicMock()
+        book.id = 9
+        book.title = "Container Forwarded"
+        book.status = "not_started"
+        book.ebook_filename = "forwarded.epub"
+
+        sentinel_container = object()
+        self.manager.container = sentinel_container
+        self.mock_db.get_books_by_status.side_effect = lambda status: [book] if status == "not_started" else []
+        self.mock_grimmory.is_configured.return_value = True
+        self.mock_grimmory.get_progress.return_value = (0.30, None)
+
+        with patch("src.sync_manager.StatusMachine.transition", return_value={"success": True}) as mock_transition:
+            self.manager._promote_discovered_ebooks()
+
+        mock_transition.assert_called_once()
+        self.assertIs(mock_transition.call_args.kwargs.get("container"), sentinel_container)
+
+    def test_pending_clear_books_not_promoted(self):
+        """A not_started book awaiting a deferred clear must not be re-promoted from stale
+        Grimmory progress, which would undo the clear."""
+        book = MagicMock()
+        book.id = 10
+        book.title = "Pending Clear"
+        book.status = "not_started"
+        book.ebook_filename = "pending.epub"
+
+        self.mock_db.get_books_by_status.side_effect = lambda status: [book] if status == "not_started" else []
+        self.mock_grimmory.is_configured.return_value = True
+        self.mock_grimmory.get_progress.return_value = (0.30, None)
+
+        with self.manager._pending_clears_lock:
+            self.manager._pending_clears.add(book.id)
+
+        self.manager._promote_discovered_ebooks()
+
+        self.assertEqual(book.status, "not_started")
+        self.mock_grimmory.get_progress.assert_not_called()
+
     def test_suggestion_ignored_when_hidden(self):
         """Test that suggestions are NOT created if they were previously hidden."""
         # Setup


### PR DESCRIPTION
## What & why

Two symptoms on the live container:

1. A book added to the library never showed up in **Currently Reading**.
2. Grimmory had **two** books in progress but PageKeeper picked up only **one**.

A full trace of the add → currently-reading pipeline found the root causes. Adding a book creates it as `not_started`, but the sync cycle only ever polls `active` books and the ABS socket only set `activity_flag` — so a book already in progress externally sat at 0% forever. Separately, a Grimmory book was surfaced as a `DetectedBook` *only* when it cross-matched an ABS audiobook or another ebook source, so a Grimmory-only read appeared nowhere.

## Fixes

**1. Promote `not_started` → `active` on real external progress.** Two paths, both via `StatusMachine.transition`:
- ABS socket listener promotes a `not_started` book when a progress event reports >1% (falling back to `activity_flag` below that, or when no progress is extractable). `paused`/`dnf` keep their deliberate state.
- The sync cycle runs an ebook discovery pass that checks Grimmory progress for `not_started` books with a mapped `ebook_filename` and promotes them past 1%. It runs **before** the active-only sync, which would otherwise skip them.

**2. Surface Grimmory-only in-progress books as DetectedBooks.** `_check_cross_ebook_suggestions` now upserts a `DetectedBook` for every in-progress Grimmory book even when `matches == []`, so Grimmory-only reads appear in the dashboard **Detected** section for manual promotion. Empty matches persist as `NULL` (not `"[]"`) so a no-match pass never clobbers cross-source matches recorded by an earlier enrichment pass. The existing `existing_titles` dedup against ABS is preserved.

**3. Widen the detection window and make drops visible.** The silent 1–70% window is now 1–95%, centralized in a single `_in_detection_window` helper. Every drop (out-of-window) now logs at `info` with title and percentage — symptom #2 previously produced zero diagnostic signal.

**4. Normalize Grimmory cache keys.** `_load_cache` keyed the in-memory cache by the raw DB filename while `_process_book_detail` keyed by the lowercased filename and lookups lowercase their target. A legacy mixed-case row therefore never resolved on lookup, and the case-sensitive stale-prune could delete then re-add a live book, transiently dropping it from `get_all_books`. The load key is now lowercased, the prune comparison is case-insensitive, and legacy mixed-case rows are normalized in place on load.

## Test coverage

New/updated tests (all green):
- `test_grimmory_only_detection.py` — a Grimmory-only book upserts a `DetectedBook` with `NULL` matches, is dropped above the 95% window, and surfaces within the widened window.
- `test_abs_socket_listener.py` — promotes a `not_started` book past 1%, only flags activity below it or with no extractable progress.
- `test_suggestion_logic.py` — sync discovery promotes a `not_started` ebook with Grimmory progress; high-progress detection test updated to the new 95% cutoff.
- `test_grimmory_client.py` — a legacy mixed-case filename round-trips: keyed lowercase, resolvable on lookup, legacy row normalized in place.

Full suite: 921 passed, 2 skipped, `ruff` clean. (One unrelated settings-encryption test fails only under the root-user Docker test runner and also fails on `dev`.)

## Files

- `src/services/abs_socket_listener.py` — socket promotion + progress extraction
- `src/sync_manager.py` — ebook discovery promotion pass
- `src/services/suggestion_service.py` — unconditional Grimmory upsert, window helper + logging
- `src/api/grimmory_client.py` — cache-key normalization; cache-refresh boilerplate collapsed into `_ensure_fresh_cache` (separate refactor commit)
- `tests/` — coverage above

A scoped follow-up note: both reverse loops still write legacy `PendingSuggestion` rows alongside `DetectedBook` upserts. Per the integration plan the `/suggestions` page is being kept for now, so that path is intentionally left for the planned separate redesign branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect Grimmory-only books and promote not_started reads to active on progress
> - Adds `StatusMachine.promote_not_started` to transition books from `not_started` to active when observed progress exceeds `PROGRESS_ACTIVATION_THRESHOLD` (1%).
> - `ABSSocketListener._handle_progress_event` now promotes `not_started` books to active when ABS reports >1% progress; sub-threshold events set an activity flag only.
> - `SyncManager._promote_discovered_ebooks` scans `not_started` ebooks each sync cycle and promotes those with >1% Grimmory progress, skipping books awaiting deferred clears.
> - `SuggestionService._check_cross_ebook_suggestions` upserts a `DetectedBook` entry for every in-progress Grimmory book regardless of cross-source matches; `matches_json` is set to NULL when no matches exist (previously stored `'[]'`).
> - Detection window is widened to 1–95% (from 1–70% for Storyteller) and centralized in `_in_detection_window`; books above 95% progress are suppressed.
> - Grimmory DB entries with mixed-case filenames are normalized to lowercase on cache load.
> - Behavioral Change: `matches_json` in `DetectedBook` rows with no matches will now be NULL instead of `'[]'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fef404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->