### PR TITLE
Cleanup 08: consolidate KoSync link mutations

### DIFF
--- a/src/db/kosync_repository.py
+++ b/src/db/kosync_repository.py
@@ -24,25 +24,22 @@ class KoSyncRepository(BaseRepository):
             order_by=KosyncDocument.last_updated.desc(),
         )
 
-    def link_kosync_document(self, document_hash, book_id, abs_id=None):
+    def _mutate_kosync_link(self, document_hash, *, linked_book_id, linked_abs_id):
+        """Set link fields on an existing document. Returns True if it existed."""
         with self.get_session() as session:
             doc = session.query(KosyncDocument).filter(KosyncDocument.document_hash == document_hash).first()
             if doc:
-                doc.linked_book_id = book_id
-                doc.linked_abs_id = abs_id
+                doc.linked_book_id = linked_book_id
+                doc.linked_abs_id = linked_abs_id
                 doc.last_updated = datetime.now(UTC)
                 return True
             return False
 
+    def link_kosync_document(self, document_hash, book_id, abs_id=None):
+        return self._mutate_kosync_link(document_hash, linked_book_id=book_id, linked_abs_id=abs_id)
+
     def unlink_kosync_document(self, document_hash):
-        with self.get_session() as session:
-            doc = session.query(KosyncDocument).filter(KosyncDocument.document_hash == document_hash).first()
-            if doc:
-                doc.linked_abs_id = None
-                doc.linked_book_id = None
-                doc.last_updated = datetime.now(UTC)
-                return True
-            return False
+        return self._mutate_kosync_link(document_hash, linked_book_id=None, linked_abs_id=None)
 
     def delete_kosync_document(self, document_hash):
         return self._delete_one(KosyncDocument, KosyncDocument.document_hash == document_hash)

--- a/tests/test_kosync_server.py
+++ b/tests/test_kosync_server.py
@@ -232,6 +232,87 @@ class TestKosyncDocument(unittest.TestCase):
         self.assertEqual(saved.document_hash, "6" * 32)
         self.assertAlmostEqual(float(saved.percentage), 0.3)
 
+    def test_link_sets_both_book_id_and_abs_id(self):
+        """Linking an existing document sets linked_book_id and linked_abs_id exactly as passed."""
+        doc = KosyncDocument(document_hash="7" * 32, percentage=0.3)
+        self.db_service.save_kosync_document(doc)
+        book = Book(abs_id="book-link", title="Link Book")
+        book = self.db_service.save_book(book)
+
+        result = self.db_service.link_kosync_document("7" * 32, book.id, "abs-7")
+
+        self.assertTrue(result)
+        retrieved = self.db_service.get_kosync_document("7" * 32)
+        self.assertEqual(retrieved.linked_book_id, book.id)
+        self.assertEqual(retrieved.linked_abs_id, "abs-7")
+
+    def test_link_with_abs_id_none_sets_abs_id_none(self):
+        """Linking with abs_id=None stores linked_abs_id as None while setting the book id."""
+        doc = KosyncDocument(document_hash="8" * 32, percentage=0.3, linked_abs_id="stale-abs")
+        self.db_service.save_kosync_document(doc)
+        book = Book(abs_id="book-none", title="None Book")
+        book = self.db_service.save_book(book)
+
+        result = self.db_service.link_kosync_document("8" * 32, book.id)
+
+        self.assertTrue(result)
+        retrieved = self.db_service.get_kosync_document("8" * 32)
+        self.assertEqual(retrieved.linked_book_id, book.id)
+        self.assertIsNone(retrieved.linked_abs_id)
+
+    def test_link_missing_document_returns_false_and_creates_nothing(self):
+        """Linking a missing hash returns False and inserts no row."""
+        result = self.db_service.link_kosync_document("9" * 32, 12345, "abs-missing")
+
+        self.assertFalse(result)
+        self.assertIsNone(self.db_service.get_kosync_document("9" * 32))
+        with self.db_service.get_session() as session:
+            count = session.query(KosyncDocument).filter(KosyncDocument.document_hash == "9" * 32).count()
+        self.assertEqual(count, 0)
+
+    def test_unlink_clears_both_link_fields(self):
+        """Unlinking an existing document clears linked_book_id and linked_abs_id."""
+        doc = KosyncDocument(document_hash="a" * 31 + "0", percentage=0.3)
+        self.db_service.save_kosync_document(doc)
+        book = Book(abs_id="book-unlink", title="Unlink Book")
+        book = self.db_service.save_book(book)
+        self.db_service.link_kosync_document("a" * 31 + "0", book.id, "abs-unlink")
+
+        result = self.db_service.unlink_kosync_document("a" * 31 + "0")
+
+        self.assertTrue(result)
+        retrieved = self.db_service.get_kosync_document("a" * 31 + "0")
+        self.assertIsNone(retrieved.linked_book_id)
+        self.assertIsNone(retrieved.linked_abs_id)
+
+    def test_unlink_missing_document_returns_false_and_creates_nothing(self):
+        """Unlinking a missing hash returns False and inserts no row."""
+        result = self.db_service.unlink_kosync_document("b" * 31 + "0")
+
+        self.assertFalse(result)
+        self.assertIsNone(self.db_service.get_kosync_document("b" * 31 + "0"))
+        with self.db_service.get_session() as session:
+            count = session.query(KosyncDocument).filter(KosyncDocument.document_hash == "b" * 31 + "0").count()
+        self.assertEqual(count, 0)
+
+    def test_link_and_unlink_update_last_updated(self):
+        """last_updated is refreshed on both link and unlink of an existing document."""
+        doc = KosyncDocument(document_hash="c" * 31 + "0", percentage=0.3)
+        saved = self.db_service.save_kosync_document(doc)
+        baseline = saved.last_updated
+        book = Book(abs_id="book-ts", title="Timestamp Book")
+        book = self.db_service.save_book(book)
+
+        time.sleep(0.01)
+        self.db_service.link_kosync_document("c" * 31 + "0", book.id, "abs-ts")
+        after_link = self.db_service.get_kosync_document("c" * 31 + "0").last_updated
+        self.assertGreater(after_link, baseline)
+
+        time.sleep(0.01)
+        self.db_service.unlink_kosync_document("c" * 31 + "0")
+        after_unlink = self.db_service.get_kosync_document("c" * 31 + "0").last_updated
+        self.assertGreater(after_unlink, after_link)
+
 
 class _KosyncMockContainer:
     """Lightweight mock container to avoid importing epubcfi (Docker-only)."""


