### PR TITLE
Cleanup 04: consolidate suggestion repository upsert

### DIFF
--- a/src/db/suggestion_repository.py
+++ b/src/db/suggestion_repository.py
@@ -49,27 +49,18 @@ class SuggestionRepository(BaseRepository):
 
     def save_pending_suggestion(self, suggestion):
         """Upsert a suggestion, preserving hidden status if already hidden."""
-        filters = [
-            PendingSuggestion.source_id == suggestion.source_id,
-            PendingSuggestion.source == suggestion.source,
-        ]
-        with self.get_session() as session:
-            existing = session.query(PendingSuggestion).filter(*filters).first()
-            if existing:
-                if existing.status == "hidden" and suggestion.status == "pending":
-                    suggestion.status = "hidden"
-                for attr in ("title", "author", "cover_url", "matches_json", "status"):
-                    setattr(existing, attr, getattr(suggestion, attr))
-                session.flush()
-                session.refresh(existing)
-                session.expunge(existing)
-                return existing
-            else:
-                session.add(suggestion)
-                session.flush()
-                session.refresh(suggestion)
-                session.expunge(suggestion)
-                return suggestion
+        existing = self.get_suggestion(suggestion.source_id, suggestion.source)
+        if existing and existing.status == "hidden" and suggestion.status == "pending":
+            suggestion.status = "hidden"
+        return self._upsert(
+            PendingSuggestion,
+            [
+                PendingSuggestion.source_id == suggestion.source_id,
+                PendingSuggestion.source == suggestion.source,
+            ],
+            suggestion,
+            ["title", "author", "cover_url", "matches_json", "status"],
+        )
 
     def get_pending_suggestion_count(self):
         with self.get_session() as session:

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -1651,6 +1651,103 @@ class TestSuggestionSourceScoping(unittest.TestCase):
         self.assertFalse(self.db_service.suggestion_exists("id1", source="abs"))
         self.assertTrue(self.db_service.suggestion_exists("id1", source="kosync"))
 
+    def test_save_pending_suggestion_insert_returns_persisted_row(self):
+        """First save inserts a row and returns it with the given fields."""
+        suggestion = self.PendingSuggestion(
+            source_id="id1",
+            title="Title",
+            author="Author",
+            cover_url="http://example/c.jpg",
+            matches_json="[1]",
+            source="abs",
+        )
+        saved = self.db_service.save_pending_suggestion(suggestion)
+
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved.title, "Title")
+        self.assertEqual(saved.status, "pending")
+
+        fetched = self.db_service.get_suggestion("id1", source="abs")
+        self.assertIsNotNone(fetched)
+        self.assertEqual(fetched.author, "Author")
+        self.assertEqual(fetched.cover_url, "http://example/c.jpg")
+        self.assertEqual(fetched.matches_json, "[1]")
+
+    def test_save_pending_suggestion_update_mutates_existing_fields(self):
+        """Second save for the same (source_id, source) updates the existing row's fields."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Old", author="A1", matches_json="[1]", source="abs")
+        )
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="New", author="A2", matches_json="[2]", source="abs")
+        )
+
+        fetched = self.db_service.get_suggestion("id1", source="abs")
+        self.assertEqual(fetched.title, "New")
+        self.assertEqual(fetched.author, "A2")
+        self.assertEqual(fetched.matches_json, "[2]")
+
+    def test_save_pending_suggestion_repeated_save_creates_no_duplicate(self):
+        """Repeated saves for the same (source_id, source) keep exactly one row."""
+        from src.db.models import PendingSuggestion
+
+        for _ in range(3):
+            self.db_service.save_pending_suggestion(
+                self.PendingSuggestion(source_id="id1", title="Title", source="abs")
+            )
+
+        with self.db_service.db_manager.get_session() as session:
+            count = (
+                session.query(PendingSuggestion)
+                .filter(PendingSuggestion.source_id == "id1", PendingSuggestion.source == "abs")
+                .count()
+            )
+        self.assertEqual(count, 1)
+
+    def test_save_pending_suggestion_hidden_stays_hidden_when_incoming_pending(self):
+        """A hidden suggestion must remain hidden when re-saved as pending."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Title", source="abs")
+        )
+        self.assertTrue(self.db_service.hide_suggestion("id1", source="abs"))
+
+        saved = self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Updated", status="pending", source="abs")
+        )
+
+        self.assertEqual(saved.status, "hidden")
+        fetched = self.db_service.get_suggestion("id1", source="abs")
+        self.assertEqual(fetched.status, "hidden")
+        self.assertEqual(fetched.title, "Updated")
+
+    def test_save_pending_suggestion_hidden_overwritten_by_incoming_non_pending(self):
+        """An incoming non-pending status replaces an existing hidden status as before."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Title", source="abs")
+        )
+        self.assertTrue(self.db_service.hide_suggestion("id1", source="abs"))
+
+        saved = self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Title", status="ignored", source="abs")
+        )
+
+        self.assertEqual(saved.status, "ignored")
+        self.assertEqual(self.db_service.get_suggestion("id1", source="abs").status, "ignored")
+
+    def test_save_pending_suggestion_hidden_preservation_scoped_by_source(self):
+        """Hidden preservation only applies within the same source, not across sources."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="ABS", source="abs")
+        )
+        self.assertTrue(self.db_service.hide_suggestion("id1", source="abs"))
+
+        kosync_saved = self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="KOSync", status="pending", source="kosync")
+        )
+
+        self.assertEqual(kosync_saved.status, "pending")
+        self.assertEqual(self.db_service.get_suggestion("id1", source="abs").status, "hidden")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Stage 04: suggestion repository consolidation

