### PR TITLE
Cleanup 21: consolidate settings read getters

### DIFF
--- a/src/db/settings_repository.py
+++ b/src/db/settings_repository.py
@@ -23,13 +23,6 @@ logger = logging.getLogger(__name__)
 
 class SettingsRepository(BaseRepository):
     @staticmethod
-    def _persist_and_detach(session, obj):
-        """Flush, refresh, and detach an object so it's usable outside the session."""
-        session.flush()
-        session.refresh(obj)
-        session.expunge(obj)
-
-    @staticmethod
     def _encrypt_for_storage(key, value):
         """Encrypt *value* if *key* is a secret setting; else return as-is."""
         if value is None or not is_secret_setting(key):
@@ -46,7 +39,8 @@ class SettingsRepository(BaseRepository):
     def get_setting(self, key, default=None):
         """Get a setting value by key. Returns a string or *default*."""
         with self.get_session() as session:
-            setting = session.query(Setting).filter(Setting.key == key).first()
+            query = session.query(Setting).filter(Setting.key == key)
+            setting = self._query_and_expunge(session, query, one=True)
             if not setting:
                 return default
             return self._decrypt_from_storage(key, setting.value)
@@ -78,7 +72,8 @@ class SettingsRepository(BaseRepository):
         secret and non-secret settings still load.
         """
         with self.get_session() as session:
-            settings = session.query(Setting).all()
+            query = session.query(Setting)
+            settings = self._query_and_expunge(session, query, one=False)
             result = {}
             for s in settings:
                 try:

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -68,6 +68,14 @@ class TestEncryptOnSaveDecryptOnRead:
         assert _raw_value(db_service, "HARDCOVER_TOKEN") is None
         assert db_service.get_setting("HARDCOVER_TOKEN") is None
 
+    def test_missing_key_returns_default(self, encryption_key, db_service):
+        sentinel = object()
+        assert db_service.get_setting("NEVER_STORED") is None
+        assert db_service.get_setting("NEVER_STORED", sentinel) is sentinel
+
+    def test_get_all_empty_db_returns_empty_dict(self, encryption_key, db_service):
+        assert db_service.get_all_settings() == {}
+
     def test_resave_does_not_double_encrypt(self, encryption_key, db_service):
         db_service.set_setting("KOSYNC_KEY", "dummy-kosync-key")
         # Round-trip the decrypted value back through set_setting.


### PR DESCRIPTION
## Stage 21: SettingsRepository read getter cleanup

Part of the backend cleanup effort. **Base branch:** `cleanup/backend-cleanup-2026-06-29`.

**This does not merge to `dev`.** It targets the cleanup integration branch only.

### What changed

- `SettingsRepository.get_setting()` and `get_all_settings()` now route their query/detach step through the existing `BaseRepository._query_and_expunge(...)` helper instead of inlining `.first()` / `.all()` + manual handling.
- Removed the unused private `SettingsRepository._persist_and_detach()` helper (verified dead by a fresh repo-wide search; only its own definition referenced it).

### Behavior preserved

- `get_setting(key, default=None)`: still filters exactly `Setting.key == key`, keeps `.first()` semantics, returns `default` for a missing row, returns `None` for a stored `None`, decrypts only secret keys, and still raises through `SettingsCrypto`/`SettingsDecryptionError` on wrong-key/corrupt reads. Public signature unchanged.
- `get_all_settings()`: still queries all rows with no ordering/filtering, returns `{}` when empty, maps keys to decrypted/plain values, and keeps the per-row `try/except SettingsCryptoError` so a single corrupt secret is logged/omitted while healthy settings still load. Public signature unchanged.
- Detaching before scalar access is safe: `Setting.key` (PK) and `Setting.value` (Text) are already-loaded scalar columns.
- `set_setting()`, `delete_setting()`, `encrypt_plaintext_secrets()`, and all encryption/decryption helpers are untouched.

### Tests added

In `tests/test_settings_repository_encryption.py`:
- `test_missing_key_returns_default` — `get_setting()` returns the caller-provided default for a missing key.
- `test_get_all_empty_db_returns_empty_dict` — `get_all_settings()` returns `{}` for an empty DB.

Existing tests already cover secret decrypt-after-save, stored-`None`, non-secret plaintext, and corrupt-secret isolation.

### Verification

- `ruff check src/ tests/ alembic/ scripts/` → All checks passed
- `./run-tests.sh tests/test_settings_repository_encryption.py tests/test_suggestions_feature.py tests/test_dashboard_errors.py` → 34 passed, 1 skipped
- `./run-tests.sh` (full suite) → 1108 passed, 3 skipped
- No DB/fixture files, no frontend files, no route/snapshot changes.

### Caveats

None. The refactor is behavior-preserving.

### Next stage

Proceed to the next stage only after this PR's checks/Macroscope are reviewed and merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate settings read getters in `SettingsRepository` to use `_query_and_expunge`
> - Replaces direct `session.query()` calls in `get_setting` and `get_all_settings` with the shared `_query_and_expunge` helper, removing the now-redundant `_persist_and_detach` utility.
> - Adds tests in [test_settings_repository_encryption.py](https://github.com/serabi/pagekeeper/pull/105/files#diff-6dbbb40f4f73b33357eb34127f978b828e66aa5ff97b2713ceacc8fd5e244c02) covering missing-key defaults and empty-DB behavior for `get_all_settings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31714ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->