### PR TITLE
Cleanup 10: consolidate Storyteller getters

### DIFF
--- a/src/db/storyteller_repository.py
+++ b/src/db/storyteller_repository.py
@@ -31,18 +31,15 @@ class StorytellerRepository(BaseRepository):
 
     def get_active_storyteller_submission_by_book_id(self, book_id):
         with self.get_session() as session:
-            sub = (
+            query = (
                 session.query(StorytellerSubmission)
                 .filter(
                     StorytellerSubmission.book_id == book_id,
                     StorytellerSubmission.status.in_(["queued", "processing"]),
                 )
                 .order_by(StorytellerSubmission.submitted_at.desc())
-                .first()
             )
-            if sub:
-                session.expunge(sub)
-            return sub
+            return self._query_and_expunge(session, query, one=True)
 
     def update_storyteller_submission_status(
         self, submission_id, status, last_checked_at=None, storyteller_uuid=None, submission_dir=None
@@ -61,15 +58,12 @@ class StorytellerRepository(BaseRepository):
 
     def get_storyteller_submission_by_book_id(self, book_id):
         with self.get_session() as session:
-            sub = (
+            query = (
                 session.query(StorytellerSubmission)
                 .filter(StorytellerSubmission.book_id == book_id)
                 .order_by(StorytellerSubmission.submitted_at.desc())
-                .first()
             )
-            if sub:
-                session.expunge(sub)
-            return sub
+            return self._query_and_expunge(session, query, one=True)
 
     def get_all_storyteller_submissions_latest(self):
         """Get the most recent submission per book (for dashboard bulk display).

--- a/tests/test_storyteller_repository.py
+++ b/tests/test_storyteller_repository.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+
+import pytest
+
+from src.db.models import Base, Book, DatabaseManager, StorytellerSubmission
+from src.db.storyteller_repository import StorytellerRepository
+
+
+@pytest.fixture()
+def repository(tmp_path):
+    manager = DatabaseManager(str(tmp_path / "storyteller_repository.db"))
+    Base.metadata.create_all(manager.engine)
+    try:
+        yield StorytellerRepository(manager)
+    finally:
+        manager.close()
+
+
+def _make_book(repository, book_id):
+    with repository.get_session() as session:
+        book = Book(abs_id=f"abs-{book_id}", title=f"Book {book_id}")
+        book.id = book_id
+        session.add(book)
+
+
+def _insert_submission(repository, book_id, status, submitted_at):
+    with repository.get_session() as session:
+        submission = StorytellerSubmission(abs_id=f"abs-{book_id}", status=status, book_id=book_id)
+        submission.submitted_at = submitted_at
+        session.add(submission)
+
+
+def _ts(day):
+    # SQLite stores naive datetimes; use naive values so equality checks hold
+    # after the row round-trips through the database.
+    return datetime(2026, 1, day)
+
+
+def test_active_getter_returns_newest_queued_or_processing_row(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "queued", _ts(1))
+    _insert_submission(repository, 1, "processing", _ts(3))
+    _insert_submission(repository, 1, "queued", _ts(2))
+
+    sub = repository.get_active_storyteller_submission_by_book_id(1)
+
+    assert sub is not None
+    assert sub.status == "processing"
+    assert sub.submitted_at == _ts(3)
+
+
+def test_active_getter_ignores_terminal_statuses(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "ready", _ts(5))
+    _insert_submission(repository, 1, "failed", _ts(4))
+    _insert_submission(repository, 1, "superseded", _ts(3))
+    _insert_submission(repository, 1, "queued", _ts(1))
+
+    sub = repository.get_active_storyteller_submission_by_book_id(1)
+
+    assert sub is not None
+    assert sub.status == "queued"
+
+
+def test_active_getter_returns_none_when_only_terminal_rows_exist(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "ready", _ts(2))
+    _insert_submission(repository, 1, "failed", _ts(1))
+
+    assert repository.get_active_storyteller_submission_by_book_id(1) is None
+
+
+def test_active_getter_returns_none_for_missing_book(repository):
+    assert repository.get_active_storyteller_submission_by_book_id(999) is None
+
+
+def test_latest_getter_returns_newest_row_regardless_of_status(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "queued", _ts(1))
+    _insert_submission(repository, 1, "ready", _ts(4))
+    _insert_submission(repository, 1, "processing", _ts(2))
+
+    sub = repository.get_storyteller_submission_by_book_id(1)
+
+    assert sub is not None
+    assert sub.status == "ready"
+    assert sub.submitted_at == _ts(4)
+
+
+def test_latest_getter_returns_none_for_missing_book(repository):
+    assert repository.get_storyteller_submission_by_book_id(999) is None
+
+
+def test_getters_filter_by_book_id_exactly(repository):
+    _make_book(repository, 1)
+    _make_book(repository, 2)
+    _insert_submission(repository, 1, "queued", _ts(1))
+    _insert_submission(repository, 2, "processing", _ts(5))
+
+    active = repository.get_active_storyteller_submission_by_book_id(1)
+    latest = repository.get_storyteller_submission_by_book_id(1)
+
+    assert active is not None and active.book_id == 1
+    assert latest is not None and latest.book_id == 1
+
+
+def test_returned_submission_is_detached_after_session_closes(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "processing", _ts(1))
+
+    sub = repository.get_active_storyteller_submission_by_book_id(1)
+
+    # Accessing attributes after the session is closed must not raise
+    # (the row is expunged/detached, with values already loaded).
+    assert sub.book_id == 1
+    assert sub.status == "processing"


### PR DESCRIPTION
This is **Stage 10** (Storyteller getter consolidation) of the backend cleanup.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.** The integration branch stays open until the whole cleanup is complete and approved.

## What changed

Consolidated the ordered single-row query/expunge boilerplate in `StorytellerRepository` by using the existing `BaseRepository._query_and_expunge(session, query, one=True)` helper inside two getters only:

- `get_active_storyteller_submission_by_book_id(book_id)`
- `get_storyteller_submission_by_book_id(book_id)`

Each now builds the same SQLAlchemy query as before and returns `self._query_and_expunge(session, query, one=True)` instead of a manual `.first()` + `if sub: session.expunge(sub)`.

## Behavior preserved (exactly)

`_query_and_expunge(..., one=True)` runs `query.first()`, expunges the row only when truthy, and returns the object or `None` — identical to the prior inline code.

- **Active getter:** filters by `book_id` exactly; includes only `queued`/`processing`; returns most recent `submitted_at`; `None` when no active row; returned row expunged/detached; signature unchanged.
- **Latest getter:** filters by `book_id` exactly; any status; returns most recent `submitted_at`; `None` when no row; returned row expunged/detached; signature unchanged.

Out of scope and untouched: `save_storyteller_submission()` supersede-and-insert, `update_storyteller_submission_status()`, `get_all_storyteller_submissions_latest()`, and all Storyteller service/client/background-job behavior. No routes, response shapes, schema, or frontend changes. `DatabaseService` delegates dynamically via `__getattr__`, so no passthrough edits were needed.

## Tests added

New `tests/test_storyteller_repository.py` (integration-style, follows the existing `test_grimmory_repository.py` fixture pattern with `DatabaseManager` + `Base.metadata.create_all`):

- active getter returns newest `queued`/`processing` row
- active getter ignores terminal statuses (`ready`/`failed`/`superseded`)
- active getter returns `None` when only terminal rows exist
- active/latest getters return `None` for a missing book
- latest getter returns newest row regardless of status
- both getters filter by `book_id` exactly
- returned submission is detached/usable after the session closes

## Verification

```
git status --short          -> only the two intended files
git branch --show-current   -> cleanup/10-storyteller-getter-helper
ruff check src/ tests/ alembic/ scripts/   -> All checks passed!
./run-tests.sh tests/test_storyteller_repository.py        -> 8 passed
storyteller + background-job + dashboard + db-integration + book-intake
                                                          -> 146 passed
./run-tests.sh (full suite) -> 998 passed, 3 skipped
```

No DB/fixture files staged; no frontend files changed; no route/snapshot changes.

## Caveats

- SQLite stores naive datetimes, so the test uses naive `submitted_at` values for exact equality after round-trip; ordering/selection assertions are unaffected.
- Pre-existing `datetime.utcnow()` deprecation warnings in `test_storyteller_submission.py` are unrelated to this change.

## Next

The next stage will be another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged. Do not merge to `dev`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `StorytellerRepository` getters to use shared `_query_and_expunge` helper
> - Refactors `get_active_storyteller_submission_by_book_id` and `get_storyteller_submission_by_book_id` in [storyteller_repository.py](https://github.com/serabi/pagekeeper/pull/94/files#diff-e034cf3fc09d93cf2e8861f377d449a34d121939d5e4229a7d8f72810ecc15fa) to delegate result retrieval and session expunge to the shared `_query_and_expunge` helper instead of calling `.first()` and expunging manually.
> - Adds a new test module [test_storyteller_repository.py](https://github.com/serabi/pagekeeper/pull/94/files#diff-ea6306a33eb39d85e51b73dd8b0ed68e0cd4ac51d4378a5495572886a8c1419a) covering both getters, including active-status filtering, ordering by recency, book_id scoping, and detached-object behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa4e12f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->