### PR TITLE
Cleanup 18: consolidate bulk job getter

### DIFF
--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -491,18 +491,14 @@ class BookRepository(BaseRepository):
                 .group_by(Job.book_id)
                 .subquery()
             )
-            rows = (
-                session.query(Job)
-                .join(
-                    latest,
-                    (Job.book_id == latest.c.book_id)
-                    & (func.coalesce(Job.last_attempt, "1970-01-01") == func.coalesce(latest.c.max_ts, "1970-01-01")),
-                )
-                .all()
+            db_query = session.query(Job).join(
+                latest,
+                (Job.book_id == latest.c.book_id)
+                & (func.coalesce(Job.last_attempt, "1970-01-01") == func.coalesce(latest.c.max_ts, "1970-01-01")),
             )
+            rows = self._query_and_expunge(session, db_query, one=False)
             result = {}
             for job in rows:
-                session.expunge(job)
                 result[job.book_id] = job
             return result
 

--- a/tests/test_book_repository_getters.py
+++ b/tests/test_book_repository_getters.py
@@ -8,6 +8,11 @@ in the Stage 16 backend cleanup:
 - ``get_latest_job()``
 - ``get_books_with_recent_activity()``
 - ``get_failed_jobs()``
+
+They also lock in the bulk getter consolidated onto ``_query_and_expunge`` in
+the Stage 18 backend cleanup:
+
+- ``get_latest_jobs_bulk()``
 """
 
 import tempfile
@@ -145,6 +150,64 @@ def test_get_latest_job_row_detached_and_usable(db_service):
     latest = db_service.get_latest_job(book.id)
     assert latest.last_attempt == 100.0
     assert latest.book_id == book.id
+
+
+# ── get_latest_jobs_bulk ──
+
+
+def test_get_latest_jobs_bulk_empty_input_returns_empty_dict(db_service):
+    assert db_service.get_latest_jobs_bulk([]) == {}
+    assert db_service.get_latest_jobs_bulk(None) == {}
+
+
+def test_get_latest_jobs_bulk_returns_latest_per_book_by_max_last_attempt(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    _save_job(db_service, book_a, last_attempt=100.0)
+    _save_job(db_service, book_a, last_attempt=300.0)
+    _save_job(db_service, book_b, last_attempt=200.0)
+    result = db_service.get_latest_jobs_bulk([book_a.id, book_b.id])
+    assert set(result.keys()) == {book_a.id, book_b.id}
+    assert result[book_a.id].last_attempt == 300.0
+    assert result[book_b.id].last_attempt == 200.0
+
+
+def test_get_latest_jobs_bulk_ignores_books_not_requested(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    _save_job(db_service, book_a, last_attempt=100.0)
+    _save_job(db_service, book_b, last_attempt=500.0)
+    result = db_service.get_latest_jobs_bulk([book_a.id])
+    assert set(result.keys()) == {book_a.id}
+    assert result[book_a.id].last_attempt == 100.0
+
+
+def test_get_latest_jobs_bulk_empty_when_requested_books_have_no_jobs(db_service):
+    book_a = _save_book(db_service, "abs-a", "Book A")
+    book_b = _save_book(db_service, "abs-b", "Book B")
+    assert db_service.get_latest_jobs_bulk([book_a.id, book_b.id]) == {}
+
+
+def test_get_latest_jobs_bulk_handles_single_null_last_attempt(db_service):
+    # With one job whose last_attempt is NULL, the coalesce join matches the
+    # NULL row against its own grouped max (also NULL via coalesce to the
+    # epoch sentinel), so that job is returned for the book.
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=None)
+    result = db_service.get_latest_jobs_bulk([book.id])
+    assert set(result.keys()) == {book.id}
+    assert result[book.id].book_id == book.id
+    assert result[book.id].last_attempt is None
+
+
+def test_get_latest_jobs_bulk_rows_detached_and_usable(db_service):
+    book = _save_book(db_service, "abs-1", "Book")
+    _save_job(db_service, book, last_attempt=100.0)
+    result = db_service.get_latest_jobs_bulk([book.id])
+    job = result[book.id]
+    assert job.book_id == book.id
+    assert job.last_attempt == 100.0
+    assert job.abs_id == "abs-1"
 
 
 # ── get_books_with_recent_activity ──


### PR DESCRIPTION
## Stage 18: BookRepository bulk job getter consolidation

Backend cleanup Stage 18. Consolidates the manual terminal query/expunge
boilerplate in a single `BookRepository` bulk getter onto the shared
`_query_and_expunge` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This PR does NOT merge to `dev`.**

### What changed

`BookRepository.get_latest_jobs_bulk(book_ids)` previously ran a
`session.query(Job).join(...).all()` and then expunged each returned job in a
loop while building a `{book_id: Job}` dict. The terminal `.all()` + manual
`session.expunge(job)` loop is replaced by
`self._query_and_expunge(session, db_query, one=False)`.

### Behavior preserved

- Falsy/empty `book_ids` still returns `{}` before opening a DB session.
- The grouped latest-job subquery is unchanged:
  `session.query(Job.book_id, func.max(Job.last_attempt).label("max_ts")).filter(Job.book_id.in_(book_ids)).group_by(Job.book_id).subquery()`.
- The join condition is byte-identical: `Job.book_id == latest.c.book_id` AND
  `func.coalesce(Job.last_attempt, "1970-01-01") == func.coalesce(latest.c.max_ts, "1970-01-01")`.
- No ordering or tie-breaking added or changed.
- Returns `{}` when no matching jobs exist.
- Returns a dict keyed by `job.book_id` with detached `Job` rows; dict
  construction stays inline in the method.
- Public signature unchanged. `book_id` is a loaded mapped column read on the
  detached instance — the prior code already read `job.book_id` immediately
  after `session.expunge(job)`, so post-expunge access is the established
  behavior.

### Tests added

Added characterization tests to `tests/test_book_repository_getters.py` for
`get_latest_jobs_bulk()`:

- empty input returns `{}`;
- latest job per requested book by max `last_attempt`;
- ignores jobs for books not requested;
- returns `{}` for requested books with no jobs;
- single `None` `last_attempt` job returned per the coalesce join behavior;
- returned `Job` rows are detached/usable after session close.

All use explicit deterministic timestamps; none rely on tie ordering for equal
max timestamps.

### Verification

```
git status --short                       # only src/db/book_repository.py + tests file
ruff check src/ tests/ alembic/ scripts/ # All checks passed!
./run-tests.sh <four focused files>      # 115 passed
./run-tests.sh                           # 1092 passed, 3 skipped
```

New bulk-getter tests confirmed passing against the pre-refactor implementation
(characterization) and again after the refactor.

### Caveats

None. Scope is limited to the one bulk getter's terminal query/expunge
boilerplate. No `save_book`/`_upsert`, state, migration, job mutation, Stage
16/17, route, schema, or frontend changes.

Next stage should proceed only after this PR's checks/Macroscope are reviewed
and it is merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `BookRepository.get_latest_jobs_bulk` to use `_query_and_expunge` helper
> Replaces the inline `session.query().join().all()` loop with a call to the shared `_query_and_expunge` helper in [book_repository.py](https://github.com/serabi/pagekeeper/pull/102/files#diff-6640b6d835c572d39e06863fb3d7fb78a901c877d9b6583d967c20236e6d5619), matching the pattern used by other getters. Adds tests in [test_book_repository_getters.py](https://github.com/serabi/pagekeeper/pull/102/files#diff-6d6bdf5319fbaab39f46bb5669cf4915179f281d6927ac33bb031e240e259020) covering edge cases including empty input, missing jobs, NULL `last_attempt`, and detached row usability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a92c047.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->