### PR TITLE
Cleanup 09: consolidate detected status mutations

### DIFF
--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -82,7 +82,12 @@ class DetectedRepository(BaseRepository):
         else:
             detected_book.first_detected_at = existing.first_detected_at
 
-    def dismiss_detected_book(self, source_id, source="abs"):
+    def _set_detected_status(self, source_id, source, status):
+        """Set the status of a matching detected book, refreshing last_seen_at.
+
+        Returns True only when a row scoped by (source_id, source) exists; returns
+        False without inserting anything when none does.
+        """
         with self.get_session() as session:
             detected = (
                 session.query(DetectedBook)
@@ -94,25 +99,15 @@ class DetectedRepository(BaseRepository):
             )
             if not detected:
                 return False
-            detected.status = "dismissed"
+            detected.status = status
             detected.last_seen_at = datetime.now(UTC)
             return True
 
+    def dismiss_detected_book(self, source_id, source="abs"):
+        return self._set_detected_status(source_id, source, "dismissed")
+
     def resolve_detected_book(self, source_id, source="abs"):
-        with self.get_session() as session:
-            detected = (
-                session.query(DetectedBook)
-                .filter(
-                    DetectedBook.source_id == source_id,
-                    DetectedBook.source == source,
-                )
-                .first()
-            )
-            if not detected:
-                return False
-            detected.status = "resolved"
-            detected.last_seen_at = datetime.now(UTC)
-            return True
+        return self._set_detected_status(source_id, source, "resolved")
 
     def get_all_ebook_filenames(self):
         """Get all ebook filenames from detected books with matches."""

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -125,6 +125,84 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(resolved.status, "resolved")
         self.assertEqual(still_active.status, "detected")
 
+    def test_dismiss_detected_book_sets_status_on_existing_row(self):
+        """Dismissing an existing detected book sets status to dismissed and returns True."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="dismiss-existing", title="D", progress_percentage=0.1)
+        )
+
+        self.assertTrue(self.db_service.dismiss_detected_book("dismiss-existing", source="abs"))
+
+        row = self.db_service.get_detected_book("dismiss-existing", source="abs")
+        self.assertEqual(row.status, "dismissed")
+
+    def test_resolve_detected_book_sets_status_on_existing_row(self):
+        """Resolving an existing detected book sets status to resolved and returns True."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="resolve-existing", title="R", progress_percentage=0.1)
+        )
+
+        self.assertTrue(self.db_service.resolve_detected_book("resolve-existing", source="abs"))
+
+        row = self.db_service.get_detected_book("resolve-existing", source="abs")
+        self.assertEqual(row.status, "resolved")
+
+    def test_dismiss_detected_book_missing_returns_false_and_creates_nothing(self):
+        """Dismissing a missing detected book returns False without inserting a row."""
+        self.assertFalse(self.db_service.dismiss_detected_book("dismiss-missing", source="abs"))
+        self.assertIsNone(self.db_service.get_detected_book("dismiss-missing", source="abs"))
+
+    def test_resolve_detected_book_missing_returns_false_and_creates_nothing(self):
+        """Resolving a missing detected book returns False without inserting a row."""
+        self.assertFalse(self.db_service.resolve_detected_book("resolve-missing", source="abs"))
+        self.assertIsNone(self.db_service.get_detected_book("resolve-missing", source="abs"))
+
+    def test_dismiss_detected_book_scoped_by_source(self):
+        """Dismissing a detected book only affects the matching source row."""
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(source="abs", source_id="dismiss-shared", title="ABS", progress_percentage=0.2)
+        )
+        self.db_service.save_detected_book(
+            DetectedBook(source="kosync", source_id="dismiss-shared", title="KOSync", progress_percentage=0.3)
+        )
+
+        self.assertTrue(self.db_service.dismiss_detected_book("dismiss-shared", source="abs"))
+
+        dismissed = self.db_service.get_detected_book("dismiss-shared", source="abs")
+        still_active = self.db_service.get_detected_book("dismiss-shared", source="kosync")
+        self.assertEqual(dismissed.status, "dismissed")
+        self.assertEqual(still_active.status, "detected")
+
+    def test_dismiss_and_resolve_advance_last_seen_at(self):
+        """Both dismiss and resolve refresh last_seen_at on the existing row."""
+        from datetime import UTC, datetime
+
+        from src.db.models import DetectedBook
+
+        old_seen = datetime(2020, 1, 1, tzinfo=UTC)
+
+        dismiss_book = DetectedBook(source="abs", source_id="dismiss-seen", title="D", progress_percentage=0.1)
+        dismiss_book.last_seen_at = old_seen
+        self.db_service.save_detected_book(dismiss_book)
+
+        resolve_book = DetectedBook(source="abs", source_id="resolve-seen", title="R", progress_percentage=0.1)
+        resolve_book.last_seen_at = old_seen
+        self.db_service.save_detected_book(resolve_book)
+
+        self.assertTrue(self.db_service.dismiss_detected_book("dismiss-seen", source="abs"))
+        self.assertTrue(self.db_service.resolve_detected_book("resolve-seen", source="abs"))
+
+        dismissed = self.db_service.get_detected_book("dismiss-seen", source="abs")
+        resolved = self.db_service.get_detected_book("resolve-seen", source="abs")
+        self.assertGreater(dismissed.last_seen_at.replace(tzinfo=UTC), old_seen)
+        self.assertGreater(resolved.last_seen_at.replace(tzinfo=UTC), old_seen)
+
     def test_save_detected_book_repeat_save_does_not_duplicate(self):
         """Re-saving the same (source_id, source) updates in place, never inserts a duplicate."""
         from src.db.models import DetectedBook


