### PR TITLE
Cleanup 12: consolidate TBR item mutations

### DIFF
--- a/src/db/tbr_repository.py
+++ b/src/db/tbr_repository.py
@@ -99,6 +99,23 @@ class TbrRepository(BaseRepository):
             session.expunge(item)
             return item, True
 
+    def _mutate_tbr_item(self, item_id, mutate):
+        """Load a TBR item by ID, apply ``mutate`` to it, and return it detached.
+
+        Returns None without mutating or flushing when no item matches the ID.
+        Shared by update_tbr_item and link_tbr_to_book to keep the
+        load -> mutate -> flush/refresh/expunge sequence in one place.
+        """
+        with self.get_session() as session:
+            item = session.query(TbrItem).filter(TbrItem.id == item_id).first()
+            if not item:
+                return None
+            mutate(item)
+            session.flush()
+            session.refresh(item)
+            session.expunge(item)
+            return item
+
     def update_tbr_item(self, item_id, **fields):
         """Update arbitrary fields on a TBR item. Returns the updated item or None."""
         ALLOWED = {
@@ -111,17 +128,13 @@ class TbrRepository(BaseRepository):
             "hardcover_slug",
             *ENRICHMENT_FIELDS,
         }
-        with self.get_session() as session:
-            item = session.query(TbrItem).filter(TbrItem.id == item_id).first()
-            if not item:
-                return None
+
+        def apply_fields(item):
             for key, value in fields.items():
                 if key in ALLOWED:
                     setattr(item, key, value)
-            session.flush()
-            session.refresh(item)
-            session.expunge(item)
-            return item
+
+        return self._mutate_tbr_item(item_id, apply_fields)
 
     def delete_tbr_item(self, item_id):
         """Remove a TBR item. Returns True if deleted."""
@@ -129,15 +142,11 @@ class TbrRepository(BaseRepository):
 
     def link_tbr_to_book(self, item_id, book_id):
         """Set book_id on a TBR item (linking it to an owned book)."""
-        with self.get_session() as session:
-            item = session.query(TbrItem).filter(TbrItem.id == item_id).first()
-            if not item:
-                return None
+
+        def set_book_id(item):
             item.book_id = book_id
-            session.flush()
-            session.refresh(item)
-            session.expunge(item)
-            return item
+
+        return self._mutate_tbr_item(item_id, set_book_id)
 
     def find_tbr_by_hardcover_id(self, hc_book_id):
         """Find a TBR item by its Hardcover book ID."""

--- a/tests/test_tbr_repository.py
+++ b/tests/test_tbr_repository.py
@@ -136,6 +136,123 @@ class TestTbrRepository(unittest.TestCase):
         result = self.db.link_tbr_to_book(9999, 1)
         self.assertIsNone(result)
 
