### PR TITLE
Cleanup 20: consolidate detected ebook filenames getter

### DIFF
--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -109,20 +109,15 @@ class DetectedRepository(BaseRepository):
     def get_all_ebook_filenames(self):
         """Get all ebook filenames from detected books with matches."""
         with self.get_session() as session:
-            results = (
-                session.query(DetectedBook)
-                .filter(
-                    DetectedBook.status.in_(self.ACTIVE_STATUSES),
-                    DetectedBook.matches_json.isnot(None),
-                )
-                .all()
+            query = session.query(DetectedBook).filter(
+                DetectedBook.status.in_(self.ACTIVE_STATUSES),
+                DetectedBook.matches_json.isnot(None),
             )
+            results = self._query_and_expunge(session, query, one=False)
             filenames = set()
             for detected in results:
                 matches = detected.matches or []
                 for match in matches:
                     if match.get("filename"):
                         filenames.add(match["filename"])
-            for item in results:
-                session.expunge(item)
             return filenames

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -574,6 +574,107 @@ class TestDatabaseServiceIntegration(unittest.TestCase):
         self.assertEqual(rows[0].status, "detected")
         self.assertEqual(rows[0].title, "detached")
 
+    def _save_detected_with_matches(self, source_id, matches_json, status="detected"):
+        """Persist a detected row carrying an explicit matches_json string.
+
+        Built directly (not via _make_detected) because that helper does not set
+        matches_json. Non-active statuses are applied through the dismiss/resolve
+        mutators so normalization does not clobber them back to 'detected'.
+        """
+        from src.db.models import DetectedBook
+
+        self.db_service.save_detected_book(
+            DetectedBook(
+                source="abs",
+                source_id=source_id,
+                title=source_id,
+                progress_percentage=0.1,
+                matches_json=matches_json,
+            )
+        )
+        if status == "dismissed":
+            self.db_service.dismiss_detected_book(source_id, source="abs")
+        elif status == "resolved":
+            self.db_service.resolve_detected_book(source_id, source="abs")
+
+    def test_get_all_ebook_filenames_returns_filenames_from_active_rows(self):
+        """Filenames are collected from active detected rows' matches_json."""
+        self._save_detected_with_matches(
+            "active-one", '[{"filename": "alpha.epub"}, {"filename": "beta.epub"}]'
+        )
+
+        self.assertEqual(
+            self.db_service.get_all_ebook_filenames(), {"alpha.epub", "beta.epub"}
+        )
+
+    def test_get_all_ebook_filenames_excludes_dismissed_and_resolved(self):
+        """Dismissed and resolved rows are excluded even when they carry matches."""
+        self._save_detected_with_matches("active", '[{"filename": "active.epub"}]')
+        self._save_detected_with_matches(
+            "dismissed", '[{"filename": "dismissed.epub"}]', status="dismissed"
+        )
+        self._save_detected_with_matches(
+            "resolved", '[{"filename": "resolved.epub"}]', status="resolved"
+        )
+
+        self.assertEqual(self.db_service.get_all_ebook_filenames(), {"active.epub"})
+
+    def test_get_all_ebook_filenames_ignores_matches_json_none(self):
+        """Rows with matches_json=None are filtered out by the DB query."""
+        self._save_detected_with_matches("has-matches", '[{"filename": "keep.epub"}]')
+        self._save_detected_with_matches("no-matches", None)
+
+        self.assertEqual(self.db_service.get_all_ebook_filenames(), {"keep.epub"})
+
+    def test_get_all_ebook_filenames_corrupt_json_contributes_nothing(self):
+        """Corrupt JSON yields [] from the matches property and adds no filenames."""
+        self._save_detected_with_matches("good", '[{"filename": "good.epub"}]')
+        self._save_detected_with_matches("corrupt", "{not valid json")
+
+        self.assertEqual(self.db_service.get_all_ebook_filenames(), {"good.epub"})
+
+    def test_get_all_ebook_filenames_ignores_entries_without_filename(self):
+        """Match dicts missing filename or with falsey filename values are skipped."""
+        self._save_detected_with_matches(
+            "mixed",
+            '[{"filename": "kept.epub"}, {"author": "no filename"}, '
+            '{"filename": ""}, {"filename": null}]',
+        )
+
+        self.assertEqual(self.db_service.get_all_ebook_filenames(), {"kept.epub"})
+
+    def test_get_all_ebook_filenames_collapses_duplicates(self):
+        """Identical filenames across rows collapse to a single set entry."""
+        self._save_detected_with_matches("first", '[{"filename": "dup.epub"}]')
+        self._save_detected_with_matches(
+            "second", '[{"filename": "dup.epub"}, {"filename": "dup.epub"}]'
+        )
+
+        self.assertEqual(self.db_service.get_all_ebook_filenames(), {"dup.epub"})
+
+    def test_get_all_ebook_filenames_empty_set_when_no_usable_filenames(self):
+        """Returns an empty set (not None/list) when nothing usable exists."""
+        self._save_detected_with_matches("empty-matches", "[]")
+        self._save_detected_with_matches("no-filenames", '[{"author": "x"}]')
+
+        result = self.db_service.get_all_ebook_filenames()
+        self.assertEqual(result, set())
+        self.assertIsInstance(result, set)
+
+    def test_get_all_ebook_filenames_extracts_after_session_close(self):
+        """The matches property is read after _query_and_expunge detaches the rows.
+
+        Reading matches_json post-expunge must not raise DetachedInstanceError;
+        a non-empty result proves the scalar column was available after detach.
+        """
+        self._save_detected_with_matches(
+            "detached", '[{"filename": "detached.epub"}]'
+        )
+
+        self.assertEqual(
+            self.db_service.get_all_ebook_filenames(), {"detached.epub"}
+        )
+
     def test_upsert_without_normalize_hook_is_unaffected(self):
         """Default _upsert callers (no normalize hook) keep blind attribute-copy
         semantics: the existing-row update path overwrites every update attr."""


### PR DESCRIPTION
## Stage 20: consolidate detected ebook filenames getter

Stage 20 of the backend cleanup. This consolidates the terminal `.all()` plus manual expunge loop in `DetectedRepository.get_all_ebook_filenames()` onto the existing `BaseRepository._query_and_expunge(...)` helper.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`

> This does **not** merge to `dev`. The cleanup integration branch is not merged to `dev` until the whole cleanup is complete and explicitly approved.

### What changed

`get_all_ebook_filenames()` previously built the query, called `.all()`, extracted filenames, then ran a manual `session.expunge(item)` loop. It now builds the same query and calls `self._query_and_expunge(session, query, one=False)`, keeping the filename extraction inline.

### Behavior preserved

- Filters exactly `DetectedBook.status.in_(self.ACTIVE_STATUSES)` and `DetectedBook.matches_json.isnot(None)`.
- `ACTIVE_STATUSES` unchanged (`("detected",)`); no ordering or limit added.
- Returns a `set`, not a list; empty `set()` when nothing usable exists.
- Parses valid `matches_json` via `DetectedBook.matches`; corrupt JSON contributes nothing (property returns `[]`).
- `matches_json=None` rows excluded by the DB filter; only truthy `filename` values contribute; duplicates collapse via set semantics.
- Public signature and the `database_service` delegation (via `__getattr__`) unchanged.

**Rationale:** `DetectedBook.matches` only parses the already-loaded scalar `matches_json` column, so reading it after `_query_and_expunge` detaches the rows is equivalent. The method returns filename strings, not ORM rows.

### Tests added

New focused tests in `tests/test_database_service_integration.py`:

- returns filenames from active rows' `matches_json`
- excludes dismissed and resolved rows even when they carry matches
- ignores `matches_json=None` rows
- corrupt JSON contributes no filenames
- ignores match entries missing/with falsey `filename`
- duplicate filenames collapse to one value
- returns `set()` when no usable filenames exist
- extraction still works after the helper detaches rows (post-session-close)

### Verification

- `git status --short`: only `src/db/detected_repository.py` and `tests/test_database_service_integration.py` changed. No DB/fixture/frontend/route/schema files.
- `ruff check src/ tests/ alembic/ scripts/`: All checks passed.
- `./run-tests.sh tests/test_database_service_integration.py tests/test_cache_cleanup_service.py tests/test_cache_cleanup.py tests/test_suggestions_feature.py`: 87 passed (`test_cache_cleanup.py` is `pytest.mark.docker` and deselected in the standard run).
- `./run-tests.sh`: 1106 passed, 3 skipped.

### Caveats

None. Pure terminal-execution consolidation; no normalization, dismiss/resolve, active-getter, or `matches` property behavior touched.

Next stage should proceed only after this PR's checks/Macroscope are reviewed and it is merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `DetectedRepository.get_all_ebook_filenames` to use shared query helper
> - Replaces manual ORM execution and per-item `expunge` calls in `get_all_ebook_filenames` with the shared `_query_and_expunge` helper in [detected_repository.py](https://github.com/serabi/pagekeeper/pull/104/files#diff-563c97c1e42930502ec6842fb3ffdba645b32995bcc36a1a07dc3d929c4b900d).
> - Adds integration tests in [test_database_service_integration.py](https://github.com/serabi/pagekeeper/pull/104/files#diff-354128dd9d6dc5e5d57491f00f1cefe1992bf8195ac01776c2dadbe9a21d1b9e) covering active rows, dismissed/resolved exclusion, null/corrupt JSON, missing filenames, deduplication, and post-expunge access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c00068c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->