### PR TITLE
Cleanup 19: consolidate detected active getter

### DIFF
--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -25,10 +25,7 @@ class DetectedRepository(BaseRepository):
             )
             if limit is not None:
                 query = query.limit(limit)
-            items = query.all()
-            for item in items:
-                session.expunge(item)
-            return items
+            return self._query_and_expunge(session, query, one=False)
 
     UPSERT_ATTRS = (
         "title",

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -477,6 +477,103 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(row.author, "Existing Author")
         self.assertAlmostEqual(row.progress_percentage, 0.7)
 
+    def _make_detected(self, source_id, last_seen_at, status="detected"):
+        from src.db.models import DetectedBook
+
+        book = DetectedBook(
+            source="abs",
+            source_id=source_id,
+            title=source_id,
+            progress_percentage=0.1,
+            status=status,
+        )
+        book.last_seen_at = last_seen_at
+        return book
+
+    def test_get_active_detected_books_returns_only_detected_status(self):
+        """Only rows with status 'detected' are returned; dismissed/resolved are excluded."""
+        from datetime import UTC, datetime
+
+        base = datetime(2023, 1, 1, tzinfo=UTC)
+        for source_id, status in (
+            ("active-a", "detected"),
+            ("active-b", "detected"),
+            ("gone-dismissed", "detected"),
+            ("gone-resolved", "detected"),
+        ):
+            self.db_service.save_detected_book(self._make_detected(source_id, base, status))
+
+        self.assertTrue(self.db_service.dismiss_detected_book("gone-dismissed", source="abs"))
+        self.assertTrue(self.db_service.resolve_detected_book("gone-resolved", source="abs"))
+
+        active_ids = {b.source_id for b in self.db_service.get_active_detected_books()}
+        self.assertEqual(active_ids, {"active-a", "active-b"})
+
+    def test_get_active_detected_books_orders_by_last_seen_desc(self):
+        """Results are ordered by last_seen_at descending."""
+        from datetime import UTC, datetime
+
+        self.db_service.save_detected_book(
+            self._make_detected("oldest", datetime(2020, 1, 1, tzinfo=UTC))
+        )
+        self.db_service.save_detected_book(
+            self._make_detected("newest", datetime(2024, 1, 1, tzinfo=UTC))
+        )
+        self.db_service.save_detected_book(
+            self._make_detected("middle", datetime(2022, 1, 1, tzinfo=UTC))
+        )
+
+        ordered = [b.source_id for b in self.db_service.get_active_detected_books()]
+        self.assertEqual(ordered, ["newest", "middle", "oldest"])
+
+    def test_get_active_detected_books_honors_limit(self):
+        """A positive limit caps the number of returned rows, keeping DESC order."""
+        from datetime import UTC, datetime
+
+        for i in range(5):
+            self.db_service.save_detected_book(
+                self._make_detected(f"limit-{i}", datetime(2020, 1, 1 + i, tzinfo=UTC))
+            )
+
+        limited = self.db_service.get_active_detected_books(limit=2)
+        self.assertEqual([b.source_id for b in limited], ["limit-4", "limit-3"])
+
+    def test_get_active_detected_books_limit_zero_returns_empty(self):
+        """limit=0 applies .limit(0) and returns an empty list."""
+        from datetime import UTC, datetime
+
+        self.db_service.save_detected_book(
+            self._make_detected("present", datetime(2023, 1, 1, tzinfo=UTC))
+        )
+
+        self.assertEqual(self.db_service.get_active_detected_books(limit=0), [])
+
+    def test_get_active_detected_books_empty_when_none_active(self):
+        """Returns an empty list when no active detected rows exist."""
+        from datetime import UTC, datetime
+
+        self.db_service.save_detected_book(
+            self._make_detected("only-dismissed", datetime(2023, 1, 1, tzinfo=UTC))
+        )
+        self.assertTrue(self.db_service.dismiss_detected_book("only-dismissed", source="abs"))
+
+        self.assertEqual(self.db_service.get_active_detected_books(), [])
+
+    def test_get_active_detected_books_rows_detached_after_session_close(self):
+        """Returned rows are expunged, so their attributes remain usable after the session closes."""
+        from datetime import UTC, datetime
+
+        self.db_service.save_detected_book(
+            self._make_detected("detached", datetime(2023, 5, 5, tzinfo=UTC))
+        )
+
+        rows = self.db_service.get_active_detected_books()
+        self.assertEqual(len(rows), 1)
+        # Accessing attributes outside any open session must not raise DetachedInstanceError.
+        self.assertEqual(rows[0].source_id, "detached")
+        self.assertEqual(rows[0].status, "detected")
+        self.assertEqual(rows[0].title, "detached")
+
     def test_upsert_without_normalize_hook_is_unaffected(self):
         """Default _upsert callers (no normalize hook) keep blind attribute-copy
         semantics: the existing-row update path overwrites every update attr."""


### PR DESCRIPTION
## Stage 19: DetectedRepository active getter consolidation

This is Stage 19 of the backend cleanup. It consolidates only the manual `.all()` + expunge boilerplate in `DetectedRepository.get_active_detected_books()` using the existing `BaseRepository._query_and_expunge(...)` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.**

### Change

`get_active_detected_books(limit=None)` builds the same SQLAlchemy query as before (status filter, `last_seen_at DESC` order, optional `.limit`) and now delegates the terminal `.all()` + per-item `session.expunge(...)` loop to `self._query_and_expunge(session, query, one=False)`.

```python
-            items = query.all()
-            for item in items:
-                session.expunge(item)
-            return items
+            return self._query_and_expunge(session, query, one=False)
```

### Behavior preserved

`_query_and_expunge(..., one=False)` runs `query.all()` then expunges every item, which is exactly the prior loop. Verified equivalent for:

- filters exactly `DetectedBook.status.in_(self.ACTIVE_STATUSES)` (`ACTIVE_STATUSES` unchanged: `("detected",)`);
- orders by `DetectedBook.last_seen_at.desc()`;
- applies `.limit(limit)` only when `limit is not None` (built before the helper call);
- `limit=0` still applies `.limit(0)` and returns `[]`;
- returns `[]` when no active rows exist;
- returned rows are detached/usable after session close;
- public signature unchanged; `database_service` delegation (via `__getattr__` over `_detected`) and call sites (`api.py`, `dashboard.py`) untouched.

`get_all_ebook_filenames()`, save/upsert/normalization, and dismiss/resolve status mutations were left untouched.

### Tests added

Six focused integration tests in `tests/test_database_service_integration.py`, with explicit deterministic datetimes (no sleeping):

- returns only `status == "detected"` rows, excluding dismissed/resolved;
- orders by `last_seen_at DESC`;
- honors a positive `limit`;
- `limit=0` returns `[]`;
- returns `[]` when no active rows exist;
- returned rows are detached/usable after session close.

### Verification

```
git status --short                # clean (only the two intended files committed)
git branch --show-current         # cleanup/19-detected-active-getter-helper
ruff check src/ tests/ alembic/ scripts/   # All checks passed!
./run-tests.sh tests/test_database_service_integration.py tests/test_suggestions_feature.py tests/test_dashboard_errors.py
                                  # 85 passed
./run-tests.sh                    # 1098 passed, 3 skipped
```

### Caveats

- The plan referenced `tests/test_detected_repository.py`; that file does not exist in this repo. Detected-book tests live in `tests/test_database_service_integration.py`, so the new tests were added there alongside the existing detected-book coverage.
- No DB/fixture files, frontend files, routes, or snapshots changed.

Next stage should proceed only after this PR's checks/Macroscope are reviewed and it is merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `DetectedRepository.get_active_detected_books` to use `_query_and_expunge`
> Replaces manual query execution and expunge loop in `get_active_detected_books` with a call to the shared `_query_and_expunge` helper. Results are filtered by `ACTIVE_STATUSES`, ordered by `last_seen_at` descending, and optionally capped by a limit parameter. Integration tests are added to cover status filtering, ordering, limit behavior (including `limit=0`), and session detachment of returned rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20c67f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->