### PR TITLE
Cleanup 06: consolidate detected-book upsert

### DIFF
--- a/src/db/base_repository.py
+++ b/src/db/base_repository.py
@@ -87,14 +87,19 @@ class BaseRepository:
             session.expunge(obj)
             return obj
 
-    def _upsert(self, model, lookup_filters, obj, update_attrs):
-        """Find existing by filters and update attrs, or insert new. Returns the saved object."""
+    def _upsert(self, model, lookup_filters, obj, update_attrs, normalize=None):
+        """Find existing by filters and update attrs, or insert new. Returns the saved object.
+
+        When ``normalize`` is provided, it is invoked as ``normalize(obj, existing)``
+        against the row found inside this transaction before update attributes are
+        copied. This lets callers reconcile incoming values against the actual
+        existing row atomically, closing the race where a concurrent insert lands
+        between a caller's pre-read and this transaction's own lookup.
+        """
         with self.get_session() as session:
             existing = session.query(model).filter(*lookup_filters).first()
             if existing:
-                for attr in update_attrs:
-                    if hasattr(obj, attr):
-                        setattr(existing, attr, getattr(obj, attr))
+                self._apply_update(existing, obj, update_attrs, normalize)
                 session.flush()
                 session.refresh(existing)
                 session.expunge(existing)
@@ -107,9 +112,7 @@ class BaseRepository:
                     session.rollback()
                     existing = session.query(model).filter(*lookup_filters).first()
                     if existing:
-                        for attr in update_attrs:
-                            if hasattr(obj, attr):
-                                setattr(existing, attr, getattr(obj, attr))
+                        self._apply_update(existing, obj, update_attrs, normalize)
                         session.flush()
                         session.refresh(existing)
                         session.expunge(existing)
@@ -118,3 +121,11 @@ class BaseRepository:
                 session.refresh(obj)
                 session.expunge(obj)
                 return obj
+
+    @staticmethod
+    def _apply_update(existing, obj, update_attrs, normalize=None):
+        if normalize is not None:
+            normalize(obj, existing)
+        for attr in update_attrs:
+            if hasattr(obj, attr):
+                setattr(existing, attr, getattr(obj, attr))

--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -44,10 +44,12 @@ class DetectedRepository(BaseRepository):
     )
 
     def save_detected_book(self, detected_book):
-        """Upsert a detected book while preserving dismissed status."""
-        existing = self.get_detected_book(detected_book.source_id, detected_book.source)
-        if existing:
-            self._normalize_for_update(detected_book, existing)
+        """Upsert a detected book while preserving dismissed status.
+
+        Normalization runs against the existing row inside the upsert transaction
+        so a concurrent insert of the same (source_id, source) cannot bypass the
+        conditional update rules.
+        """
         return self._upsert(
             DetectedBook,
             [
@@ -56,6 +58,7 @@ class DetectedRepository(BaseRepository):
             ],
             detected_book,
             self.UPSERT_ATTRS,
+            normalize=self._normalize_for_update,
         )
 
     def _normalize_for_update(self, detected_book, existing):

--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -30,48 +30,54 @@ class DetectedRepository(BaseRepository):
                 session.expunge(item)
             return items
 
+    UPSERT_ATTRS = (
+        "title",
+        "author",
+        "cover_url",
+        "matches_json",
+        "device",
+        "ebook_filename",
+        "progress_percentage",
+        "status",
+        "last_seen_at",
+        "first_detected_at",
+    )
+
     def save_detected_book(self, detected_book):
         """Upsert a detected book while preserving dismissed status."""
-        filters = [
-            DetectedBook.source_id == detected_book.source_id,
-            DetectedBook.source == detected_book.source,
-        ]
-        with self.get_session() as session:
-            existing = session.query(DetectedBook).filter(*filters).first()
-            now = datetime.now(UTC)
-            if existing:
-                if existing.status == "dismissed" and detected_book.status == "detected":
-                    detected_book.status = "dismissed"
+        existing = self.get_detected_book(detected_book.source_id, detected_book.source)
+        if existing:
+            self._normalize_for_update(detected_book, existing)
+        return self._upsert(
+            DetectedBook,
+            [
+                DetectedBook.source_id == detected_book.source_id,
+                DetectedBook.source == detected_book.source,
+            ],
+            detected_book,
+            self.UPSERT_ATTRS,
+        )
 