+    def test_link_tbr_to_book_unlink_with_none(self):
+        """link_tbr_to_book accepts None to unlink an item from its book."""
+        from src.db.models import Book
+
+        book = self.db.save_book(Book(abs_id="abs-unlink", title="Owned", status="active"))
+        item, _ = self.db.add_tbr_item("Dune")
+        self.db.link_tbr_to_book(item.id, book.id)
+
+        unlinked = self.db.link_tbr_to_book(item.id, None)
+        self.assertIsNotNone(unlinked)
+        self.assertIsNone(unlinked.book_id)
+
+        refreshed = self.db.get_tbr_item(item.id)
+        self.assertIsNone(refreshed.book_id)
+
+    def test_link_tbr_to_book_detached_after_session(self):
+        """link_tbr_to_book returns a detached item usable after the session closes."""
+        from src.db.models import Book
+
+        book = self.db.save_book(Book(abs_id="abs-detach", title="Owned", status="active"))
+        item, _ = self.db.add_tbr_item("Detached Link", author="Author Y")
+
+        linked = self.db.link_tbr_to_book(item.id, book.id)
+        # Accessing attributes must not raise DetachedInstanceError.
+        self.assertEqual(linked.book_id, book.id)
+        self.assertEqual(linked.title, "Detached Link")
+        self.assertEqual(linked.author, "Author Y")
+
+    # -- Updating --
+
+    def test_update_tbr_item_regular_fields(self):
+        """update_tbr_item updates allowed regular fields."""
+        item, _ = self.db.add_tbr_item("Original", author="Old Author")
+        updated = self.db.update_tbr_item(
+            item.id,
+            title="New Title",
+            author="New Author",
+            cover_url="http://example.com/cover.jpg",
+            priority=7,
+            hardcover_book_id=123,
+            hardcover_slug="new-title",
+        )
+        self.assertEqual(updated.title, "New Title")
+        self.assertEqual(updated.author, "New Author")
+        self.assertEqual(updated.cover_url, "http://example.com/cover.jpg")
+        self.assertEqual(updated.priority, 7)
+        self.assertEqual(updated.hardcover_book_id, 123)
+        self.assertEqual(updated.hardcover_slug, "new-title")
+
+    def test_update_tbr_item_enrichment_fields(self):
+        """update_tbr_item updates enrichment fields."""
+        item, _ = self.db.add_tbr_item("Enrich Me")
+        updated = self.db.update_tbr_item(
+            item.id,
+            description="A great book",
+            page_count=321,
+            rating=4.5,
+            ratings_count=1000,
+            release_year=1965,
+            genres='["sci-fi"]',
+            subtitle="A Subtitle",
+        )
+        self.assertEqual(updated.description, "A great book")
+        self.assertEqual(updated.page_count, 321)
+        self.assertEqual(updated.rating, 4.5)
+        self.assertEqual(updated.ratings_count, 1000)
+        self.assertEqual(updated.release_year, 1965)
+        self.assertEqual(updated.genres, '["sci-fi"]')
+        self.assertEqual(updated.subtitle, "A Subtitle")
+
+    def test_update_tbr_item_ignores_unknown_fields(self):
+        """update_tbr_item silently ignores fields not in the allowlist."""
+        item, _ = self.db.add_tbr_item("Keep Me", author="Real Author")
+        updated = self.db.update_tbr_item(
+            item.id,
+            title="Updated Title",
+            bogus_field="should be ignored",
+            source="manipulated",
+        )
+        self.assertEqual(updated.title, "Updated Title")
+        # source is not in the allowlist, so it stays unchanged.
+        self.assertEqual(updated.source, "manual")
+        self.assertFalse(hasattr(updated, "bogus_field"))
+
+    def test_update_tbr_item_writes_none_for_nullable_field(self):
+        """update_tbr_item writes None through for an allowed nullable field."""
+        item, _ = self.db.add_tbr_item("Has Notes", notes="some notes", cover_url="http://x/y.jpg")
+        updated = self.db.update_tbr_item(item.id, notes=None, cover_url=None)
+        self.assertIsNone(updated.notes)
+        self.assertIsNone(updated.cover_url)
+
+        refreshed = self.db.get_tbr_item(item.id)
+        self.assertIsNone(refreshed.notes)
+        self.assertIsNone(refreshed.cover_url)
+
+    def test_update_tbr_item_only_unknown_fields_returns_unchanged(self):
+        """update_tbr_item returns the unchanged item when only unknown fields are passed."""
+        item, _ = self.db.add_tbr_item("Untouched", author="Author Z", notes="keep")
+        updated = self.db.update_tbr_item(item.id, not_a_field=1, source="hack")
+        self.assertIsNotNone(updated)
+        self.assertEqual(updated.title, "Untouched")
+        self.assertEqual(updated.author, "Author Z")
+        self.assertEqual(updated.notes, "keep")
+        self.assertEqual(updated.source, "manual")
+
+    def test_update_tbr_item_not_found(self):
+        """update_tbr_item returns None for a missing item ID."""
+        self.assertIsNone(self.db.update_tbr_item(9999, title="Nope"))
+
+    def test_update_tbr_item_detached_after_session(self):
+        """update_tbr_item returns a detached item usable after the session closes."""
+        item, _ = self.db.add_tbr_item("Detached Update")
+        updated = self.db.update_tbr_item(item.id, title="Detached New", author="Author D")
+        # Accessing attributes must not raise DetachedInstanceError.
+        self.assertEqual(updated.title, "Detached New")
+        self.assertEqual(updated.author, "Author D")
+
     # -- Lookup --
 
     def test_find_tbr_by_hardcover_id(self):