Fifth backend-cleanup stage. Continues the repository consolidation rollout with exactly one safe slice: `SuggestionRepository.save_pending_suggestion()` now delegates to `BaseRepository._upsert()` instead of carrying its own inline insert/update logic, mirroring the Stage 03 Grimmory pilot.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`

This does **not** merge to `dev`.

### Behavior preserved
- Lookup filters unchanged: `(source_id, source)`.
- Update fields unchanged: `title`, `author`, `cover_url`, `matches_json`, `status`.
- Return value unchanged: the persisted (expunged) `PendingSuggestion` row.
- **Hidden-status rule preserved:** if an existing suggestion is `hidden` and a new save comes in as `pending`, it stays `hidden`. This rule is kept as a small pre-check inside `SuggestionRepository` (reads existing status, mutates the incoming object's status) before delegating to `_upsert`.
- A DB-level unique index on `(source_id, source)` exists (migration `p6q7r8s9t0u1`), so `_upsert`'s `IntegrityError` race-recovery path is applicable here just as in the Grimmory pilot.
- Public method name/signature unchanged; the two service call sites in `suggestion_service.py` are untouched.

### Tests added
Added focused repository tests to `TestSuggestionSourceScoping` in `tests/test_database_service_integration.py`:
- insert path returns the persisted row with the given fields;
- update path mutates existing fields for the same `(source_id, source)`;
- repeated save creates no duplicate row (exactly one row remains);
- `hidden` stays `hidden` when incoming status is `pending`;
- incoming non-pending status (`ignored`) overwrites an existing `hidden` as before;
- hidden preservation is scoped by source (does not bleed across sources).

### Verification
```
git status --short        # only src/db/suggestion_repository.py and tests/test_database_service_integration.py
git branch --show-current # cleanup/04-suggestion-upsert-consolidation
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh tests/test_database_service_integration.py tests/test_suggestion_logic.py tests/test_suggestions_feature.py
                          # 62 passed (was 56; +6 new tests)
./run-tests.sh            # 958 passed, 3 skipped
```

### Caveats
- The refactor adds one extra read (`get_suggestion`) before `_upsert` to evaluate the hidden rule, since `_upsert` does not expose the prior row state. Behavior is identical; this is a tiny internal trade kept inside the repository.
- No DB/fixture files, no frontend, no routes, no snapshots, no schema/migration changes.

### Next
Next stage will be another single-repository consolidation, only after this PR's checks/Macroscope are reviewed and merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `SuggestionRepository.save_pending_suggestion` to use shared upsert helpers
> - Replaces inline session-based query/update/flush logic in `save_pending_suggestion` with calls to `get_suggestion` and `_upsert`, filtering on `(source_id, source)` and updating `["title", "author", "cover_url", "matches_json", "status"]`.
> - Preserves `hidden` status when an incoming suggestion has `pending` status by checking the existing row before delegating to `_upsert`.
> - Adds integration tests covering insert, update, idempotent upsert, hidden-status preservation (scoped by source), and non-pending status overwriting hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ebd3fd8. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->