### PR TITLE
Cleanup 17: consolidate BookRepository mutations

### DIFF
--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -145,22 +145,37 @@ class BookRepository(BaseRepository):
         else:
             return self._save_new(book)
 
+    def _mutate_first_and_detach(self, query_factory, mutate):
+        """Load the first row from ``query_factory``, mutate it, and return it detached.
+
+        Returns ``None`` when no row matches. Otherwise applies ``mutate(obj)``
+        for the method's domain-specific semantics, then flushes, refreshes, and
+        expunges the row so callers receive a detached, usable object after the
+        session closes.
+        """
+        with self.get_session() as session:
+            obj = query_factory(session).first()
+            if not obj:
+                return None
+            mutate(obj)
+            session.flush()
+            session.refresh(obj)
+            session.expunge(obj)
+            return obj
+
     def update_book_metadata_overrides(self, book_id, *, title_override=_UNSET, author_override=_UNSET):
         """Update PageKeeper-local metadata override fields for a book."""
-        with self.get_session() as session:
-            book = session.query(Book).filter(Book.id == book_id).first()
-            if not book:
-                return None
 
+        def mutate(book):
             if title_override is not _UNSET:
                 book.title_override = title_override or None
             if author_override is not _UNSET:
                 book.author_override = author_override or None
 
-            session.flush()
-            session.refresh(book)
-            session.expunge(book)
-            return book
+        return self._mutate_first_and_detach(
+            lambda session: session.query(Book).filter(Book.id == book_id),
+            mutate,
+        )
 
     def delete_book(self, book_id):
         with self.get_session() as session:
@@ -501,19 +516,17 @@ class BookRepository(BaseRepository):
         return self._save_new(job)
 
     def update_latest_job(self, book_id, **kwargs):
-        with self.get_session() as session:
-            job = session.query(Job).filter(Job.book_id == book_id).order_by(Job.last_attempt.desc()).first()
-            if job:
-                for key, value in kwargs.items():
-                    if hasattr(job, key):
-                        setattr(job, key, value)
-                    else:
-                        logger.warning(f"update_latest_job: unknown attribute '{key}' for job {job.id}")
-                session.flush()
-                session.refresh(job)
-                session.expunge(job)
-                return job
-            return None
+        def mutate(job):
+            for key, value in kwargs.items():
+                if hasattr(job, key):
+                    setattr(job, key, value)
+                else:
+                    logger.warning(f"update_latest_job: unknown attribute '{key}' for job {job.id}")
+
+        return self._mutate_first_and_detach(
+            lambda session: session.query(Job).filter(Job.book_id == book_id).order_by(Job.last_attempt.desc()),
+            mutate,
+        )
 
     def delete_jobs_for_book(self, book_id):
         with self.get_session() as session:

--- a/tests/test_book_repository_mutations.py
+++ b/tests/test_book_repository_mutations.py
@@ -1,0 +1,201 @@
+"""Behavior-characterization tests for BookRepository object-return mutations.
+
+These lock in the filtering, mutation, and detachment behavior of the two
+mutation methods consolidated onto the private ``_mutate_first_and_detach``
+helper in the Stage 17 backend cleanup:
+
+- ``update_book_metadata_overrides()``
+- ``update_latest_job()``
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.db.database_service import DatabaseService
+from src.db.models import Book, Job
+
+
+@pytest.fixture
+def db_service():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+        service = DatabaseService(str(db_path))
+        try:
+            yield service
+        finally:
+            service.db_manager.close()
+
+
+def _save_book(db_service, abs_id="book-1", title="Title", author="Author"):
+    return db_service.save_book(Book(abs_id=abs_id, title=title, author=author))
+
+
+def _save_job(db_service, book, last_attempt, **kwargs):
+    return db_service.save_job(
+        Job(abs_id=book.abs_id, book_id=book.id, last_attempt=last_attempt, **kwargs)
+    )
+
+
+# ── update_book_metadata_overrides ──
+
+
+def test_updates_title_and_author_overrides_independently(db_service):
+    book = _save_book(db_service)
+
+    updated = db_service.update_book_metadata_overrides(
+        book.id, title_override="Clean Title", author_override="Clean Author"
+    )
+
+    assert updated.title_override == "Clean Title"
+    assert updated.author_override == "Clean Author"
+
+    title_only = db_service.update_book_metadata_overrides(book.id, title_override="New Title")
+    assert title_only.title_override == "New Title"
+    assert title_only.author_override == "Clean Author"
+
+
+def test_unset_preserves_existing_override(db_service):
+    book = _save_book(db_service)
+    db_service.update_book_metadata_overrides(
+        book.id, title_override="Keep Title", author_override="Keep Author"
+    )
+
+    updated = db_service.update_book_metadata_overrides(book.id, author_override="Changed Author")
+
+    assert updated.title_override == "Keep Title"
+    assert updated.author_override == "Changed Author"
+
+
+def test_none_clears_only_specified_override(db_service):
+    book = _save_book(db_service)
+    db_service.update_book_metadata_overrides(
+        book.id, title_override="Title Override", author_override="Author Override"
+    )
+
+    updated = db_service.update_book_metadata_overrides(book.id, title_override=None)
+
+    assert updated.title_override is None
+    assert updated.author_override == "Author Override"
+
+
+def test_empty_string_clears_only_specified_override(db_service):
+    book = _save_book(db_service)
+    db_service.update_book_metadata_overrides(
+        book.id, title_override="Title Override", author_override="Author Override"
+    )
+
+    updated = db_service.update_book_metadata_overrides(book.id, author_override="")
+
+    assert updated.title_override == "Title Override"
+    assert updated.author_override is None
+
+
+def test_missing_book_returns_none(db_service):
+    assert db_service.update_book_metadata_overrides(99999, title_override="Missing") is None
+
+
+def test_no_argument_call_returns_unchanged_detached_book(db_service):
+    book = _save_book(db_service)
+    db_service.update_book_metadata_overrides(book.id, title_override="Existing")
+
+    updated = db_service.update_book_metadata_overrides(book.id)
+
+    assert updated.id == book.id
+    assert updated.title_override == "Existing"
+
+
+def test_returned_book_is_detached_and_usable(db_service):
+    book = _save_book(db_service, title="Imported")
+    updated = db_service.update_book_metadata_overrides(book.id, title_override="Override")
+
+    assert updated.title == "Imported"
+    assert updated.title_override == "Override"
+    assert updated.display_title == "Override"
+
+
+# ── update_latest_job ──
+
+
+def test_updates_only_newest_job_by_last_attempt_desc(db_service):
+    book = _save_book(db_service)
+    _save_job(db_service, book, last_attempt=100.0, progress=0.1)
+    newest = _save_job(db_service, book, last_attempt=200.0, progress=0.2)
+
+    updated = db_service.update_latest_job(book.id, progress=0.9)
+
+    assert updated.id == newest.id
+    assert updated.progress == 0.9
+
+    older = db_service.get_jobs_for_book(book.id)
+    older_by_ts = {job.last_attempt: job.progress for job in older}
+    assert older_by_ts[100.0] == 0.1
+
+
+def test_ignores_jobs_for_other_books(db_service):
+    book = _save_book(db_service, abs_id="book-a")
+    other = _save_book(db_service, abs_id="book-b")
+    _save_job(db_service, other, last_attempt=500.0, progress=0.0)
+    target = _save_job(db_service, book, last_attempt=100.0, progress=0.0)
+
+    updated = db_service.update_latest_job(book.id, progress=0.5)
+
+    assert updated.id == target.id
+    assert updated.progress == 0.5
+
+
+def test_writes_allowed_fields_including_none(db_service):
+    book = _save_book(db_service)
+    _save_job(db_service, book, last_attempt=100.0, last_error="boom")
+
+    updated = db_service.update_latest_job(book.id, last_error=None, retry_count=3)
+
+    assert updated.last_error is None
+    assert updated.retry_count == 3
+
+
+def test_unknown_kwargs_ignored_but_warning_logged(db_service, caplog):
+    book = _save_book(db_service)
+    job = _save_job(db_service, book, last_attempt=100.0, progress=0.0)
+
+    with caplog.at_level("WARNING"):
+        updated = db_service.update_latest_job(book.id, progress=0.7, bogus_field="x")
+
+    assert updated.progress == 0.7
+    assert not hasattr(updated, "bogus_field")
+    assert f"update_latest_job: unknown attribute 'bogus_field' for job {job.id}" in caplog.text
+
+
+def test_unknown_only_kwargs_return_unchanged_detached_latest_job(db_service):
+    book = _save_book(db_service)
+    _save_job(db_service, book, last_attempt=100.0, progress=0.42)
+
+    updated = db_service.update_latest_job(book.id, nope="x")
+
+    assert updated.progress == 0.42
+
+
+def test_empty_kwargs_return_unchanged_detached_latest_job(db_service):
+    book = _save_book(db_service)
+    _save_job(db_service, book, last_attempt=100.0, progress=0.33)
+
+    updated = db_service.update_latest_job(book.id)
+
+    assert updated.progress == 0.33
+
+
+def test_missing_job_returns_none(db_service):
+    book = _save_book(db_service)
+
+    assert db_service.update_latest_job(book.id, progress=0.5) is None
+
+
+def test_returned_job_is_detached_and_usable(db_service):
+    book = _save_book(db_service)
+    _save_job(db_service, book, last_attempt=100.0, progress=0.0)
+
+    updated = db_service.update_latest_job(book.id, progress=0.6)
+
+    assert updated.book_id == book.id
+    assert updated.progress == 0.6


### PR DESCRIPTION
## Stage 17: BookRepository mutation consolidation

Part of the backend cleanup series. Base branch is `cleanup/backend-cleanup-2026-06-29`. **This does not merge to `dev`.**

### What changed

Extracted the repeated object-return mutation finalization path shared by two `BookRepository` methods into a private `_mutate_first_and_detach(query_factory, mutate)` helper:

- `update_book_metadata_overrides(book_id, *, title_override=_UNSET, author_override=_UNSET)`
- `update_latest_job(book_id, **kwargs)`

Both previously open-coded the same shape: `query.first()` -> return `None` if missing -> mutate -> `flush` / `refresh` / `expunge` / return. Each public method now passes a query builder and a mutation callback, keeping its own domain-specific semantics in a small local closure.

The helper is private to `BookRepository` only. No `BaseRepository` helper was added or changed.

### Behavior preserved (exactly)

`update_book_metadata_overrides`:
- Filters exactly `Book.id == book_id`; missing book returns `None`.
- `_UNSET` leaves the field unchanged; `None` and `""` clear via `value or None`.
- Title and author independent; no-arg call returns the unchanged detached book.
- Public signature and detachment behavior unchanged.

`update_latest_job`:
- Filters exactly `Job.book_id == book_id`, orders by `Job.last_attempt.desc()`, mutates only `.first()`.
- Missing job returns `None`.
- Per kwarg in iteration order: `setattr` when `hasattr` (including `None`), else logs the identical warning `update_latest_job: unknown attribute '{key}' for job {job.id}` and continues.
- Unknown-only and empty kwargs return the unchanged detached latest job.
- Public signature and detachment behavior unchanged.

Not touched: `save_book`/`_upsert`, `save_state`/state dedupe, `migrate_book_data`, Stage 16 getters, `get_latest_jobs_bulk`, `save_job`, delete/count/statistics methods.

### Tests

Added `tests/test_book_repository_mutations.py` (15 focused tests) covering, for both methods: independent field updates, `_UNSET`/`None`/`""` clearing semantics, missing-row `None`, no-arg/empty/unknown-only no-op paths, newest-by-`last_attempt DESC` selection, other-book isolation, allowed `None` writes, the unknown-attribute warning, and post-session detachment. Deterministic float timestamps; no sleeps.

### Verification

```
git status --short        # clean (only the two intended changes before commit)
git branch --show-current # cleanup/17-book-repository-mutation-helper
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh <targeted suites>           # 204 passed
./run-tests.sh                             # 1086 passed, 3 skipped (pre-existing)
```

No DB/fixture files, no frontend files, no routes/snapshots, no migrations changed. Only `src/db/book_repository.py` and the new test file.

### Caveats

None. Pure readability refactor with exact behavior preservation.

### Next

Another bounded repository consolidation only after this PR's checks/Macroscope are reviewed and merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `BookRepository` mutation logic into `_mutate_first_and_detach` helper
> - Adds `_mutate_first_and_detach` to [book_repository.py](https://github.com/serabi/pagekeeper/pull/101/files#diff-6640b6d835c572d39e06863fb3d7fb78a901c877d9b6583d967c20236e6d5619), a shared helper that runs a query, applies a mutation function, then flushes, refreshes, and expunges the object before returning it.
> - Refactors `update_book_metadata_overrides` and `update_latest_job` to delegate their core logic to this helper, removing duplicated session-management code.
> - Adds [test_book_repository_mutations.py](https://github.com/serabi/pagekeeper/pull/101/files#diff-eae10a4e1da1bcb828e568bce9ec1fc3568e9f0c2dca2b7341eae6c960ce6fad) with behavior-characterization tests covering edge cases such as missing records, detached object usability, unknown kwargs, and job ordering by `last_attempt` descending.
> - Behavioral Change: both methods now consistently return a detached, refreshed object after mutation, and `None` when no matching row exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 630d4cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->