### PR DESCRIPTION
## Stage 09: consolidate detected status mutations

This is Stage 09 detected status mutation consolidation for the backend cleanup.

- **Base branch:** `cleanup/backend-cleanup-2026-06-29`
- This does **not** merge to `dev`.

### What changed

Extracted a private `_set_detected_status(source_id, source, status)` helper in `DetectedRepository`. Both `dismiss_detected_book()` and `resolve_detected_book()` now delegate to it, removing the duplicated query / status assignment / `last_seen_at` refresh / bool-return boilerplate. Public method signatures are unchanged.

### Behavior preserved

- dismiss returns `True` only when a matching `(source_id, source)` row exists; otherwise `False` and creates nothing.
- resolve returns `True` only when a matching `(source_id, source)` row exists; otherwise `False` and creates nothing.
- dismiss sets `status="dismissed"`; resolve sets `status="resolved"`.
- both update `last_seen_at` only on existing rows.
- both scoped exactly by `source_id` and `source`, committed via `get_session()`.
- both return bool only; neither expunges or returns a document object.
- `save_detected_book()` and its Stage 06 `_upsert(normalize=...)` behavior untouched.

### Tests added

New focused characterization tests in `tests/test_database_service_integration.py`:

- dismiss existing row sets `status="dismissed"`
- resolve existing row sets `status="resolved"`
- dismiss missing row returns `False`, creates no row
- resolve missing row returns `False`, creates no row
- dismiss source scoping (same `source_id`, different `source`)
- `last_seen_at` advances on both dismiss and resolve

### Verification

```
git status --short            # only the two intended files
git branch --show-current     # cleanup/09-detected-status-helper
ruff check src/ tests/ alembic/ scripts/    # All checks passed!
./run-tests.sh tests/test_database_service_integration.py tests/test_queue_suggestion.py \
  tests/test_grimmory_only_detection.py tests/test_suggestion_logic.py    # 82 passed
./run-tests.sh                # 990 passed, 3 skipped (pre-existing)
```

No DB/fixture files, frontend files, routes, response shapes, schema, or migrations changed.

### Caveats

None. Pure repository-internal consolidation with behavior-freeze tests.

### Next

Next stage will be another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `dismiss_detected_book` and `resolve_detected_book` into a shared `_set_detected_status` helper
> Introduces `_set_detected_status` in [`detected_repository.py`](https://github.com/serabi/pagekeeper/pull/93/files#diff-563c97c1e42930502ec6842fb3ffdba645b32995bcc36a1a07dc3d929c4b900d), a private helper that looks up a `DetectedBook` by `(source_id, source)`, sets its status, and refreshes `last_seen_at` to the current UTC time. Both `dismiss_detected_book` and `resolve_detected_book` now delegate to this helper and return its boolean result (`True` if the row existed, `False` otherwise). Integration tests cover status changes, missing-row behavior, source scoping, and `last_seen_at` advancement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4d0ecf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->