### PR TITLE
Cleanup 15: consolidate reading mutations

### DIFF
--- a/src/db/reading_repository.py
+++ b/src/db/reading_repository.py
@@ -12,6 +12,22 @@ BOOKFUSION_CHAPTER_PREFIX = re.compile(r"^#{1,6}\s*")
 
 
 class ReadingRepository(BaseRepository):
+    def _mutate_and_detach(self, model, *filters, mutate):
+        """Look up a single row by ``filters``, apply ``mutate``, and return it detached.
+
+        Returns None when no row matches. On a match, runs ``mutate(obj)`` then the
+        shared flush/refresh/expunge finalization so callers get a detached object.
+        """
+        with self.get_session() as session:
+            obj = session.query(model).filter(*filters).first()
+            if not obj:
+                return None
+            mutate(obj)
+            session.flush()
+            session.refresh(obj)
+            session.expunge(obj)
+            return obj
+
     def update_book_reading_fields(self, book_id, **kwargs):
         """Update reading-specific fields on a book (started_at, finished_at, rating, read_count)."""
         allowed = {"started_at", "finished_at", "rating", "read_count"}
@@ -21,17 +37,13 @@ class ReadingRepository(BaseRepository):
         read_count = kwargs.get("read_count")
         if read_count is not None and read_count < 1:
             raise ValueError("read_count must be >= 1")
-        with self.get_session() as session:
-            book = session.query(Book).filter(Book.id == book_id).first()
-            if not book:
-                return None
+
+        def _apply(book):
             for key, value in kwargs.items():
                 if key in allowed:
                     setattr(book, key, value)
-            session.flush()
-            session.refresh(book)
-            session.expunge(book)
-            return book
+
+        return self._mutate_and_detach(Book, Book.id == book_id, mutate=_apply)
 
     def get_reading_journals(self, book_id):
         return self._get_all(
@@ -70,18 +82,13 @@ class ReadingRepository(BaseRepository):
         )
 
     def update_reading_journal(self, journal_id, *, entry=None, created_at=None):
-        with self.get_session() as session:
-            journal = session.query(ReadingJournal).filter(ReadingJournal.id == journal_id).first()
-            if not journal:
-                return None
+        def _apply(journal):
             if entry is not None:
                 journal.entry = entry
             if created_at is not None:
                 journal.created_at = created_at
-            session.flush()
-            session.refresh(journal)
-            session.expunge(journal)
-            return journal
+
+        return self._mutate_and_detach(ReadingJournal, ReadingJournal.id == journal_id, mutate=_apply)
 
     def find_journal_by_event(self, book_id, event):
         """Find the most recent journal entry for a book with a given event type."""

--- a/tests/test_reading_tracker.py
+++ b/tests/test_reading_tracker.py
@@ -132,6 +132,92 @@ class TestReadingTrackerModels(unittest.TestCase):
         refreshed = self.db.get_book_by_abs_id("test-book-1")
         self.assertEqual(refreshed.title, "Test Book")
 