### PR DESCRIPTION
## Stage 08: consolidate KoSync link mutations

Ninth cleanup-stage PR for the backend cleanup effort. Base branch is `cleanup/backend-cleanup-2026-06-29`. **This does not merge to `dev`.**

### What changed
Extracted the duplicated query/mutate/timestamp/boolean-return boilerplate shared by `link_kosync_document()` and `unlink_kosync_document()` in `src/db/kosync_repository.py` into a single private helper:

```python
def _mutate_kosync_link(self, document_hash, *, linked_book_id, linked_abs_id):
    with self.get_session() as session:
        doc = session.query(KosyncDocument).filter(KosyncDocument.document_hash == document_hash).first()
        if doc:
            doc.linked_book_id = linked_book_id
            doc.linked_abs_id = linked_abs_id
            doc.last_updated = datetime.now(UTC)
            return True
        return False
```

`link_kosync_document()` and `unlink_kosync_document()` keep their exact public signatures and now delegate to the helper.

### Behavior preserved (exactly)
- link returns `True` only when the document exists; `False` (and creates nothing) when the hash is missing
- link sets both `linked_book_id` and `linked_abs_id` exactly as passed, including `abs_id=None`
- unlink returns `True` only when the document exists; `False` (and creates nothing) when missing
- unlink clears both `linked_abs_id` and `linked_book_id`
- both refresh `last_updated` only on existing rows
- both commit via the `get_session()` context manager
- neither expunges/returns a document object; they return bool only
- public method names / call sites unchanged (DatabaseService resolves these via `__getattr__` delegation; the names stay on `KoSyncRepository`)

### Tests added
New characterization tests in `tests/test_kosync_server.py::TestKosyncDocument`:
- link existing document sets `linked_book_id` and `linked_abs_id`
- link with `abs_id=None` stores `linked_abs_id` as `None` (over a previously-set value)
- link missing hash returns `False` and inserts no row
- unlink existing document clears both link fields
- unlink missing hash returns `False` and inserts no row
- `last_updated` is refreshed on both link and unlink of an existing document

### Verification
```
git status --short        # only src/db/kosync_repository.py, tests/test_kosync_server.py
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh tests/test_kosync_server.py tests/test_kosync_service.py tests/test_kosync_protocol_freeze.py
                          # 67 passed, 2 warnings (pre-existing)
./run-tests.sh            # 984 passed, 3 skipped, 17 warnings (pre-existing)
```

Stage 01 KoSync protocol freeze tests remain green. No DB/fixture files, frontend files, routes, response shapes, schema, or migrations changed.

### Caveats
None. `save_kosync_document()` (Stage 07 merge-save) and `delete_kosync_document()` were left untouched.

### Next
Next stage will be another bounded repository consolidation, only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `KoSyncRepository` link and unlink mutations into a shared helper
> - Extracts a private `_mutate_kosync_link` helper in [kosync_repository.py](https://github.com/serabi/pagekeeper/pull/92/files#diff-ddf2b7bbf66fdcc61525d0ce0197125954436af2357ea4baff1bba4be07a0315) that handles session management, document lookup, field updates, and `last_updated` timestamping.
> - Refactors `link_kosync_document` and `unlink_kosync_document` to delegate to the helper, reducing duplicated inline session logic.
> - Adds six unit tests in [test_kosync_server.py](https://github.com/serabi/pagekeeper/pull/92/files#diff-f9275d5698f4a29807b1beb8a92dba2ebe62bd960f7ed2c875a6fe1785c5a876) covering linking, unlinking, missing-document no-op behavior, and `last_updated` progression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c4a0b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->