### PR TITLE
Cleanup 05: consolidate reading goal upsert

### DIFF
--- a/src/db/reading_repository.py
+++ b/src/db/reading_repository.py
@@ -197,21 +197,12 @@ class ReadingRepository(BaseRepository):
             raise ValueError("target_books must be a non-negative integer")
         if target_books < 0:
             raise ValueError("target_books must be a non-negative integer")
-        with self.get_session() as session:
-            existing = session.query(ReadingGoal).filter(ReadingGoal.year == year).first()
-            if existing:
-                existing.target_books = target_books
-                session.flush()
-                session.refresh(existing)
-                session.expunge(existing)
-                return existing
-            else:
-                goal = ReadingGoal(year=year, target_books=target_books)
-                session.add(goal)
-                session.flush()
-                session.refresh(goal)
-                session.expunge(goal)
-                return goal
+        return self._upsert(
+            ReadingGoal,
+            [ReadingGoal.year == year],
+            ReadingGoal(year=year, target_books=target_books),
+            ["target_books"],
+        )
 
     def get_reading_stats(self, year):
         """Backward-compatible lightweight stats summary."""

--- a/tests/test_reading_tracker.py
+++ b/tests/test_reading_tracker.py
@@ -218,6 +218,42 @@ class TestReadingTrackerModels(unittest.TestCase):
         """Returns None for a year with no goal."""
         self.assertIsNone(self.db.get_reading_goal(1999))
 
+    def test_save_goal_no_duplicate_row_on_repeated_save(self):
+        """Repeated saves for the same year update in place, never inserting a duplicate."""
+        from src.db.models import ReadingGoal
+
+        self.db.save_reading_goal(2026, 24)
+        self.db.save_reading_goal(2026, 50)
+        self.db.save_reading_goal(2026, 7)
+
+        with self.db._reading.get_session() as session:
+            rows = session.query(ReadingGoal).filter(ReadingGoal.year == 2026).all()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0].target_books, 7)
+
+    def test_save_goal_inserts_then_updates(self):
+        """First save inserts, second save for the same year updates the same row."""
+        inserted = self.db.save_reading_goal(2026, 24)
+        self.assertEqual(inserted.target_books, 24)
+
+        updated = self.db.save_reading_goal(2026, 30)
+        self.assertEqual(updated.target_books, 30)
+        self.assertEqual(updated.year, 2026)
+        self.assertEqual(self.db.get_reading_goal(2026).target_books, 30)
+
+    def test_save_goal_allows_zero(self):
+        """A target of zero is a valid non-negative goal."""
+        goal = self.db.save_reading_goal(2026, 0)
+        self.assertEqual(goal.target_books, 0)
+
+    def test_save_goal_rejects_invalid_targets(self):
+        """Invalid target_books values raise ValueError without persisting a goal."""
+        for invalid in (None, True, False, 3.5, "12", -1):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    self.db.save_reading_goal(2030, invalid)
+        self.assertIsNone(self.db.get_reading_goal(2030))
+
     # -- Reading stats --
 
     def test_reading_stats(self):


### PR DESCRIPTION
## Stage 05: reading goal repository consolidation

Continues the repository-consolidation rollout. Replaces the inline insert/update branch in `ReadingRepository.save_reading_goal()` with the shared `BaseRepository._upsert(...)` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29` — this does **not** merge to `dev`.

### Behavior preserved
- Validation stays inline and unchanged: rejects `None`, `bool`, non-`int`, and negative `target_books` with `ValueError`; allows `0`.
- Lookup remains by `ReadingGoal.year`; update field remains `target_books`.
- Public signature and return behavior unchanged (returns the flushed/refreshed/expunged `ReadingGoal`).
- Insert path, update-existing-year path, and no-duplicate-row-on-repeated-save all preserved.
- `_upsert` additionally provides an `IntegrityError` retry path, which hardens concurrent saves without changing existing behavior.

### Diff
- `src/db/reading_repository.py` — `save_reading_goal()` now delegates to `_upsert`; the duplicate insert/update block is removed (net -6 lines of logic).
- `tests/test_reading_tracker.py` — added focused tests:
  - `test_save_goal_no_duplicate_row_on_repeated_save` — three saves for the same year leave exactly one row with the latest value.
  - `test_save_goal_inserts_then_updates` — insert then update same year.
  - `test_save_goal_allows_zero` — zero is a valid non-negative goal.
  - `test_save_goal_rejects_invalid_targets` — `None`, `True`, `False`, `3.5`, `"12"`, `-1` all raise `ValueError` and persist nothing.

  Existing `test_save_and_get_goal` and `test_update_goal` already cover the basic insert/update paths.

### Verification (actual results)
```
ruff check src/ tests/ alembic/ scripts/   -> All checks passed!
./run-tests.sh tests/test_reading_tracker.py -> 25 passed
./run-tests.sh                              -> 962 passed, 3 skipped, 17 warnings
```
Stage 01 route/snapshot/protocol behavior-freeze tests remain green (part of the full suite). No DB/fixture files, no frontend files, no routes/response shapes, no schema/migrations touched.

### Caveats
- None. The `date` import warning in `test_reading_tracker.py` is pre-existing and outside this change.

### Next
Next stage is another single-repository consolidation, only after this PR's checks/Macroscope are reviewed and it is merged into the integration branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `ReadingRepository.save_reading_goal` to use `_upsert` helper
> Replaces explicit session-based insert-or-update logic in [`reading_repository.py`](https://github.com/serabi/pagekeeper/pull/89/files#diff-09510a40cdc79c2d86d62bc0c932f66726523b53f4c2125c5dbce128b0a74eb9) with a call to the shared `_upsert` helper, matching on year and updating `target_books`. Adds tests covering idempotent saves, insert-then-update flow, zero as a valid target, and validation rejection of invalid inputs without side effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4925885.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->