+    def test_update_book_reading_fields_all_allowed_fields(self):
+        """Updates every allowed reading field in one call."""
+        book = self._create_book()
+        updated = self.db.update_book_reading_fields(
+            book.id,
+            started_at="2026-03-01",
+            finished_at="2026-03-20",
+            rating=4.0,
+            read_count=3,
+        )
+        self.assertEqual(updated.started_at, "2026-03-01")
+        self.assertEqual(updated.finished_at, "2026-03-20")
+        self.assertEqual(updated.rating, 4.0)
+        self.assertEqual(updated.read_count, 3)
+
+    def test_update_book_reading_fields_writes_none_for_nullable_fields(self):
+        """Passing None for allowed nullable fields writes the None through."""
+        book = self._create_book()
+        self.db.update_book_reading_fields(
+            book.id,
+            started_at="2026-03-01",
+            finished_at="2026-03-20",
+            rating=4.0,
+        )
+
+        cleared = self.db.update_book_reading_fields(
+            book.id,
+            started_at=None,
+            finished_at=None,
+            rating=None,
+        )
+        self.assertIsNone(cleared.started_at)
+        self.assertIsNone(cleared.finished_at)
+        self.assertIsNone(cleared.rating)
+
+        refreshed = self.db.get_book_by_abs_id("test-book-1")
+        self.assertIsNone(refreshed.started_at)
+        self.assertIsNone(refreshed.finished_at)
+        self.assertIsNone(refreshed.rating)
+
+    def test_update_book_reading_fields_unknown_only_returns_unchanged_book(self):
+        """Unknown-only kwargs return the unchanged detached book without mutating it."""
+        book = self._create_book()
+        self.db.update_book_reading_fields(book.id, started_at="2026-03-01", rating=4.0)
+
+        result = self.db.update_book_reading_fields(book.id, title="HACKED", author="HACKED")
+        self.assertIsNotNone(result)
+        # Pre-existing reading fields untouched, ignored kwargs not applied.
+        self.assertEqual(result.started_at, "2026-03-01")
+        self.assertEqual(result.rating, 4.0)
+        self.assertEqual(result.title, "Test Book")
+
+        refreshed = self.db.get_book_by_abs_id("test-book-1")
+        self.assertEqual(refreshed.title, "Test Book")
+        self.assertEqual(refreshed.started_at, "2026-03-01")
+
+    def test_update_book_reading_fields_detached_after_session_close(self):
+        """Returned book is usable after the session has closed."""
+        book = self._create_book()
+        updated = self.db.update_book_reading_fields(book.id, started_at="2026-03-01", rating=4.0)
+        # Accessing attributes after the session closed must not raise DetachedInstanceError.
+        self.assertEqual(updated.started_at, "2026-03-01")
+        self.assertEqual(updated.rating, 4.0)
+        self.assertEqual(updated.id, book.id)
+
+    def test_update_book_reading_fields_rejects_invalid_rating(self):
+        """An out-of-range rating raises ValueError."""
+        book = self._create_book()
+        for invalid in (-0.5, 5.5):
+            with self.subTest(rating=invalid):
+                with self.assertRaises(ValueError):
+                    self.db.update_book_reading_fields(book.id, rating=invalid)
+
+    def test_update_book_reading_fields_rejects_invalid_read_count(self):
+        """A read_count below 1 raises ValueError."""
+        book = self._create_book()
+        with self.assertRaises(ValueError):
+            self.db.update_book_reading_fields(book.id, read_count=0)
+
+    def test_update_book_reading_fields_validates_before_lookup(self):
+        """Validation runs before the DB lookup, so invalid input raises even for a missing book."""
+        with self.assertRaises(ValueError):
+            self.db.update_book_reading_fields(99999, rating=9.0)
+        with self.assertRaises(ValueError):
+            self.db.update_book_reading_fields(99999, read_count=0)
+
     def test_update_book_reading_fields_nonexistent(self):
         """Returns None for a missing book."""
         result = self.db.update_book_reading_fields(99999, rating=3.0)
@@ -280,6 +366,79 @@ class TestReadingTrackerModels(unittest.TestCase):
         journal = self.db.find_journal_by_event(book.id, "note")
         self.assertEqual(journal.entry, "detached")
         self.assertEqual(journal.book_id, book.id)
+
+    # -- update_reading_journal --
+
+    def test_update_reading_journal_updates_entry_only(self):
+        """Passing only entry updates the entry and leaves created_at intact."""
+        book = self._create_book()
+        created = datetime(2026, 1, 1, 0, 0, 0)
+        j = self.db.add_reading_journal(book.id, event="note", entry="old", created_at=created)
+
+        updated = self.db.update_reading_journal(j.id, entry="new")
+        self.assertEqual(updated.entry, "new")
+        self.assertEqual(updated.created_at, created)
+
+    def test_update_reading_journal_updates_created_at_only(self):
+        """Passing only created_at updates the timestamp and leaves entry intact."""
+        book = self._create_book()
+        j = self.db.add_reading_journal(
+            book.id, event="note", entry="keep", created_at=datetime(2026, 1, 1, 0, 0, 0)
+        )
+
+        new_dt = datetime(2026, 2, 2, 12, 30, 0)
+        updated = self.db.update_reading_journal(j.id, created_at=new_dt)
+        self.assertEqual(updated.entry, "keep")
+        self.assertEqual(updated.created_at, new_dt)
+
+    def test_update_reading_journal_updates_both(self):
+        """Passing both entry and created_at updates both fields."""
+        book = self._create_book()
+        j = self.db.add_reading_journal(
+            book.id, event="note", entry="old", created_at=datetime(2026, 1, 1, 0, 0, 0)
+        )
+
+        new_dt = datetime(2026, 3, 3, 9, 0, 0)
+        updated = self.db.update_reading_journal(j.id, entry="new", created_at=new_dt)
+        self.assertEqual(updated.entry, "new")
+        self.assertEqual(updated.created_at, new_dt)
+
+    def test_update_reading_journal_none_does_not_clear_fields(self):
+        """Passing None for entry/created_at leaves the existing values intact."""
+        book = self._create_book()
+        created = datetime(2026, 1, 1, 0, 0, 0)
+        j = self.db.add_reading_journal(book.id, event="note", entry="keep", created_at=created)
+
+        updated = self.db.update_reading_journal(j.id, entry=None, created_at=None)
+        self.assertEqual(updated.entry, "keep")
+        self.assertEqual(updated.created_at, created)
+
+    def test_update_reading_journal_no_kwargs_returns_unchanged(self):
+        """Calling with no update kwargs returns the unchanged journal."""
+        book = self._create_book()
+        created = datetime(2026, 1, 1, 0, 0, 0)
+        j = self.db.add_reading_journal(book.id, event="note", entry="keep", created_at=created)
+
+        updated = self.db.update_reading_journal(j.id)
+        self.assertIsNotNone(updated)
+        self.assertEqual(updated.entry, "keep")
+        self.assertEqual(updated.created_at, created)
+
+    def test_update_reading_journal_nonexistent(self):
+        """Returns None for a missing journal."""
+        self.assertIsNone(self.db.update_reading_journal(99999, entry="x"))
+
+    def test_update_reading_journal_detached_after_session_close(self):
+        """Returned journal is usable after the session has closed."""
+        book = self._create_book()
+        j = self.db.add_reading_journal(
+            book.id, event="note", entry="old", created_at=datetime(2026, 1, 1, 0, 0, 0)
+        )
+
+        updated = self.db.update_reading_journal(j.id, entry="detached")
+        # Accessing attributes after the session closed must not raise DetachedInstanceError.
+        self.assertEqual(updated.entry, "detached")
+        self.assertEqual(updated.book_id, book.id)
 
     # -- ReadingGoal CRUD --
 


