### PR TITLE
Cleanup 00: add pytest CI baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches: [main, dev, "cleanup/**"]
+  pull_request:
+    branches: [main, dev, "cleanup/**"]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run pytest in the test container
+        run: docker compose -f docker-compose.test.yml run --rm test tests/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ docker-compose.yml*
 *.json
 epub_cache/
 
+# Local test fixtures (database.db, .flask_secret_key) used by cleanup planning
+test_data/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,19 @@ For a direct Docker compose invocation:
 docker compose -f docker-compose.test.yml run --rm test tests/test_app_runtime.py
 ```
 
+### Continuous Integration
+
+CI runs two separate jobs on pushes and pull requests:
+
+- **Ruff** (`.github/workflows/lint.yml`) — `ruff check src/ tests/ alembic/ scripts/`
+- **pytest** (`.github/workflows/test.yml`) — runs the full suite in the Docker test container with the same command you can run locally:
+
+  ```bash
+  docker compose -f docker-compose.test.yml run --rm test tests/
+  ```
+
+Both jobs must be green before a PR is merged.
+
 ### Dev App Smoke Test
 
 ```bash


### PR DESCRIPTION
## Summary

Stage 0/1 kickoff for the backend cleanup safety harness.

Base branch: `cleanup/backend-cleanup-2026-06-29`

This PR does **not** merge to `dev`; it targets the long-lived cleanup integration branch only.

Changes:
- Adds a pytest GitHub Actions workflow using the repo's existing Docker test path.
- Keeps the existing Ruff workflow separate.
- Adds `test_data/` to `.gitignore` so local fixture DBs are not committed.
- Documents the CI/local test commands in `CONTRIBUTING.md`.

No source refactor, backend behavior change, frontend change, or DB fixture commit is included.

## Verification

- `ruff check src/ tests/ alembic/ scripts/` — passed.
- `./run-tests.sh` / Docker test container — completed with exit code `0`.
- Verified the commit contains no `.db` files and no `test_data/` fixture contents.
- Verified PR base is `cleanup/backend-cleanup-2026-06-29`, not `dev`.

## Next stage

Next PR should add the behavior-freeze safety harness:
- route inventory test;
- UI API golden snapshots;
- KoSync protocol byte-level tests.

Do not merge this PR automatically; review first.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pytest CI workflow with Docker Compose test runner
> - Adds [test.yml](.github/workflows/test.yml), a GitHub Actions workflow that runs pytest on push and pull request events targeting `main`, `dev`, and `cleanup/**` branches via `docker compose -f docker-compose.test.yml run --rm test tests/`.
> - Updates [CONTRIBUTING.md](https://github.com/serabi/pagekeeper/pull/84/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) to document both the Ruff lint and pytest CI jobs, including the local equivalent command.
> - Adds `test_data/` to [.gitignore](https://github.com/serabi/pagekeeper/pull/84/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to exclude local test fixtures from version control.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7a65959. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->