-                if detected_book.title:
-                    existing.title = detected_book.title
-                if detected_book.author:
-                    existing.author = detected_book.author
-                if detected_book.cover_url:
-                    existing.cover_url = detected_book.cover_url
-                if detected_book.matches_json is not None:
-                    existing.matches_json = detected_book.matches_json
-                if detected_book.device:
-                    existing.device = detected_book.device
-                if detected_book.ebook_filename:
-                    existing.ebook_filename = detected_book.ebook_filename
+    def _normalize_for_update(self, detected_book, existing):
+        """Reconcile incoming values against an existing row so an unconditional
+        attribute copy preserves the original conditional update rules."""
+        now = datetime.now(UTC)
 
-                existing.progress_percentage = detected_book.progress_percentage
-                existing.status = detected_book.status
-                existing.last_seen_at = detected_book.last_seen_at or now
-                if existing.first_detected_at is None:
-                    existing.first_detected_at = detected_book.first_detected_at or now
+        if existing.status == "dismissed" and detected_book.status == "detected":
+            detected_book.status = "dismissed"
 
-                session.flush()
-                session.refresh(existing)
-                session.expunge(existing)
-                return existing
+        for attr in ("title", "author", "cover_url", "device", "ebook_filename"):
+            if not getattr(detected_book, attr):
+                setattr(detected_book, attr, getattr(existing, attr))
 
-            session.add(detected_book)
-            session.flush()
-            session.refresh(detected_book)
-            session.expunge(detected_book)
-            return detected_book
+        if detected_book.matches_json is None:
+            detected_book.matches_json = existing.matches_json
+
+        detected_book.last_seen_at = detected_book.last_seen_at or now
+        if existing.first_detected_at is None:
+            detected_book.first_detected_at = detected_book.first_detected_at or now
+        else:
+            detected_book.first_detected_at = existing.first_detected_at
 
     def dismiss_detected_book(self, source_id, source="abs"):
         with self.get_session() as session:

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -286,6 +286,163 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(row.first_detected_at.replace(tzinfo=UTC), original_first)
         self.assertEqual(row.last_seen_at.replace(tzinfo=UTC), new_last)
 
