### PR TITLE
Cleanup 07: consolidate KoSync document save helper

### DIFF
--- a/src/db/base_repository.py
+++ b/src/db/base_repository.py
@@ -87,6 +87,21 @@ class BaseRepository:
             session.expunge(obj)
             return obj
 
+    def _merge_save(self, obj):
+        """Merge an object by primary key, flush/refresh/expunge and return it.
+
+        Uses ``session.merge`` so a new primary key inserts and an existing one
+        copies every column attribute from ``obj`` onto the loaded row. This
+        differs from ``_upsert``, which only copies a chosen subset of
+        attributes; callers needing merge's copy-all semantics use this helper.
+        """
+        with self.get_session() as session:
+            merged = session.merge(obj)
+            session.flush()
+            session.refresh(merged)
+            session.expunge(merged)
+            return merged
+
     def _upsert(self, model, lookup_filters, obj, update_attrs, normalize=None):
         """Find existing by filters and update attrs, or insert new. Returns the saved object.
 

--- a/src/db/kosync_repository.py
+++ b/src/db/kosync_repository.py
@@ -11,13 +11,8 @@ class KoSyncRepository(BaseRepository):
         return self._get_one(KosyncDocument, KosyncDocument.document_hash == document_hash)
 
     def save_kosync_document(self, doc):
-        with self.get_session() as session:
-            doc.last_updated = datetime.now(UTC)
-            merged = session.merge(doc)
-            session.flush()
-            session.refresh(merged)
-            session.expunge(merged)
-            return merged
+        doc.last_updated = datetime.now(UTC)
+        return self._merge_save(doc)
 
     def get_all_kosync_documents(self):
         return self._get_all(KosyncDocument, order_by=KosyncDocument.last_updated.desc())

--- a/tests/test_kosync_server.py
+++ b/tests/test_kosync_server.py
@@ -132,6 +132,106 @@ class TestKosyncDocument(unittest.TestCase):
         retrieved = self.db_service.get_kosync_document("f" * 32)
         self.assertIsNone(retrieved)
 
+    def test_save_insert_creates_single_document(self):
+        """A first save inserts exactly one row for the hash."""
+        doc = KosyncDocument(document_hash="1" * 32, percentage=0.2)
+        self.db_service.save_kosync_document(doc)
+
+        with self.db_service.get_session() as session:
+            count = session.query(KosyncDocument).filter(KosyncDocument.document_hash == "1" * 32).count()
+        self.assertEqual(count, 1)
+
+    def test_save_update_does_not_duplicate(self):
+        """Re-saving the same detached object updates in place, no duplicate row."""
+        doc = KosyncDocument(document_hash="2" * 32, percentage=0.1)
+        saved = self.db_service.save_kosync_document(doc)
+
+        saved.percentage = 0.8
+        self.db_service.save_kosync_document(saved)
+
+        with self.db_service.get_session() as session:
+            rows = session.query(KosyncDocument).filter(KosyncDocument.document_hash == "2" * 32).all()
+            count = len(rows)
+        self.assertEqual(count, 1)
+        retrieved = self.db_service.get_kosync_document("2" * 32)
+        self.assertAlmostEqual(float(retrieved.percentage), 0.8)
+
+    def test_save_updates_last_updated(self):
+        """last_updated is refreshed on every save."""
+        doc = KosyncDocument(document_hash="3" * 32, percentage=0.1)
+        first = self.db_service.save_kosync_document(doc)
+        first_updated = first.last_updated
+
+        time.sleep(0.01)
+        first.percentage = 0.4
+        second = self.db_service.save_kosync_document(first)
+
+        self.assertGreater(second.last_updated, first_updated)
+
+    def test_save_new_object_with_existing_hash_overwrites_fields(self):
+        """A freshly constructed object with an existing hash overwrites all merged columns.
+
+        merge() copies every column attribute from the incoming object, so
+        fields left at their constructor defaults overwrite the stored values.
+        This characterizes current behavior and must not regress.
+        """
+        original = KosyncDocument(
+            document_hash="4" * 32,
+            percentage=0.5,
+            device="OriginalDevice",
+            progress="/body/div[1]",
+        )
+        self.db_service.save_kosync_document(original)
+
+        # A brand-new object reusing the hash; device/progress left at defaults (None).
+        replacement = KosyncDocument(document_hash="4" * 32, percentage=0.9)
+        self.db_service.save_kosync_document(replacement)
+
+        retrieved = self.db_service.get_kosync_document("4" * 32)
+        self.assertAlmostEqual(float(retrieved.percentage), 0.9)
+        # merge copies the None defaults onto the existing row.
+        self.assertIsNone(retrieved.device)
+        self.assertIsNone(retrieved.progress)
+
+    def test_save_new_object_with_existing_hash_overwrites_first_seen(self):
+        """first_seen is overwritten when a new object reuses an existing hash.
+
+        __init__ always stamps first_seen, and merge() copies it onto the
+        existing row. Saving the SAME detached object back, by contrast,
+        preserves first_seen. Both branches are characterized here so a future
+        switch to _upsert (which would preserve first_seen) is caught.
+        """
+        original = KosyncDocument(document_hash="5" * 32, percentage=0.5)
+        saved = self.db_service.save_kosync_document(original)
+        original_first_seen = saved.first_seen
+
+        # Re-saving the same object preserves first_seen (no new __init__ stamp).
+        saved.percentage = 0.6
+        again = self.db_service.save_kosync_document(saved)
+        self.assertEqual(again.first_seen, original_first_seen)
+
+        # A new object reusing the hash overwrites first_seen with its own stamp.
+        # The DB column is timezone-naive, so compare naive wall-clock values:
+        # the stored first_seen tracks the replacement's stamp, not the original's.
+        time.sleep(0.01)
+        replacement = KosyncDocument(document_hash="5" * 32, percentage=0.7)
+        replacement_first_seen = replacement.first_seen.replace(tzinfo=None)
+        merged = self.db_service.save_kosync_document(replacement)
+        self.assertEqual(merged.first_seen.replace(tzinfo=None), replacement_first_seen)
+        self.assertNotEqual(
+            merged.first_seen.replace(tzinfo=None),
+            original_first_seen.replace(tzinfo=None),
+        )
+
+    def test_save_returns_expunged_detached_instance(self):
+        """Returned object is detached (expunged) yet has its attributes loaded."""
+        doc = KosyncDocument(document_hash="6" * 32, percentage=0.3)
+        saved = self.db_service.save_kosync_document(doc)
+
+        # Accessing attributes after the session closes must not raise (expunged + refreshed).
+        self.assertEqual(saved.document_hash, "6" * 32)
+        self.assertAlmostEqual(float(saved.percentage), 0.3)
+
 
 class _KosyncMockContainer:
     """Lightweight mock container to avoid importing epubcfi (Docker-only)."""


### PR DESCRIPTION
## Stage 07: consolidate KoSync document save helper

Backend cleanup Stage 07. Base branch: `cleanup/backend-cleanup-2026-06-29`.

**This does not merge to `dev`.**

### What changed

- Added `BaseRepository._merge_save(obj)` encapsulating the repeated session boilerplate: `session.merge(obj)` -> `flush` -> `refresh(merged)` -> `expunge(merged)` -> return merged.
- `KoSyncRepository.save_kosync_document()` now stamps `doc.last_updated = datetime.now(UTC)` and delegates to `_merge_save`.

### Behavior preserved (exactly)

`session.merge()` semantics are unchanged, and intentionally NOT collapsed into `_upsert`:

- **Insert path** (new `document_hash`): merge inserts a new row, copying all attributes from the incoming object.
- **Update path** (existing `document_hash`): merge loads the existing row by primary key and copies **every** column attribute from the incoming object onto it — this is `merge`'s copy-all behavior, which differs from `_upsert` (copies only a chosen subset). For this reason `merge` was kept; replacing it with `_upsert` would change `first_seen` and nullable-field handling.
- `last_updated` is still set immediately before the save.
- Return value is still refreshed and expunged (detached but fully loaded).
- Public method signature and all call sites are unchanged.

Characterized merge-specific edge cases:

- Re-saving the **same** detached object preserves `first_seen` (no new constructor stamp).
- Constructing a **new** object with an existing `document_hash` **overwrites** `first_seen` and any nullable fields left at constructor defaults (e.g. `device`, `progress` -> `None`), because `merge` copies all columns.

### Tests added (in `tests/test_kosync_server.py::TestKosyncDocument`)

- `test_save_insert_creates_single_document`
- `test_save_update_does_not_duplicate`
- `test_save_updates_last_updated`
- `test_save_new_object_with_existing_hash_overwrites_fields`
- `test_save_new_object_with_existing_hash_overwrites_first_seen`
- `test_save_returns_expunged_detached_instance`

Note: the DB column is timezone-naive (SQLite), so datetime assertions compare naive wall-clock values.

### Verification

```
git status --short                       # clean (only the 3 files below)
git branch --show-current                # cleanup/07-kosync-merge-save-helper
ruff check src/ tests/ alembic/ scripts/ # All checks passed!
./run-tests.sh tests/test_kosync_server.py tests/test_kosync_service.py tests/test_kosync_protocol_freeze.py
                                         # 61 passed
./run-tests.sh                           # 978 passed, 3 skipped
```

Files changed:
- `src/db/base_repository.py`
- `src/db/kosync_repository.py`
- `tests/test_kosync_server.py`

No DB/fixture files, no frontend, no routes/snapshots, no migrations, no dependency changes.

### Caveats

- The pre-existing `datetime.utcnow()` deprecation warnings and unused imports in `test_kosync_server.py` were left untouched (out of scope).

### Next

Next stage will be another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate KoSync document save logic into `BaseRepository._merge_save`
> - Extracts the inline `session.merge/flush/refresh/expunge` sequence from `KoSyncRepository.save_kosync_document` into a new `BaseRepository._merge_save` helper in [base_repository.py](https://github.com/serabi/pagekeeper/pull/91/files#diff-b524b275e70582a0f190cb4b5ed9a7fdeac1da4b366ee7736920f66da9433064).
> - `_merge_save` differs from `_upsert` by overwriting all column attributes on existing rows rather than selectively updating them.
> - Adds tests in [test_kosync_server.py](https://github.com/serabi/pagekeeper/pull/91/files#diff-f9275d5698f4a29807b1beb8a92dba2ebe62bd960f7ed2c875a6fe1785c5a876) covering insert, update, deduplication, `last_updated` refresh, merge-overwrite semantics, and detached instance behavior.
> - Risk: merge semantics mean saving a newly constructed object with an existing primary key will overwrite all fields, including setting previously populated fields to `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e2caf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->