### PR DESCRIPTION
## Stage 12: consolidate TBR item mutations

Part of the backend cleanup effort (Step 5 — repository consolidation rollout).

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.** It targets the long-lived cleanup integration branch only.

### What changed

`update_tbr_item()` and `link_tbr_to_book()` both repeated the same
`session.query(TbrItem).filter(TbrItem.id == item_id).first()` -> mutate ->
`flush/refresh/expunge/return` boilerplate. This adds a small private helper
`_mutate_tbr_item(item_id, mutate)` inside `TbrRepository` that owns that
sequence, and makes both methods delegate to it via a small mutation callback.

No `BaseRepository` helper was added — this is a TBR-local pattern, so a private
helper keeps the change bounded (per stage direction).

### Behavior preserved exactly

`update_tbr_item(item_id, **fields)`:
- Returns the updated `TbrItem` or `None` for a missing ID.
- Same allowlist (`title`, `author`, `cover_url`, `notes`, `priority`,
  `hardcover_book_id`, `hardcover_slug`, plus `ENRICHMENT_FIELDS`).
- Silently ignores unknown fields.
- Writes `None` through for allowed nullable fields.
- Returns the unchanged item when only unknown fields are supplied.
- Public signature unchanged; returned object stays detached/usable.

`link_tbr_to_book(item_id, book_id)`:
- Returns the updated `TbrItem` or `None` for a missing ID.
- Sets `item.book_id = book_id` exactly, including `book_id=None` to unlink
  (no special-casing).
- Public signature unchanged; returned object stays detached/usable.

`add_tbr_item()` dedup/created-tuple behavior and Stage 11
`get_tbr_items()` / `get_unlinked_items()` behavior were not touched. No
routes, response shapes, schema, or frontend changed.

### Tests added (`tests/test_tbr_repository.py`)

- `update_tbr_item` updates allowed regular fields
- `update_tbr_item` updates enrichment fields
- `update_tbr_item` ignores unknown fields
- `update_tbr_item` writes `None` for nullable fields (`notes`, `cover_url`)
- `update_tbr_item` returns unchanged item for unknown-only fields
- `update_tbr_item` returns `None` for missing ID
- `update_tbr_item` returned object detached after session close
- `link_tbr_to_book` accepts `None` to unlink
- `link_tbr_to_book` returned object detached after session close

(Existing `link_tbr_to_book` link and missing-ID tests retained.)

### Verification

```
git status --short              # only the two intended files
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh tests/test_tbr_repository.py tests/test_reading_routes.py \
  tests/test_dashboard_errors.py tests/test_database_service_integration.py
  # 131 passed
./run-tests.sh                  # 1014 passed, 3 skipped (pre-existing), 17 warnings
```

### Caveats

- Two unused imports (`datetime`, `timedelta`) at the top of
  `test_tbr_repository.py` pre-date this stage and are not flagged by ruff;
  left untouched as out of scope.

### Next

Next stage will be another bounded repository consolidation, only after this
PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate TBR item mutation logic into `TbrRepository._mutate_tbr_item` helper
> - Introduces a private `_mutate_tbr_item` helper in [tbr_repository.py](https://github.com/serabi/pagekeeper/pull/96/files#diff-aba27a20ab254c01c02110b1e6413f62ebce5324b77080f3dda7c738e95ae0da) that handles the common session open → load → mutate → flush/refresh/expunge pattern.
> - Refactors `update_tbr_item` and `link_tbr_to_book` to delegate to this helper via closures, removing duplicated session management code.
> - Adds comprehensive tests in [test_tbr_repository.py](https://github.com/serabi/pagekeeper/pull/96/files#diff-e2a21c223aedd650bf5f4e2a7da0c6f7a5420e5d7b41278c183fe601b1168640) covering field updates, unknown field filtering, nullable field writes, not-found cases, and detached instance access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dee9534.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->