+    def test_save_detected_book_normalizes_against_concurrently_inserted_row(self):
+        """Regression: a row that appears only inside the upsert transaction (not at
+        any earlier pre-read) must still get detected-book normalization applied.
+
+        Simulates the race the old code lost: a writer's pre-read sees no row, then a
+        concurrent insert lands a dismissed row before the update transaction runs.
+        Normalization must run against the row found inside _upsert, so the dismissed
+        status is preserved instead of being clobbered back to 'detected'. The
+        pre-read is simulated as returning None to prove normalization no longer
+        depends on it."""
+        from unittest.mock import patch
+
+        from src.db.detected_repository import DetectedRepository
+        from src.db.models import DetectedBook
+
+        repo = self.db_service._detected
+
+        # A concurrent writer inserts a dismissed row after the (simulated) pre-read.
+        with repo.get_session() as session:
+            session.add(
+                DetectedBook(
+                    source="abs",
+                    source_id="race-update",
+                    title="Existing Title",
+                    author="Existing Author",
+                    progress_percentage=0.1,
+                    status="dismissed",
+                    matches_json='[{"filename": "x.epub"}]',
+                )
+            )
+
+        # Pre-read returns None: the concurrent insert had not yet landed when an
+        # earlier-design caller would have read. The fix must not rely on it.
+        with patch.object(DetectedRepository, "get_detected_book", return_value=None):
+            repo.save_detected_book(
+                DetectedBook(
+                    source="abs",
+                    source_id="race-update",
+                    title="",
+                    author=None,
+                    progress_percentage=0.6,
+                    status="detected",
+                    matches_json=None,
+                )
+            )
+
+        row = self.db_service.get_detected_book("race-update", source="abs")
+        self.assertEqual(row.status, "dismissed")
+        self.assertEqual(row.title, "Existing Title")
+        self.assertEqual(row.author, "Existing Author")
+        self.assertEqual(row.matches_json, '[{"filename": "x.epub"}]')
+        self.assertAlmostEqual(row.progress_percentage, 0.6)
+
+    def test_save_detected_book_normalizes_in_integrity_error_recovery(self):
+        """Regression: the IntegrityError race-recovery branch of _upsert must also
+        apply detected-book normalization.
+
+        Forces _upsert down its insert path (existing lookup returns None) while a
+        concurrent insert already committed the same (source_id, source). The insert
+        raises IntegrityError, recovery re-finds the row, and normalization must run
+        against it so the dismissed status survives."""
+        from src.db.models import DetectedBook
+
+        repo = self.db_service._detected
+
+        # Pre-existing dismissed row that the recovery lookup will find.
+        with repo.get_session() as session:
+            session.add(
+                DetectedBook(
+                    source="abs",
+                    source_id="race-integrity",
+                    title="Existing Title",
+                    author="Existing Author",
+                    progress_percentage=0.1,
+                    status="dismissed",
+                )
+            )
+
+        # Force _upsert's initial lookup to miss so it attempts an insert, hitting
+        # the unique constraint and dropping into IntegrityError recovery.
+        from sqlalchemy.orm import Query
+
+        real_first = Query.first
+        state = {"calls": 0}
+
+        def fake_first(self):
+            # Only intercept the very first lookup inside _upsert for this model.
+            if state["calls"] == 0 and self.column_descriptions and self.column_descriptions[0]["type"] is DetectedBook:
+                state["calls"] += 1
+                return None
+            return real_first(self)
+
+        Query.first = fake_first
+        try:
+            repo.save_detected_book(
+                DetectedBook(
+                    source="abs",
+                    source_id="race-integrity",
+                    title="",
+                    author=None,
+                    progress_percentage=0.7,
+                    status="detected",
+                )
+            )
+        finally:
+            Query.first = real_first
+
+        row = self.db_service.get_detected_book("race-integrity", source="abs")
+        self.assertEqual(row.status, "dismissed")
+        self.assertEqual(row.title, "Existing Title")
+        self.assertEqual(row.author, "Existing Author")
+        self.assertAlmostEqual(row.progress_percentage, 0.7)
+
+    def test_upsert_without_normalize_hook_is_unaffected(self):
+        """Default _upsert callers (no normalize hook) keep blind attribute-copy
+        semantics: the existing-row update path overwrites every update attr."""
+        from src.db.detected_repository import DetectedRepository
+        from src.db.models import DetectedBook
+
+        repo = self.db_service._detected
+
+        with repo.get_session() as session:
+            session.add(
+                DetectedBook(
+                    source="abs",
+                    source_id="no-hook",
+                    title="Existing Title",
+                    author="Existing Author",
+                    progress_percentage=0.1,
+                    status="dismissed",
+                )
+            )
+
+        incoming = DetectedBook(
+            source="abs",
+            source_id="no-hook",
+            title="Replaced",
+            author="Replaced Author",
+            progress_percentage=0.9,
+            status="detected",
+        )
+        repo._upsert(
+            DetectedBook,
+            [
+                DetectedBook.source_id == "no-hook",
+                DetectedBook.source == "abs",
+            ],
+            incoming,
+            DetectedRepository.UPSERT_ATTRS,
+        )
+
+        row = self.db_service.get_detected_book("no-hook", source="abs")
+        self.assertEqual(row.status, "detected")
+        self.assertEqual(row.title, "Replaced")
+        self.assertEqual(row.author, "Replaced Author")
+        self.assertAlmostEqual(row.progress_percentage, 0.9)
+
     def test_delete_book(self):
         """Test deleting a book record with cascading deletes for states and hardcover details."""
         test_abs_id = "test-book-delete"

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -125,6 +125,167 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(resolved.status, "resolved")
         self.assertEqual(still_active.status, "detected")
 
