### PR TITLE
Cleanup 16: consolidate BookRepository getters

### DIFF
--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -104,10 +104,8 @@ class BookRepository(BaseRepository):
         if not query or not query.strip():
             return []
         with self.get_session() as session:
-            results = session.query(Book).filter(Book.title.ilike(f"%{query}%")).limit(limit).all()
-            for r in results:
-                session.expunge(r)
-            return results
+            db_query = session.query(Book).filter(Book.title.ilike(f"%{query}%")).limit(limit)
+            return self._query_and_expunge(session, db_query, one=False)
 
     def get_book_by_ebook_filename(self, filename):
         """Find a book by its ebook filename (current or original)."""
@@ -458,10 +456,8 @@ class BookRepository(BaseRepository):
 
     def get_latest_job(self, book_id):
         with self.get_session() as session:
-            job = session.query(Job).filter(Job.book_id == book_id).order_by(Job.last_attempt.desc()).first()
-            if job:
-                session.expunge(job)
-            return job
+            db_query = session.query(Job).filter(Job.book_id == book_id).order_by(Job.last_attempt.desc())
+            return self._query_and_expunge(session, db_query, one=True)
 
     def get_latest_jobs_bulk(self, book_ids):
         """Fetch the latest job for each book_id in one query.
@@ -534,29 +530,23 @@ class BookRepository(BaseRepository):
                 .group_by(State.book_id)
                 .subquery()
             )
-            books = (
+            db_query = (
                 session.query(Book)
                 .join(latest, Book.id == latest.c.book_id)
                 .order_by(latest.c.max_updated.desc())
                 .limit(limit)
-                .all()
             )
-            for book in books:
-                session.expunge(book)
-            return books
+            return self._query_and_expunge(session, db_query, one=False)
 
     def get_failed_jobs(self, limit=20):
         with self.get_session() as session:
-            jobs = (
+            db_query = (
                 session.query(Job)
                 .filter(Job.last_error.isnot(None))
                 .order_by(Job.last_attempt.desc())
                 .limit(limit)
-                .all()
             )
-            for job in jobs:
-                session.expunge(job)
-            return jobs
+            return self._query_and_expunge(session, db_query, one=False)
 
     def get_statistics(self):
         with self.get_session() as session:

--- a/tests/test_book_repository_getters.py
+++ b/tests/test_book_repository_getters.py
@@ -1,0 +1,233 @@
+"""Behavior-characterization tests for BookRepository getters.
+
+These lock in the filtering, ordering, limit, empty-result, and detachment
+behavior of the four getter methods consolidated onto ``_query_and_expunge``
+in the Stage 16 backend cleanup:
+
+- ``search_books()``
+- ``get_latest_job()``
+- ``get_books_with_recent_activity()``
+- ``get_failed_jobs()``
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.db.database_service import DatabaseService
+from src.db.models import Book, Job, State
+
+
+@pytest.fixture
+def db_service():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+        service = DatabaseService(str(db_path))
+        try:
+            yield service
+        finally:
+            service.db_manager.close()
+
+
+def _save_book(db_service, abs_id, title, status="active"):
+    return db_service.save_book(
+        Book(
+            abs_id=abs_id,
+            title=title,
+            ebook_filename=f"{abs_id}.epub",
+            kosync_doc_id=f"doc-{abs_id}",
+            status=status,
+        )
+    )
+
+
+def _save_job(db_service, book, last_attempt, last_error=None):
+    return db_service.save_job(
+        Job(
+            abs_id=book.abs_id,
+            book_id=book.id,
+            last_attempt=last_attempt,
+            last_error=last_error,
+        )
+    )
+
+
+def _save_state(db_service, book, client_name, last_updated):
+    return db_service.save_state(
+        State(
+            abs_id=book.abs_id,
+            book_id=book.id,
+            client_name=client_name,
+            last_updated=last_updated,
+            percentage=0.5,
+        )
+    )
+
+
+# ── search_books ──
+
+
+def test_search_books_blank_query_returns_empty(db_service):
+    _save_book(db_service, "abs-1", "The Hobbit")
+    assert db_service.search_books("") == []
+    assert db_service.search_books(None) == []
+    assert db_service.search_books("   ") == []
+
+
+def test_search_books_is_case_insensitive_substring(db_service):
+    _save_book(db_service, "abs-1", "The Hobbit")
+    _save_book(db_service, "abs-2", "Dune")
+    results = db_service.search_books("hobb")
+    assert {b.title for b in results} == {"The Hobbit"}
+    results_upper = db_service.search_books("HOBB")
+    assert {b.title for b in results_upper} == {"The Hobbit"}
+
+
+def test_search_books_preserves_unstripped_query_in_filter(db_service):
+    # The truthiness/strip guard does not strip the query passed to ILIKE, so an
+    # interior space remains significant and a padded substring with no exact
+    # spacing match returns nothing.
+    _save_book(db_service, "abs-1", "The Hobbit")
+    assert db_service.search_books("the hobbit") != []
+    assert db_service.search_books("the  hobbit") == []
+
+
+def test_search_books_honors_limit(db_service):
+    for i in range(5):
+        _save_book(db_service, f"abs-{i}", f"Book {i}")
+    results = db_service.search_books("Book", limit=2)
+    assert len(results) == 2
+
+
+def test_search_books_no_match_returns_empty(db_service):
+    _save_book(db_service, "abs-1", "The Hobbit")
+    assert db_service.search_books("nonexistent") == []
+
+
+def test_search_books_rows_detached_and_usable(db_service):
+    _save_book(db_service, "abs-1", "The Hobbit")
+    results = db_service.search_books("Hobbit")
+    assert results[0].title == "The Hobbit"
+    assert results[0].abs_id == "abs-1"
+
+
+# ── get_latest_job ──
+
+
+def test_get_latest_job_returns_newest_by_last_attempt_desc(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0)
+    _save_job(db_service, book, last_attempt=300.0)
+    _save_job(db_service, book, last_attempt=200.0)
+    latest = db_service.get_latest_job(book.id)
+    assert latest.last_attempt == 300.0
+
+
+def test_get_latest_job_ignores_other_books(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    _save_job(db_service, book_a, last_attempt=100.0)
+    _save_job(db_service, book_b, last_attempt=500.0)
+    latest = db_service.get_latest_job(book_a.id)
+    assert latest.book_id == book_a.id
+    assert latest.last_attempt == 100.0
+
+
+def test_get_latest_job_none_when_no_jobs(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    assert db_service.get_latest_job(book.id) is None
+
+
+def test_get_latest_job_row_detached_and_usable(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0)
+    latest = db_service.get_latest_job(book.id)
+    assert latest.last_attempt == 100.0
+    assert latest.book_id == book.id
+
+
+# ── get_books_with_recent_activity ──
+
+
+def test_recent_activity_orders_by_latest_state_desc(db_service):
+    book_old = _save_book(db_service, "abs-old", "Old Book")
+    book_new = _save_book(db_service, "abs-new", "New Book")
+    _save_state(db_service, book_old, "koreader", last_updated=100.0)
+    _save_state(db_service, book_new, "koreader", last_updated=300.0)
+    books = db_service.get_books_with_recent_activity()
+    assert [b.title for b in books] == ["New Book", "Old Book"]
+
+
+def test_recent_activity_uses_max_state_per_book(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    # Book A's most-recent state beats Book B's single state.
+    _save_state(db_service, book_a, "koreader", last_updated=100.0)
+    _save_state(db_service, book_a, "calibre", last_updated=400.0)
+    _save_state(db_service, book_b, "koreader", last_updated=300.0)
+    books = db_service.get_books_with_recent_activity()
+    assert [b.title for b in books] == ["Book A", "Book B"]
+
+
+def test_recent_activity_honors_limit(db_service):
+    for i in range(5):
+        book = _save_book(db_service, f"abs-{i}", f"Book {i}")
+        _save_state(db_service, book, "koreader", last_updated=float(i))
+    books = db_service.get_books_with_recent_activity(limit=2)
+    assert len(books) == 2
+
+
+def test_recent_activity_empty_when_no_states(db_service):
+    _save_book(db_service, "abs-1", "Book")
+    assert db_service.get_books_with_recent_activity() == []
+
+
+def test_recent_activity_rows_detached_and_usable(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_state(db_service, book, "koreader", last_updated=100.0)
+    books = db_service.get_books_with_recent_activity()
+    assert books[0].title == "Book"
+    assert books[0].abs_id == "abs-1"
+
+
+# ── get_failed_jobs ──
+
+
+def test_get_failed_jobs_filters_non_null_error(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0, last_error=None)
+    _save_job(db_service, book, last_attempt=200.0, last_error="boom")
+    failed = db_service.get_failed_jobs()
+    assert {j.last_error for j in failed} == {"boom"}
+
+
+def test_get_failed_jobs_orders_by_last_attempt_desc(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0, last_error="first")
+    _save_job(db_service, book, last_attempt=300.0, last_error="third")
+    _save_job(db_service, book, last_attempt=200.0, last_error="second")
+    failed = db_service.get_failed_jobs()
+    assert [j.last_error for j in failed] == ["third", "second", "first"]
+
+
+def test_get_failed_jobs_honors_limit(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    for i in range(5):
+        _save_job(db_service, book, last_attempt=float(i), last_error=f"err-{i}")
+    failed = db_service.get_failed_jobs(limit=2)
+    assert len(failed) == 2
+
+
+def test_get_failed_jobs_empty_when_no_failures(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0, last_error=None)
+    assert db_service.get_failed_jobs() == []
+
+
+def test_get_failed_jobs_rows_detached_and_usable(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0, last_error="boom")
+    failed = db_service.get_failed_jobs()
+    assert failed[0].last_error == "boom"
+    assert failed[0].book_id == book.id


### PR DESCRIPTION
## Stage 16: consolidate BookRepository getters

This is **Stage 16** of the backend cleanup. It consolidates manual query/expunge boilerplate in four `BookRepository` getter methods onto the existing `BaseRepository._query_and_expunge(...)` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.**

### What changed

Four getter methods now build the same SQLAlchemy query as before and delegate the `.all()`/`.first()` + expunge step to `_query_and_expunge`:

- `search_books(query, limit=10)` → `one=False`
- `get_latest_job(book_id)` → `one=True`
- `get_books_with_recent_activity(limit=10)` → `one=False`
- `get_failed_jobs(limit=20)` → `one=False`

### Behavior preserved (exactly)

- `search_books`: falsy/whitespace-only query still returns `[]` before opening a session; filter stays `Book.title.ilike(f"%{query}%")` (query not stripped/normalized before filtering); `.limit(limit)` unchanged; no ordering added; `[]` on no match; rows detached.
- `get_latest_job`: filters `Job.book_id == book_id`; orders `Job.last_attempt.desc()`; returns first row or `None`; row detached.
- `get_books_with_recent_activity`: subquery `State.book_id, max(State.last_updated)` grouped by `State.book_id`; join on `Book.id == latest.c.book_id`; order `latest.c.max_updated.desc()`; `.limit(limit)` unchanged; `[]` when no states; rows detached.
- `get_failed_jobs`: filters `Job.last_error.isnot(None)`; order `Job.last_attempt.desc()`; `.limit(limit)` unchanged; `[]` when none; rows detached.

`_query_and_expunge` is behaviorally identical to the manual loops it replaces (it expunges each row for the list path, and expunges-if-present for the single path). No save/update/delete/statistics methods touched. `get_latest_jobs_bulk()` left bespoke as required. Public signatures and call sites unchanged.

### Tests added

New focused file `tests/test_book_repository_getters.py` (20 tests) with deterministic float timestamps, no sleeps. Covers, per method: filtering, case-insensitive substring search, unstripped-query behavior, limit honoring, ordering, ignoring other books, empty results, and post-session detachment.

### Verification

```
git status --short          # only the two intended files
git branch --show-current   # cleanup/16-book-repository-getter-helper
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh tests/test_book_repository_getters.py            # 20 passed
./run-tests.sh tests/test_background_job_service.py \
  tests/test_tbr_routes.py tests/test_dashboard_errors.py \
  tests/test_database_service_integration.py                   # 145 passed
./run-tests.sh                                                  # 1071 passed, 3 skipped
```

No DB/fixture files committed; no frontend changes; no route/response-shape changes.

### Caveats

None. Pure boilerplate consolidation with equivalent behavior.

### Next

Next stage will be another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `BookRepository` getter methods to use `_query_and_expunge`
> - Refactors `search_books`, `get_latest_job`, `get_books_with_recent_activity`, and `get_failed_jobs` in [book_repository.py](https://github.com/serabi/pagekeeper/pull/100/files#diff-6640b6d835c572d39e06863fb3d7fb78a901c877d9b6583d967c20236e6d5619) to build query objects and delegate execution and session detachment to the shared `_query_and_expunge` helper.
> - Removes duplicated manual expunge loops and direct `.all()`/`.first()` calls from each method.
> - Adds a new test module [test_book_repository_getters.py](https://github.com/serabi/pagekeeper/pull/100/files#diff-6d6bdf5319fbaab39f46bb5669cf4915179f281d6927ac33bb031e240e259020) with behavior-characterization tests covering ordering, filtering, limits, empty results, and row detachment for all four methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29434fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->