### PR TITLE
Cleanup 03: consolidate Grimmory repository upsert

### DIFF
--- a/src/db/grimmory_repository.py
+++ b/src/db/grimmory_repository.py
@@ -28,50 +28,15 @@ class GrimmoryRepository(BaseRepository):
             return rows
 
     def save_grimmory_book(self, grimmory_book):
-        with self.get_session() as session:
-            existing = (
-                session.query(GrimmoryBook)
-                .filter(
-                    GrimmoryBook.server_id == grimmory_book.server_id,
-                    GrimmoryBook.filename == grimmory_book.filename,
-                )
-                .first()
-            )
-
-            if existing:
-                for attr in ["title", "authors", "raw_metadata"]:
-                    if hasattr(grimmory_book, attr):
-                        setattr(existing, attr, getattr(grimmory_book, attr))
-                session.flush()
-                session.refresh(existing)
-                session.expunge(existing)
-                return existing
-            else:
-                try:
-                    session.add(grimmory_book)
-                    session.flush()
-                except IntegrityError:
-                    session.rollback()
-                    existing = (
-                        session.query(GrimmoryBook)
-                        .filter(
-                            GrimmoryBook.server_id == grimmory_book.server_id,
-                            GrimmoryBook.filename == grimmory_book.filename,
-                        )
-                        .first()
-                    )
-                    if existing:
-                        for attr in ["title", "authors", "raw_metadata"]:
-                            if hasattr(grimmory_book, attr):
-                                setattr(existing, attr, getattr(grimmory_book, attr))
-                        session.flush()
-                        session.refresh(existing)
-                        session.expunge(existing)
-                        return existing
-                    raise
-                session.refresh(grimmory_book)
-                session.expunge(grimmory_book)
-                return grimmory_book
+        return self._upsert(
+            GrimmoryBook,
+            [
+                GrimmoryBook.server_id == grimmory_book.server_id,
+                GrimmoryBook.filename == grimmory_book.filename,
+            ],
+            grimmory_book,
+            ["title", "authors", "raw_metadata"],
+        )
 
     def replace_grimmory_book_filename(self, old_filename, grimmory_book):
         """Atomically upsert *grimmory_book* and remove the old filename row.

--- a/tests/test_grimmory_repository.py
+++ b/tests/test_grimmory_repository.py
@@ -16,6 +16,164 @@ def repository(tmp_path):
         manager.close()
 
 
+def test_save_grimmory_book_inserts_new_row(repository):
+    saved = repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="new.epub",
+            title="New Title",
+            authors="New Author",
+            raw_metadata=json.dumps({"id": "1"}),
+            server_id="test",
+        )
+    )
+
+    assert saved.id is not None
+    fetched = repository.get_grimmory_book("new.epub", server_id="test")
+    assert fetched.title == "New Title"
+    assert fetched.authors == "New Author"
+    assert fetched.raw_metadata_dict["id"] == "1"
+
+
+def test_save_grimmory_book_updates_existing_identity(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="same.epub",
+            title="Original Title",
+            authors="Original Author",
+            raw_metadata=json.dumps({"id": "orig"}),
+            server_id="test",
+        )
+    )
+
+    updated = repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="same.epub",
+            title="Updated Title",
+            authors="Updated Author",
+            raw_metadata=json.dumps({"id": "updated"}),
+            server_id="test",
+        )
+    )
+
+    assert updated.title == "Updated Title"
+    assert updated.authors == "Updated Author"
+    assert updated.raw_metadata_dict["id"] == "updated"
+
+
+def test_save_grimmory_book_no_duplicate_on_repeated_save(repository):
+    for _ in range(3):
+        repository.save_grimmory_book(
+            GrimmoryBook(
+                filename="repeat.epub",
+                title="Repeat Title",
+                authors="Repeat Author",
+                raw_metadata=json.dumps({"id": "repeat"}),
+                server_id="test",
+            )
+        )
+
+    rows = repository.get_all_grimmory_books(server_id="test")
+    matching = [r for r in rows if r.filename == "repeat.epub"]
+    assert len(matching) == 1
+
+
+def test_save_grimmory_book_distinguishes_by_server_id(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="shared.epub", title="Server A", server_id="a")
+    )
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="shared.epub", title="Server B", server_id="b")
+    )
+
+    assert repository.get_grimmory_book("shared.epub", server_id="a").title == "Server A"
+    assert repository.get_grimmory_book("shared.epub", server_id="b").title == "Server B"
+
+
+def test_save_grimmory_book_updates_preexisting_row(repository):
+    """A row already committed by another writer is updated in place rather
+    than duplicated when save sees the same identity."""
+    with repository.get_session() as session:
+        session.add(
+            GrimmoryBook(
+                filename="preexisting.epub",
+                title="Concurrent Title",
+                authors="Concurrent Author",
+                raw_metadata=json.dumps({"id": "concurrent"}),
+                server_id="test",
+            )
+        )
+
+    saved = repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="preexisting.epub",
+            title="Winner Title",
+            authors="Winner Author",
+            raw_metadata=json.dumps({"id": "winner"}),
+            server_id="test",
+        )
+    )
+
+    assert saved.title == "Winner Title"
+    rows = repository.get_all_grimmory_books(server_id="test")
+    matching = [r for r in rows if r.filename == "preexisting.epub"]
+    assert len(matching) == 1
+    assert matching[0].title == "Winner Title"
+
+
+def test_save_grimmory_book_recovers_from_integrity_race(repository, monkeypatch):
+    """If a unique-constraint conflict fires on insert (a writer committed the
+    same identity after our lookup), save must roll back, re-find the row, and
+    update it without raising or duplicating."""
+    inserted_concurrently = {"done": False}
+
+    def insert_conflicting_row():
+        with repository.get_session() as session:
+            session.add(
+                GrimmoryBook(
+                    filename="integrity.epub",
+                    title="Sneaky Title",
+                    authors="Sneaky Author",
+                    raw_metadata=json.dumps({"id": "sneaky"}),
+                    server_id="test",
+                )
+            )
+
+    # Patch Query.first so the first lookup returns None (row not yet visible),
+    # then commit a conflicting row so the subsequent insert raises IntegrityError.
+    from sqlalchemy.orm import Query
+
+    original_first = Query.first
+    call_state = {"n": 0}
+
+    def patched_first(self):
+        call_state["n"] += 1
+        if call_state["n"] == 1 and not inserted_concurrently["done"]:
+            inserted_concurrently["done"] = True
+            insert_conflicting_row()
+            return None
+        return original_first(self)
+
+    monkeypatch.setattr(Query, "first", patched_first)
+
+    saved = repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="integrity.epub",
+            title="Winner Title",
+            authors="Winner Author",
+            raw_metadata=json.dumps({"id": "winner"}),
+            server_id="test",
+        )
+    )
+
+    monkeypatch.undo()
+
+    assert saved.title == "Winner Title"
+    rows = repository.get_all_grimmory_books(server_id="test")
+    matching = [r for r in rows if r.filename == "integrity.epub"]
+    assert len(matching) == 1
+    assert matching[0].title == "Winner Title"
+
+
 def test_replace_grimmory_book_filename_in_one_repository_call(repository):
     repository.save_grimmory_book(
         GrimmoryBook(


### PR DESCRIPTION
## Stage 03: Repository consolidation pilot

This is **Stage 03** of the backend cleanup. It pilots repository-layer consolidation by collapsing one duplicated upsert into the shared `BaseRepository._upsert` helper, proving the pattern is safe one small slice at a time.

- **Base branch:** `cleanup/backend-cleanup-2026-06-29`
- **This does NOT merge to `dev`.** The integration branch stays open until the full cleanup is complete and explicitly approved.

### What changed

Replaced the inline lookup/insert/update logic in `GrimmoryRepository.save_grimmory_book()` with a call to `BaseRepository._upsert(...)`. The inline implementation was a line-for-line duplicate of `_upsert`, which is already used by `hardcover_repository.py` and `book_repository.py`.

### Behavior preserved

- **Method name and signature unchanged** — `save_grimmory_book(self, grimmory_book)`. No service call sites change (`grimmory_client.py`, `migration_service.py`).
- **Lookup filters unchanged** — `(server_id, filename)`.
- **Update fields unchanged** — `title`, `authors`, `raw_metadata`.
- **IntegrityError path unchanged** — `_upsert` performs the same rollback, re-lookup, and update-or-raise recovery as the original inline code (the table's `uq_grimmory_server_filename` unique constraint makes this path reachable).
- **Return value unchanged** — the flushed, refreshed, expunged model instance.
- Imports for `IntegrityError` and `SQLAlchemyError` are retained because `replace_grimmory_book_filename` and `delete_grimmory_book` still use them.

### Tests added

New focused tests in `tests/test_grimmory_repository.py`:

- `test_save_grimmory_book_inserts_new_row` — insert path.
- `test_save_grimmory_book_updates_existing_identity` — update path for same identity.
- `test_save_grimmory_book_no_duplicate_on_repeated_save` — no duplicate row on repeated save.
- `test_save_grimmory_book_distinguishes_by_server_id` — identity is `(server_id, filename)`.
- `test_save_grimmory_book_updates_preexisting_row` — committed row from another writer is updated, not duplicated.
- `test_save_grimmory_book_recovers_from_integrity_race` — exercises the IntegrityError rollback-and-retry branch directly (patched `Query.first` returns `None`, then a conflicting row is committed so the insert raises and `_upsert` recovers).

### Verification

```
git branch --show-current   -> cleanup/03-grimmory-upsert-pilot
ruff check src/ tests/ alembic/ scripts/   -> All checks passed!
./run-tests.sh tests/test_grimmory_repository.py   -> 8 passed
./run-tests.sh   -> 952 passed, 3 skipped, 17 warnings
```

The 3 skips and all warnings are pre-existing and unrelated. Stage 01 route/snapshot/protocol behavior-freeze tests remain green as part of the full suite.

### Scope / caveats

- Only `src/db/grimmory_repository.py` and `tests/test_grimmory_repository.py` changed.
- No frontend, routes, response shapes, schema, migrations, sync orchestration, or dependencies touched.
- `replace_grimmory_book_filename` was deliberately left unchanged — it has bespoke case-collision logic beyond a plain upsert and is out of scope for this pilot.

### Next stage

Additional repository consolidation, one repository per PR, only after this PR's checks/Macroscope are reviewed and it is merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `GrimmoryRepository.save_grimmory_book` to use base `_upsert`
> Replaces manual insert-or-update logic in [`grimmory_repository.py`](https://github.com/serabi/pagekeeper/pull/87/files#diff-da86dd7de7d607712c6728beb34c09a89951f8752d4a890ca621ff4def20c8b7) with a single call to `self._upsert`, keyed on `(server_id, filename)`, updating only `title`, `authors`, and `raw_metadata` on conflict. Adds six tests covering insert, update, deduplication, server-scoped uniqueness, and integrity-error recovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f9fd6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->