### PR TITLE
Cleanup 14: consolidate reading journal getters

### DIFF
--- a/src/db/reading_repository.py
+++ b/src/db/reading_repository.py
@@ -46,10 +46,8 @@ class ReadingRepository(BaseRepository):
             query = session.query(ReadingJournal).filter(ReadingJournal.book_id == book_id)
             if event:
                 query = query.filter(ReadingJournal.event == event)
-            journals = query.order_by(ReadingJournal.created_at.desc()).all()
-            for j in journals:
-                session.expunge(j)
-            return journals
+            query = query.order_by(ReadingJournal.created_at.desc())
+            return self._query_and_expunge(session, query, one=False)
 
     def get_reading_journal(self, journal_id):
         return self._get_one(ReadingJournal, ReadingJournal.id == journal_id)
@@ -88,18 +86,15 @@ class ReadingRepository(BaseRepository):
     def find_journal_by_event(self, book_id, event):
         """Find the most recent journal entry for a book with a given event type."""
         with self.get_session() as session:
-            journal = (
+            query = (
                 session.query(ReadingJournal)
                 .filter(
                     ReadingJournal.book_id == book_id,
                     ReadingJournal.event == event,
                 )
                 .order_by(ReadingJournal.created_at.desc())
-                .first()
             )
-            if journal:
-                session.expunge(journal)
-            return journal
+            return self._query_and_expunge(session, query, one=True)
 
     def cleanup_bookfusion_import_notes(self, book_id=None):
         """Strip the legacy emoji prefix and backfill timestamps when a cached highlight matches."""

--- a/tests/test_reading_tracker.py
+++ b/tests/test_reading_tracker.py
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 import unittest
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -193,6 +193,93 @@ class TestReadingTrackerModels(unittest.TestCase):
     def test_journals_empty_for_unknown_book(self):
         """get_reading_journals returns empty list for unknown book_id."""
         self.assertEqual(self.db.get_reading_journals(99999), [])
+
+    # -- get_reading_journal_entries_for_book --
+
+    def test_journal_entries_for_book_returns_only_that_book_newest_first(self):
+        """Returns all entries for the given book only, ordered newest-first."""
+        book = self._create_book(abs_id="book-a", title="Book A")
+        other = self._create_book(abs_id="book-b", title="Book B")
+        self.db.add_reading_journal(book.id, event="started", created_at=datetime(2026, 1, 1, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="note", entry="middle", created_at=datetime(2026, 1, 2, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="finished", created_at=datetime(2026, 1, 3, 0, 0, 0))
+        self.db.add_reading_journal(other.id, event="started", created_at=datetime(2026, 1, 2, 12, 0, 0))
+
+        entries = self.db.get_reading_journal_entries_for_book(book.id)
+        self.assertEqual(len(entries), 3)
+        self.assertEqual([e.event for e in entries], ["finished", "note", "started"])
+
+    def test_journal_entries_for_book_filters_by_event(self):
+        """Passing an event restricts results to that event type."""
+        book = self._create_book()
+        self.db.add_reading_journal(book.id, event="highlight", entry="h1", created_at=datetime(2026, 1, 1, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="note", entry="n1", created_at=datetime(2026, 1, 2, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="highlight", entry="h2", created_at=datetime(2026, 1, 3, 0, 0, 0))
+
+        highlights = self.db.get_reading_journal_entries_for_book(book.id, "highlight")
+        self.assertEqual([e.entry for e in highlights], ["h2", "h1"])
+
+    def test_journal_entries_for_book_no_event_filter_when_falsy(self):
+        """A falsy event (None or empty string) applies no event filter."""
+        book = self._create_book()
+        self.db.add_reading_journal(book.id, event="started", created_at=datetime(2026, 1, 1, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="note", entry="n1", created_at=datetime(2026, 1, 2, 0, 0, 0))
+
+        self.assertEqual(len(self.db.get_reading_journal_entries_for_book(book.id, None)), 2)
+        self.assertEqual(len(self.db.get_reading_journal_entries_for_book(book.id, "")), 2)
+
+    def test_journal_entries_for_book_empty_for_no_matches(self):
+        """Returns an empty list when nothing matches."""
+        book = self._create_book()
+        self.assertEqual(self.db.get_reading_journal_entries_for_book(book.id), [])
+        self.assertEqual(self.db.get_reading_journal_entries_for_book(99999), [])
+
+    def test_journal_entries_for_book_detached_after_session_close(self):
+        """Returned rows are usable after the session has closed."""
+        book = self._create_book()
+        self.db.add_reading_journal(book.id, event="note", entry="detached", created_at=datetime(2026, 1, 1, 0, 0, 0))
+
+        entries = self.db.get_reading_journal_entries_for_book(book.id)
+        # Accessing attributes after the session closed must not raise DetachedInstanceError.
+        self.assertEqual(entries[0].entry, "detached")
+        self.assertEqual(entries[0].book_id, book.id)
+
+    # -- find_journal_by_event --
+
+    def test_find_journal_by_event_returns_newest_match(self):
+        """Returns the most recent journal of the requested event for the book."""
+        book = self._create_book()
+        self.db.add_reading_journal(book.id, event="progress", percentage=0.2, created_at=datetime(2026, 1, 1, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="progress", percentage=0.8, created_at=datetime(2026, 1, 5, 0, 0, 0))
+        self.db.add_reading_journal(book.id, event="progress", percentage=0.5, created_at=datetime(2026, 1, 3, 0, 0, 0))
+
+        journal = self.db.find_journal_by_event(book.id, "progress")
+        self.assertIsNotNone(journal)
+        self.assertAlmostEqual(journal.percentage, 0.8)
+
+    def test_find_journal_by_event_ignores_other_books_and_events(self):
+        """Only matches the given book and event."""
+        book = self._create_book(abs_id="book-a", title="Book A")
+        other = self._create_book(abs_id="book-b", title="Book B")
+        self.db.add_reading_journal(book.id, event="started", created_at=datetime(2026, 1, 1, 0, 0, 0))
+        self.db.add_reading_journal(other.id, event="finished", created_at=datetime(2026, 1, 2, 0, 0, 0))
+
+        self.assertIsNone(self.db.find_journal_by_event(book.id, "finished"))
+        self.assertIsNotNone(self.db.find_journal_by_event(book.id, "started"))
+
+    def test_find_journal_by_event_none_when_no_match(self):
+        """Returns None when no journal matches."""
+        book = self._create_book()
+        self.assertIsNone(self.db.find_journal_by_event(book.id, "finished"))
+
+    def test_find_journal_by_event_detached_after_session_close(self):
+        """Returned object is usable after the session has closed."""
+        book = self._create_book()
+        self.db.add_reading_journal(book.id, event="note", entry="detached", created_at=datetime(2026, 1, 1, 0, 0, 0))
+
+        journal = self.db.find_journal_by_event(book.id, "note")
+        self.assertEqual(journal.entry, "detached")
+        self.assertEqual(journal.book_id, book.id)
 
     # -- ReadingGoal CRUD --
 


### PR DESCRIPTION
## Stage 14 — Reading journal getter consolidation

Part of the backend cleanup integration effort. **Base branch: `cleanup/backend-cleanup-2026-06-29`. This does NOT merge to `dev`.**

### What changed
Consolidated the manual query/expunge boilerplate in two `ReadingRepository` getters by delegating to the existing `BaseRepository._query_and_expunge(...)` helper:

- `get_reading_journal_entries_for_book(book_id, event=None)` -> `one=False`
- `find_journal_by_event(book_id, event)` -> `one=True`

The query construction is unchanged in both methods: the same `book_id` filter, the same conditional exact `event` filter (applied only when `event` is truthy), and the same `created_at DESC` ordering. Only the trailing `.all()`/`.first()` + manual `session.expunge(...)` loop was replaced with the shared helper, which performs the identical fetch-and-detach.

### Behavior preserved
- `get_reading_journal_entries_for_book`: filters by exact `book_id`; adds exact `event` filter only when `event` is truthy; no event filter for falsy `event` (None/empty string); `created_at DESC` ordering; returns `[]` for no matches; rows detached/usable after session close; signature unchanged.
- `find_journal_by_event`: filters by exact `book_id` and exact `event`; `created_at DESC` ordering; returns newest match or `None`; row detached/usable after session close; signature unchanged.

No changes to `add_reading_journal`, `update_reading_journal`, `delete_reading_journal`, `update_book_reading_fields`, `cleanup_bookfusion_import_notes`, goals, stats, routes, response shapes, schema, or migrations.

### Tests added
Added focused tests in `tests/test_reading_tracker.py` (deterministic via explicit `created_at` datetimes, no sleeps):

- `get_reading_journal_entries_for_book`: returns only that book's entries newest-first; filters by event when provided; applies no event filter for falsy event (None and `""`); returns `[]` for no matches; rows usable after session close.
- `find_journal_by_event`: returns newest matching event; ignores other books and events; returns `None` when no match; row usable after session close.

### Verification
```
git status --short            # only src/db/reading_repository.py + tests/test_reading_tracker.py
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
focused suite                 # 83 passed
./run-tests.sh                # 1037 passed, 3 skipped (pre-existing), 17 warnings (pre-existing)
```

No DB/fixture files staged; no frontend changes; no route/snapshot changes.

### Caveats
None. Pure mechanical consolidation onto the existing helper.

### Next stage
Another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate reading journal getters to use shared `_query_and_expunge` helper
> Refactors `get_reading_journal_entries_for_book` and `find_journal_by_event` in [`reading_repository.py`](https://github.com/serabi/pagekeeper/pull/98/files#diff-09510a40cdc79c2d86d62bc0c932f66726523b53f4c2125c5dbce128b0a74eb9) to build ordered/filtered queries and delegate execution and session expunging to the existing `_query_and_expunge` method, replacing manual query execution and conditional expunge logic. Adds 9 tests in [`test_reading_tracker.py`](https://github.com/serabi/pagekeeper/pull/98/files#diff-10a389949fe9f070f769fc5e0e32bfaf31a54aaa14f67e64cc99b5e0ab4243fe) covering ordering, event filtering, falsy filter handling, empty results, and post-session detachment for both methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 243d415.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->