### PR TITLE
Cleanup 11: consolidate TBR list getters

### DIFF
--- a/src/db/tbr_repository.py
+++ b/src/db/tbr_repository.py
@@ -32,10 +32,7 @@ class TbrRepository(BaseRepository):
             if source:
                 query = query.filter(TbrItem.source == source)
             query = query.order_by(TbrItem.priority.desc(), TbrItem.added_at.desc())
-            items = query.all()
-            for item in items:
-                session.expunge(item)
-            return items
+            return self._query_and_expunge(session, query, one=False)
 
     def get_tbr_item(self, item_id):
         """Get a single TBR item by ID."""
@@ -164,10 +161,8 @@ class TbrRepository(BaseRepository):
     def get_unlinked_items(self):
         """Return TBR items where book_id is NULL (not linked to a library book)."""
         with self.get_session() as session:
-            items = session.query(TbrItem).filter(TbrItem.book_id.is_(None)).all()
-            for item in items:
-                session.expunge(item)
-            return items
+            query = session.query(TbrItem).filter(TbrItem.book_id.is_(None))
+            return self._query_and_expunge(session, query, one=False)
 
     def auto_link_by_title(self, book):
         """Auto-link unlinked TBR items by normalized title match."""

--- a/tests/test_tbr_repository.py
+++ b/tests/test_tbr_repository.py
@@ -168,6 +168,76 @@ class TestTbrRepository(unittest.TestCase):
         self.assertEqual(items[1].title, "Middle")
         self.assertEqual(items[2].title, "Oldest")
 
+    def test_items_ordered_priority_first(self):
+        """get_tbr_items sorts by priority descending before added_at."""
+        self.db.add_tbr_item("Low Priority")
+        high, _ = self.db.add_tbr_item("High Priority")
+        self.db.update_tbr_item(high.id, priority=5)
+
+        items = self.db.get_tbr_items()
+        self.assertEqual(items[0].title, "High Priority")
+        self.assertEqual(items[1].title, "Low Priority")
+
+    def test_items_priority_tiebreak_by_added_at(self):
+        """Within the same priority, newest added_at comes first."""
+        import time
+
+        a, _ = self.db.add_tbr_item("Older Same Priority")
+        time.sleep(0.05)
+        b, _ = self.db.add_tbr_item("Newer Same Priority")
+        self.db.update_tbr_item(a.id, priority=3)
+        self.db.update_tbr_item(b.id, priority=3)
+
+        items = self.db.get_tbr_items()
+        self.assertEqual(items[0].title, "Newer Same Priority")
+        self.assertEqual(items[1].title, "Older Same Priority")
+
+    def test_get_tbr_items_empty(self):
+        """get_tbr_items returns an empty list when no items exist."""
+        self.assertEqual(self.db.get_tbr_items(), [])
+
+    def test_get_tbr_items_detached_after_session(self):
+        """Returned items are detached and usable after the session closes."""
+        self.db.add_tbr_item("Detached Book", author="Some Author")
+        items = self.db.get_tbr_items()
+        # Accessing attributes must not raise DetachedInstanceError.
+        self.assertEqual(items[0].title, "Detached Book")
+        self.assertEqual(items[0].author, "Some Author")
+
+    # -- Unlinked items --
+
+    def test_get_unlinked_items_returns_only_null_book_id(self):
+        """get_unlinked_items returns only items where book_id is None."""
+        from src.db.models import Book
+
+        book = self.db.save_book(Book(abs_id="abs-u1", title="Owned", status="active"))
+
+        linked, _ = self.db.add_tbr_item("Linked Book")
+        self.db.link_tbr_to_book(linked.id, book.id)
+        self.db.add_tbr_item("Unlinked Book")
+
+        unlinked = self.db.get_unlinked_tbr_items()
+        self.assertEqual(len(unlinked), 1)
+        self.assertEqual(unlinked[0].title, "Unlinked Book")
+        self.assertIsNone(unlinked[0].book_id)
+
+    def test_get_unlinked_items_empty_when_all_linked(self):
+        """get_unlinked_items returns an empty list when every item is linked."""
+        from src.db.models import Book
+
+        book = self.db.save_book(Book(abs_id="abs-u2", title="Owned", status="active"))
+        item, _ = self.db.add_tbr_item("Linked Book")
+        self.db.link_tbr_to_book(item.id, book.id)
+
+        self.assertEqual(self.db.get_unlinked_tbr_items(), [])
+
+    def test_get_unlinked_items_detached_after_session(self):
+        """Unlinked items are detached and usable after the session closes."""
+        self.db.add_tbr_item("Unlinked Detached", author="Author X")
+        unlinked = self.db.get_unlinked_tbr_items()
+        self.assertEqual(unlinked[0].title, "Unlinked Detached")
+        self.assertEqual(unlinked[0].author, "Author X")
+
     # -- Auto-link via save_hardcover_details --
 
     def test_save_hardcover_details_auto_links_tbr(self):