### PR DESCRIPTION
## Stage 15: Reading mutation consolidation

This is Stage 15 of the backend cleanup. It consolidates one small piece of repeated boilerplate in `ReadingRepository`.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.** It targets the long-lived cleanup integration branch only.

### What changed
Extracted the repeated `query-by-id -> mutate -> flush -> refresh -> expunge -> return` pattern shared by `update_book_reading_fields` and `update_reading_journal` into a private `ReadingRepository._mutate_and_detach(model, *filters, mutate=...)` helper. Each public method keeps its own validation and field semantics in a small mutate callback.

No new `BaseRepository` helper was added (kept Reading-local per the stage plan). No public method signatures changed. No call sites changed.

### Behavior preserved (verified by tests)
`update_book_reading_fields`:
- validation runs before the DB lookup (invalid `rating`/`read_count` raise `ValueError` even for a missing book)
- `rating` allowed only when `None` or `0.0 <= rating <= 5.0`; `read_count` allowed only when `None` or `>= 1`
- exact lookup `Book.id == book_id`; allowed set exactly `{started_at, finished_at, rating, read_count}`
- unknown kwargs ignored; unknown-only kwargs return the unchanged detached book
- allowed keys with `None` values written through
- flush/refresh/expunge detached return preserved

`update_reading_journal`:
- exact lookup `ReadingJournal.id == journal_id`; missing returns `None`
- `entry`/`created_at` updated only when not `None`; passing `None` does not clear
- no-kwargs call returns the unchanged detached journal
- flush/refresh/expunge detached return preserved

### Tests added
14 focused tests in `tests/test_reading_tracker.py` covering all the behaviors above (all-allowed-fields update, None passthrough, unknown-only kwargs, detached-after-close, invalid rating/read_count, validation-before-lookup; journal entry-only/created_at-only/both/None-no-clear/no-kwargs/missing/detached).

### Verification
- `git status --short`: only `src/db/reading_repository.py` and `tests/test_reading_tracker.py`
- `ruff check src/ tests/ alembic/ scripts/`: All checks passed
- `./run-tests.sh tests/test_reading_tracker.py tests/test_reading_routes.py tests/test_reading_bp_errors.py tests/test_reading_journal_markdown.py tests/test_tbr_routes.py tests/test_reading_date_service.py`: 152 passed
- `./run-tests.sh` (full): 1051 passed, 3 skipped

### Out of scope (unchanged)
`add_reading_journal`/`delete_reading_journal` semantics, Stage 14 getters, `cleanup_bookfusion_import_notes`, reading goals/stats, routes/response shapes, DB schema/migrations, frontend.

### Caveats
None. No DB/fixture/frontend files touched; no routes or response shapes changed.

Next stage will be another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate mutation logic in `ReadingRepository` with a `_mutate_and_detach` helper
> - Adds a private `_mutate_and_detach` helper in [reading_repository.py](https://github.com/serabi/pagekeeper/pull/99/files#diff-09510a40cdc79c2d86d62bc0c932f66726523b53f4c2125c5dbce128b0a74eb9) that handles the query/flush/refresh/expunge workflow for a single row, accepting a caller-supplied mutation function.
> - Rewrites `update_book_reading_fields` and `update_reading_journal` to delegate session management to `_mutate_and_detach`, removing duplicated boilerplate from each method.
> - Adds 14 new tests in [test_reading_tracker.py](https://github.com/serabi/pagekeeper/pull/99/files#diff-10a389949fe9f070f769fc5e0e32bfaf31a54aaa14f67e64cc99b5e0ab4243fe) covering field updates, validation order, None semantics, unknown kwargs, not-found cases, and detached object safety.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 869a6b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->