+    def test_save_detected_book_repeat_save_does_not_duplicate(self):
+        """Re-saving the same (source_id, source) updates in place, never inserts a duplicate."""
+        from src.db.models import DetectedBook
+
+        for _ in range(3):
+            self.db_service.save_detected_book(
+                DetectedBook(source="abs", source_id="dup-check", title="Dup", progress_percentage=0.1)
+            )
+
+        all_for_source = [b for b in self.db_service.get_active_detected_books() if b.source_id == "dup-check"]
+        self.assertEqual(len(all_for_source), 1)
+
+    def test_save_detected_book_keeps_dismissed_when_incoming_detected(self):
+        """A dismissed row stays dismissed when a later 'detected' save arrives."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="dismiss-keep", title="Keep", progress_percentage=0.1)
+        )
+        self.assertTrue(self.db_service.dismiss_detected_book("dismiss-keep", source="abs"))
+
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs", source_id="dismiss-keep", title="Keep", progress_percentage=0.4, status="detected"
+            )
+        )
+
+        row = self.db_service.get_detected_book("dismiss-keep", source="abs")
+        self.assertEqual(row.status, "dismissed")
+        self.assertAlmostEqual(row.progress_percentage, 0.4)
+
+    def test_save_detected_book_resolved_status_is_applied(self):
+        """An incoming non-detected status (e.g. resolved) is applied over a detected row."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="status-apply", title="S", progress_percentage=0.1)
+        )
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs", source_id="status-apply", title="S", progress_percentage=0.2, status="resolved"
+            )
+        )
+
+        row = self.db_service.get_detected_book("status-apply", source="abs")
+        self.assertEqual(row.status, "resolved")
+
+    def test_save_detected_book_preserves_truthy_only_fields(self):
+        """Falsy incoming title/author/cover_url/device/ebook_filename do not overwrite existing values."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs",
+                source_id="truthy",
+                title="Original Title",
+                author="Original Author",
+                cover_url="/cover/orig",
+                progress_percentage=0.1,
+                device="OriginalDevice",
+                ebook_filename="orig.epub",
+            )
+        )
+
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs",
+                source_id="truthy",
+                title="",
+                author=None,
+                cover_url="",
+                progress_percentage=0.5,
+                device="",
+                ebook_filename=None,
+            )
+        )
+
+        row = self.db_service.get_detected_book("truthy", source="abs")
+        self.assertEqual(row.title, "Original Title")
+        self.assertEqual(row.author, "Original Author")
+        self.assertEqual(row.cover_url, "/cover/orig")
+        self.assertEqual(row.device, "OriginalDevice")
+        self.assertEqual(row.ebook_filename, "orig.epub")
+        self.assertAlmostEqual(row.progress_percentage, 0.5)
+
+    def test_save_detected_book_updates_truthy_fields(self):
+        """Truthy incoming values for the conditional fields do overwrite existing values."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="truthy-upd", title="Old", progress_percentage=0.1)
+        )
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs",
+                source_id="truthy-upd",
+                title="New",
+                author="New Author",
+                cover_url="/cover/new",
+                progress_percentage=0.2,
+                device="NewDevice",
+                ebook_filename="new.epub",
+            )
+        )
+
+        row = self.db_service.get_detected_book("truthy-upd", source="abs")
+        self.assertEqual(row.title, "New")
+        self.assertEqual(row.author, "New Author")
+        self.assertEqual(row.cover_url, "/cover/new")
+        self.assertEqual(row.device, "NewDevice")
+        self.assertEqual(row.ebook_filename, "new.epub")
+
+    def test_save_detected_book_matches_json_none_does_not_overwrite(self):
+        """matches_json updates only when incoming is not None; None preserves existing matches."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs",
+                source_id="matches",
+                title="M",
+                progress_percentage=0.1,
+                matches_json='[{"filename": "a.epub"}]',
+            )
+        )
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="matches", title="M", progress_percentage=0.2, matches_json=None)
+        )
+        preserved = self.db_service.get_detected_book("matches", source="abs")
+        self.assertEqual(preserved.matches_json, '[{"filename": "a.epub"}]')
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="matches", title="M", progress_percentage=0.3, matches_json="[]")
+        )
+        replaced = self.db_service.get_detected_book("matches", source="abs")
+        self.assertEqual(replaced.matches_json, "[]")
+
+    def test_save_detected_book_last_seen_and_first_detected_behavior(self):
+        """last_seen_at advances to incoming value; first_detected_at stays fixed once set."""
+        from datetime import UTC, datetime
+
+        from src.db.models import DetectedBook
+
+        original_first = datetime(2020, 1, 1, tzinfo=UTC)
+        original_last = datetime(2020, 1, 2, tzinfo=UTC)
+        first = DetectedBook(source="abs", source_id="times", title="T", progress_percentage=0.1)
+        first.first_detected_at = original_first
+        first.last_seen_at = original_last
+        self.db_service.save_detected_book(first)
+
+        new_last = datetime(2021, 6, 15, tzinfo=UTC)
+        second = DetectedBook(source="abs", source_id="times", title="T", progress_percentage=0.2)
+        second.first_detected_at = datetime(2099, 1, 1, tzinfo=UTC)
+        second.last_seen_at = new_last
+        self.db_service.save_detected_book(second)
+
+        row = self.db_service.get_detected_book("times", source="abs")
+        self.assertEqual(row.first_detected_at.replace(tzinfo=UTC), original_first)
+        self.assertEqual(row.last_seen_at.replace(tzinfo=UTC), new_last)
+
     def test_delete_book(self):
         """Test deleting a book record with cascading deletes for states and hardcover details."""
         test_abs_id = "test-book-delete"


### PR DESCRIPTION
## Stage 06: detected-book repository consolidation

Seventh backend-cleanup stage. Continues repository consolidation with exactly one safe slice: `DetectedRepository.save_detected_book()`.

- **Base branch:** `cleanup/backend-cleanup-2026-06-29`
- **This does not merge to `dev`.** Integration branch only; no `dev` target.

### What changed

Replaced the inline insert/update logic in `save_detected_book` with a pre-read normalization step plus `BaseRepository._upsert(...)`, matching the Stage 03-05 consolidation pattern. A small private `_normalize_for_update` helper reconciles incoming values against the existing row so the unconditional attribute copy in `_upsert` reproduces the original conditional rules exactly.

### Behavior preserved (verified equivalent)

- Lookup filters: `(source_id, source)`.
- Existing `dismissed` + incoming `detected` stays `dismissed`.
- `title`, `author`, `cover_url`, `device`, `ebook_filename` update only when incoming value is truthy.
- `matches_json` updates only when incoming is not `None`.
- `progress_percentage` and `status` always update (status after dismissed handling).
- `last_seen_at` becomes incoming value or `now`.
- `first_detected_at` only changes if existing is `None`, then incoming value or `now`; otherwise the existing value is kept.
- Insert path unchanged (new rows keep model `__init__` defaults; normalization only runs when an existing row is found).
- Return value stays persisted/refreshed/expunged.

### Caveat

`_upsert` adds an `IntegrityError` insert-recovery branch that the inline detected path did not have. This is strictly additive robustness (re-reads and updates on a racing unique conflict) and consistent with what Stages 03/04 introduced; it does not alter behavior for any of the documented single-writer cases.

### Tests added

In `tests/test_database_service_integration.py`, focused behavior-preservation tests:

- repeat-save does not duplicate the `(source_id, source)` row;
- dismissed row stays dismissed when incoming status is `detected`;
- incoming non-detected status (e.g. `resolved`) is applied;
- truthy-only fields preserved when incoming is falsy;
- truthy fields updated when incoming is truthy;
- `matches_json=None` does not overwrite existing matches (and `"[]"` does replace);
- `last_seen_at` advances to incoming value; `first_detected_at` stays fixed once set.

Existing `test_save_detected_book_creates_and_updates` and `test_resolve_detected_book_scoped_by_source` (source isolation) remain green.

### Verification

```
git status --short        # only the two intended files
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh            # 969 passed, 3 skipped
./run-tests.sh tests/test_database_service_integration.py tests/test_queue_suggestion.py \
  tests/test_grimmory_only_detection.py tests/test_suggestion_logic.py   # 73 passed
```

No DB/fixture files, no frontend files, no route/snapshot changes, no schema/migration changes. Stage 01 behavior-freeze tests are part of the full-suite pass.

Next stage will be another single-repository consolidation only after this PR's checks/Macroscope are reviewed and merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate detected-book upsert logic into `BaseRepository._upsert` with normalization hook
> - Refactors `DetectedRepository.save_detected_book` to delegate persistence to `BaseRepository._upsert`, removing inline insert/update branching.
> - Adds `BaseRepository._apply_update` static helper and an optional `normalize` parameter to `_upsert` so callers can preprocess objects before attribute copy.
> - Adds `DetectedRepository._normalize_for_update` to enforce conditional field rules: dismissed status persists over incoming 'detected'; falsy title/author/cover_url/device/ebook_filename are not overwritten; `matches_json` is skipped when incoming is `None`; `first_detected_at` is fixed once set.
> - Normalization runs in both the normal update path and the `IntegrityError` recovery path, so concurrent-insert races also preserve correct field values.
> - Adds 10 integration tests covering duplicate prevention, status preservation, truthy-only field rules, timestamp behavior, and recovery path normalization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7042d57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->