### PR TITLE
Cleanup 13: consolidate BookFusion list getters

### DIFF
--- a/src/db/bookfusion_repository.py
+++ b/src/db/bookfusion_repository.py
@@ -76,24 +76,19 @@ class BookFusionRepository(BaseRepository):
 
     def get_bookfusion_highlights(self):
         with self.get_session() as session:
-            highlights = (
-                session.query(BookfusionHighlight)
-                .order_by(BookfusionHighlight.book_title, BookfusionHighlight.id)
-                .all()
+            query = session.query(BookfusionHighlight).order_by(
+                BookfusionHighlight.book_title, BookfusionHighlight.id
             )
-            session.expunge_all()
-            return highlights
+            return self._query_and_expunge(session, query, one=False)
 
     def get_unmatched_bookfusion_highlights(self):
         with self.get_session() as session:
-            highlights = (
+            query = (
                 session.query(BookfusionHighlight)
                 .filter(BookfusionHighlight.matched_book_id.is_(None))
                 .order_by(BookfusionHighlight.book_title, BookfusionHighlight.id)
-                .all()
             )
-            session.expunge_all()
-            return highlights
+            return self._query_and_expunge(session, query, one=False)
 
     def link_bookfusion_highlights_by_book_id(self, bookfusion_book_id, book_id):
         """Link all highlights for a BookFusion book to a library book by book_id."""
@@ -110,14 +105,12 @@ class BookFusionRepository(BaseRepository):
     def get_bookfusion_highlights_for_book_by_book_id(self, book_id):
         """Get highlights matched to a book by book_id."""
         with self.get_session() as session:
-            highlights = (
+            query = (
                 session.query(BookfusionHighlight)
                 .filter(BookfusionHighlight.matched_book_id == book_id)
                 .order_by(BookfusionHighlight.highlighted_at.desc().nullslast(), BookfusionHighlight.id)
-                .all()
             )
-            session.expunge_all()
-            return highlights
+            return self._query_and_expunge(session, query, one=False)
 
     # ── BookFusion Books (Library Catalog) ──
 
@@ -188,10 +181,8 @@ class BookFusionRepository(BaseRepository):
     def get_bookfusion_books_by_book_id(self, book_id):
         """Get all BookFusion catalog entries linked to a specific PageKeeper book."""
         with self.get_session() as session:
-            books = session.query(BookfusionBook).filter(BookfusionBook.matched_book_id == book_id).all()
-            for b in books:
-                session.expunge(b)
-            return books
+            query = session.query(BookfusionBook).filter(BookfusionBook.matched_book_id == book_id)
+            return self._query_and_expunge(session, query, one=False)
 
     def save_bookfusion_book(self, bookfusion_book):
         """Save a single BookFusion catalog entry."""

--- a/tests/test_bookfusion_list_getters.py
+++ b/tests/test_bookfusion_list_getters.py
@@ -1,0 +1,228 @@
+"""Behavior-characterization tests for BookFusion list getters.
+
+These lock in the filtering, ordering, empty-result, and detachment behavior of
+the four list-query methods consolidated onto ``_query_and_expunge`` in the
+Stage 13 backend cleanup:
+
+- ``get_bookfusion_highlights()``
+- ``get_unmatched_bookfusion_highlights()``
+- ``get_bookfusion_highlights_for_book_by_book_id()``
+- ``get_bookfusion_books_by_book_id()``
+"""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.db.database_service import DatabaseService
+from src.db.models import Book, BookfusionBook
+
+
+@pytest.fixture
+def db_service():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+        service = DatabaseService(str(db_path))
+        try:
+            yield service
+        finally:
+            service.db_manager.close()
+
+
+def _save_book(db_service, abs_id, title):
+    return db_service.save_book(
+        Book(
+            abs_id=abs_id,
+            title=title,
+            ebook_filename=f"{abs_id}.epub",
+            kosync_doc_id=f"doc-{abs_id}",
+            status="active",
+        )
+    )
+
+
+def _highlight(highlight_id, book_title, bookfusion_book_id="bf-1", highlighted_at=None):
+    return {
+        "bookfusion_book_id": bookfusion_book_id,
+        "highlight_id": highlight_id,
+        "content": f"content-{highlight_id}",
+        "quote_text": f"quote-{highlight_id}",
+        "book_title": book_title,
+        "chapter_heading": "Chapter 1",
+        "highlighted_at": highlighted_at,
+    }
+
+
+# ── get_bookfusion_highlights ──
+
+
+def test_get_bookfusion_highlights_returns_all(db_service):
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-1", "Zebra"),
+            _highlight("hl-2", "Apple"),
+        ]
+    )
+    highlights = db_service.get_bookfusion_highlights()
+    assert {h.highlight_id for h in highlights} == {"hl-1", "hl-2"}
+
+
+def test_get_bookfusion_highlights_orders_by_book_title_then_id(db_service):
+    # Two share a title to force the secondary id ordering to matter.
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-1", "Mango"),
+            _highlight("hl-2", "Apple"),
+            _highlight("hl-3", "Apple"),
+        ]
+    )
+    highlights = db_service.get_bookfusion_highlights()
+    titles = [h.book_title for h in highlights]
+    assert titles == ["Apple", "Apple", "Mango"]
+    apple_ids = [h.id for h in highlights if h.book_title == "Apple"]
+    assert apple_ids == sorted(apple_ids)
+
+
+def test_get_bookfusion_highlights_empty(db_service):
+    assert db_service.get_bookfusion_highlights() == []
+
+
+def test_get_bookfusion_highlights_rows_detached_and_usable(db_service):
+    db_service.save_bookfusion_highlights([_highlight("hl-1", "Apple")])
+    highlights = db_service.get_bookfusion_highlights()
+    # Accessing attributes after the session closed must not raise
+    # DetachedInstanceError; rows are expunged, so their loaded column state
+    # remains readable.
+    assert highlights[0].book_title == "Apple"
+    assert highlights[0].content == "content-hl-1"
+
+
+# ── get_unmatched_bookfusion_highlights ──
+
+
+def test_get_unmatched_bookfusion_highlights_filters_null_match(db_service):
+    book = _save_book(db_service, "abs-1", "Linked Book")
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-1", "Apple", bookfusion_book_id="bf-1"),
+            _highlight("hl-2", "Banana", bookfusion_book_id="bf-2"),
+        ]
+    )
+    db_service.link_bookfusion_highlights_by_book_id("bf-1", book.id)
+
+    unmatched = db_service.get_unmatched_bookfusion_highlights()
+    assert {h.highlight_id for h in unmatched} == {"hl-2"}
+    assert all(h.matched_book_id is None for h in unmatched)
+
+
+def test_get_unmatched_bookfusion_highlights_orders_by_book_title_then_id(db_service):
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-1", "Mango"),
+            _highlight("hl-2", "Apple"),
+            _highlight("hl-3", "Apple"),
+        ]
+    )
+    unmatched = db_service.get_unmatched_bookfusion_highlights()
+    titles = [h.book_title for h in unmatched]
+    assert titles == ["Apple", "Apple", "Mango"]
+    apple_ids = [h.id for h in unmatched if h.book_title == "Apple"]
+    assert apple_ids == sorted(apple_ids)
+
+
+def test_get_unmatched_bookfusion_highlights_empty(db_service):
+    assert db_service.get_unmatched_bookfusion_highlights() == []
+
+
+# ── get_bookfusion_highlights_for_book_by_book_id ──
+
+
+def test_get_highlights_for_book_filters_by_matched_book_id(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-1", "Apple", bookfusion_book_id="bf-a"),
+            _highlight("hl-2", "Banana", bookfusion_book_id="bf-b"),
+        ]
+    )
+    db_service.link_bookfusion_highlights_by_book_id("bf-a", book_a.id)
+    db_service.link_bookfusion_highlights_by_book_id("bf-b", book_b.id)
+
+    for_a = db_service.get_bookfusion_highlights_for_book_by_book_id(book_a.id)
+    assert {h.highlight_id for h in for_a} == {"hl-1"}
+    assert all(h.matched_book_id == book_a.id for h in for_a)
+
+
+def test_get_highlights_for_book_orders_by_highlighted_at_desc_nulls_last_then_id(db_service):
+    book = _save_book(db_service, "abs-a", "Book A")
+    db_service.save_bookfusion_highlights(
+        [
+            _highlight("hl-old", "Apple", bookfusion_book_id="bf-a", highlighted_at=datetime(2020, 1, 1)),
+            _highlight("hl-new", "Apple", bookfusion_book_id="bf-a", highlighted_at=datetime(2024, 1, 1)),
+            _highlight("hl-null-1", "Apple", bookfusion_book_id="bf-a", highlighted_at=None),
+            _highlight("hl-null-2", "Apple", bookfusion_book_id="bf-a", highlighted_at=None),
+        ]
+    )
+    db_service.link_bookfusion_highlights_by_book_id("bf-a", book.id)
+
+    result = db_service.get_bookfusion_highlights_for_book_by_book_id(book.id)
+    order = [h.highlight_id for h in result]
+    # Newest first, then older dated, then the null-dated rows last in id order.
+    assert order[0] == "hl-new"
+    assert order[1] == "hl-old"
+    null_tail = order[2:]
+    assert set(null_tail) == {"hl-null-1", "hl-null-2"}
+    null_ids = [h.id for h in result if h.highlighted_at is None]
+    assert null_ids == sorted(null_ids)
+
+
+def test_get_highlights_for_book_empty(db_service):
+    book = _save_book(db_service, "abs-a", "Book A")
+    assert db_service.get_bookfusion_highlights_for_book_by_book_id(book.id) == []
+
+
+# ── get_bookfusion_books_by_book_id ──
+
+
+def test_get_bookfusion_books_by_book_id_filters_by_matched_book_id(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    db_service.save_bookfusion_book(
+        BookfusionBook(bookfusion_id="bf-a", title="Catalog A", matched_book_id=book_a.id)
+    )
+    db_service.save_bookfusion_book(
+        BookfusionBook(bookfusion_id="bf-b", title="Catalog B", matched_book_id=book_b.id)
+    )
+
+    for_a = db_service.get_bookfusion_books_by_book_id(book_a.id)
+    assert {b.bookfusion_id for b in for_a} == {"bf-a"}
+    assert all(b.matched_book_id == book_a.id for b in for_a)
+
+
+def test_get_bookfusion_books_by_book_id_returns_all_matches(db_service):
+    book = _save_book(db_service, "abs-a", "Book A")
+    db_service.save_bookfusion_book(
+        BookfusionBook(bookfusion_id="bf-a1", title="Catalog A1", matched_book_id=book.id)
+    )
+    db_service.save_bookfusion_book(
+        BookfusionBook(bookfusion_id="bf-a2", title="Catalog A2", matched_book_id=book.id)
+    )
+    result = db_service.get_bookfusion_books_by_book_id(book.id)
+    assert {b.bookfusion_id for b in result} == {"bf-a1", "bf-a2"}
+
+
+def test_get_bookfusion_books_by_book_id_empty(db_service):
+    book = _save_book(db_service, "abs-a", "Book A")
+    assert db_service.get_bookfusion_books_by_book_id(book.id) == []
+
+
+def test_get_bookfusion_books_by_book_id_rows_detached_and_usable(db_service):
+    book = _save_book(db_service, "abs-a", "Book A")
+    db_service.save_bookfusion_book(
+        BookfusionBook(bookfusion_id="bf-a", title="Catalog A", matched_book_id=book.id)
+    )
+    result = db_service.get_bookfusion_books_by_book_id(book.id)
+    assert result[0].title == "Catalog A"


### PR DESCRIPTION
## Stage 13: Consolidate BookFusion list getters

This is **Stage 13** of the backend cleanup. It is a single, bounded `BookFusionRepository` consolidation: replacing manual `.all()` + expunge boilerplate in four list getters with the existing `BaseRepository._query_and_expunge(session, query, one=False)` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`

> This does **not** merge to `dev`. The cleanup integration branch stays separate until the whole cleanup is complete and approved.

### Methods consolidated

- `get_bookfusion_highlights()`
- `get_unmatched_bookfusion_highlights()`
- `get_bookfusion_highlights_for_book_by_book_id(book_id)`
- `get_bookfusion_books_by_book_id(book_id)`

### Behavior preserved

Query construction (filters and ordering) is unchanged in every method; only the post-query expunge boilerplate is replaced by the shared helper:

- `get_bookfusion_highlights`: returns all rows, ordered by `book_title` then `id`.
- `get_unmatched_bookfusion_highlights`: filters `matched_book_id IS NULL`, ordered by `book_title` then `id`.
- `get_bookfusion_highlights_for_book_by_book_id`: filters `matched_book_id == book_id`, ordered `highlighted_at DESC NULLS LAST` then `id`.
- `get_bookfusion_books_by_book_id`: filters `matched_book_id == book_id`, no explicit ordering.

The two methods that previously used `session.expunge_all()` open a fresh session, run a single query, and access no relationships, so they load only the queried rows. Replacing `expunge_all()` with the helper's item-wise expunge is therefore equivalent — no other loaded objects existed to leave attached. All returned rows remain detached and usable after the session closes. Public method signatures are unchanged.

### Tests added

New `tests/test_bookfusion_list_getters.py` (14 tests against a real temp SQLite DB) covering, per getter:
- filtering (`matched_book_id` / `IS NULL`),
- ordering (`book_title`/`id`; `highlighted_at DESC NULLS LAST`/`id`),
- empty-result returns `[]`,
- rows detached and usable after the session closes.

### Out of scope (unchanged)

`save_bookfusion_highlights`, `save_bookfusion_books`, link/unlink/match mutations, aggregate methods, `auto_link_by_title`, routes, client, response shapes, schema/migrations.

### Verification

```
git status --short          # only repo file + new test file
git branch --show-current   # cleanup/13-bookfusion-list-getter-helper
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
```

- Focused: `tests/test_bookfusion_list_getters.py tests/test_bookfusion_repository.py tests/test_bookfusion_routes.py tests/test_bookfusion_save_journal_regressions.py tests/test_dashboard_errors.py` -> **48 passed**
- Full suite: **1028 passed, 3 skipped** (skips and warnings pre-existing, unrelated)

No frontend, route, schema, migration, or DB/fixture files changed.

### Caveats

None. The refactor is mechanical and behavior-preserving.

### Next

The next stage will be another bounded repository consolidation, only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate BookFusion list getter methods to use `_query_and_expunge`
> Refactors four list-getter methods in [bookfusion_repository.py](https://github.com/serabi/pagekeeper/pull/97/files#diff-436d6dade32dd9cdde7d1947ddefc0d7016ce52fb604843e5fc1deea4bba3c68) to delegate query execution and session expunge to the shared `_query_and_expunge` helper, replacing inline `.all()` and `session.expunge_all()` calls. Adds behavior-characterization tests in [test_bookfusion_list_getters.py](https://github.com/serabi/pagekeeper/pull/97/files#diff-f37acd5bc59311b2e20749e561c656e277af480aed9a91e3a57133f3dc911ff3) covering filtering, ordering, empty results, and detached-row usability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 295cc64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->