### PR DESCRIPTION
## Stage 11: TBR list getter consolidation

This is **Stage 11** of the backend cleanup. It consolidates list-query/expunge boilerplate in `TbrRepository` onto the existing `BaseRepository._query_and_expunge` helper.

- **Base branch:** `cleanup/backend-cleanup-2026-06-29`
- **This does NOT merge to `dev`.** It targets the long-lived cleanup integration branch only.

### What changed

Replaced the manual `query.all()` + looped `session.expunge()` pattern with `self._query_and_expunge(session, query, one=False)` in two methods only:

- `get_tbr_items(source=None)`
- `get_unlinked_items()`

### Behavior preserved (exactly)

The helper performs the same `query.all()` then expunges each row, so results are identical.

- `get_tbr_items()` with no source returns all items; with a source filters by exact `TbrItem.source == source`.
- Sort order unchanged: priority descending, then `added_at` descending.
- Empty list when no rows match.
- Returned items remain expunged/detached.
- `get_unlinked_items()` returns rows with `book_id IS NULL` exactly, no ordering added.
- Public method signatures unchanged; `DatabaseService` passthroughs (`get_tbr_items`, `get_unlinked_tbr_items`) unchanged.

Out of scope and untouched: `add_tbr_item()` dedup/created tuple, `update_tbr_item()` allowed-fields, `link_tbr_to_book()`, `auto_link_by_title()`, delete/find helpers, `_get_all()`, routes, schema, migrations.

### Tests added/strengthened (`tests/test_tbr_repository.py`)

- `test_items_ordered_priority_first` — priority desc takes precedence over added_at.
- `test_items_priority_tiebreak_by_added_at` — within equal priority, newest first.
- `test_get_tbr_items_empty` — empty list when no items.
- `test_get_tbr_items_detached_after_session` — attributes usable after session closes.
- `test_get_unlinked_items_returns_only_null_book_id` — only `book_id IS NULL` rows.
- `test_get_unlinked_items_empty_when_all_linked` — empty list when all linked.
- `test_get_unlinked_items_detached_after_session` — attributes usable after session closes.

(Existing `test_get_all_items`, `test_items_ordered_newest_first`, `test_filter_by_source` retained.)

### Verification

```
git branch --show-current  -> cleanup/11-tbr-list-getter-helper
git status --short          -> only src/db/tbr_repository.py, tests/test_tbr_repository.py
ruff check src/ tests/ alembic/ scripts/  -> All checks passed!
./run-tests.sh tests/test_tbr_repository.py tests/test_reading_routes.py \
  tests/test_dashboard_errors.py tests/test_database_service_integration.py
                           -> 122 passed
./run-tests.sh             -> 1005 passed, 3 skipped
```

- No DB/local fixture files staged or committed.
- No frontend files changed.
- No routes/response shapes/snapshots changed.

### Caveats

None. Pure behavior-preserving consolidation plus added coverage.

### Next

After this PR's checks/Macroscope are reviewed and it is merged, the next stage will be another bounded repository consolidation only.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate TBR list getters to use shared `_query_and_expunge` helper
> - Refactors `TbrRepository.get_tbr_items` and `get_unlinked_items` in [tbr_repository.py](https://github.com/serabi/pagekeeper/pull/95/files#diff-aba27a20ab254c01c02110b1e6413f62ebce5324b77080f3dda7c738e95ae0da) to delegate fetching and session expunge to the shared `_query_and_expunge` helper instead of calling `.all()` and manually expunging each item.
> - `get_tbr_items` now orders results by priority desc, then added_at desc.
> - Adds tests covering ordering, tiebreaking, empty results, and detached-after-session access for both methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff8f46f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->