### PR TITLE
Cleanup 22: consolidate Grimmory filtered list getter

### DIFF
--- a/src/db/grimmory_repository.py
+++ b/src/db/grimmory_repository.py
@@ -21,11 +21,7 @@ class GrimmoryRepository(BaseRepository):
     def get_all_grimmory_books(self, server_id=None):
         if server_id is None:
             return self._get_all(GrimmoryBook)
-        with self.get_session() as session:
-            rows = session.query(GrimmoryBook).filter(GrimmoryBook.server_id == server_id).all()
-            for r in rows:
-                session.expunge(r)
-            return rows
+        return self._get_all(GrimmoryBook, GrimmoryBook.server_id == server_id)
 
     def save_grimmory_book(self, grimmory_book):
         return self._upsert(

--- a/tests/test_grimmory_repository.py
+++ b/tests/test_grimmory_repository.py
@@ -77,6 +77,78 @@ def test_save_grimmory_book_no_duplicate_on_repeated_save(repository):
     assert len(matching) == 1
 
 
+def test_get_all_grimmory_books_none_returns_all_servers(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="a.epub", title="A", server_id="server-a")
+    )
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="b.epub", title="B", server_id="server-b")
+    )
+
+    rows = repository.get_all_grimmory_books()
+
+    assert sorted((r.filename, r.server_id) for r in rows) == [
+        ("a.epub", "server-a"),
+        ("b.epub", "server-b"),
+    ]
+
+
+def test_get_all_grimmory_books_filters_by_server_id(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="a.epub", title="A", server_id="server-a")
+    )
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="b.epub", title="B", server_id="server-b")
+    )
+
+    rows = repository.get_all_grimmory_books(server_id="server-a")
+
+    assert [r.filename for r in rows] == ["a.epub"]
+    assert all(r.server_id == "server-a" for r in rows)
+
+
+def test_get_all_grimmory_books_empty_string_filters_not_returns_all(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="empty.epub", title="Empty", server_id="")
+    )
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="named.epub", title="Named", server_id="server-a")
+    )
+
+    rows = repository.get_all_grimmory_books(server_id="")
+
+    assert [r.filename for r in rows] == ["empty.epub"]
+    assert all(r.server_id == "" for r in rows)
+
+
+def test_get_all_grimmory_books_missing_server_returns_empty(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="a.epub", title="A", server_id="server-a")
+    )
+
+    assert repository.get_all_grimmory_books(server_id="absent") == []
+
+
+def test_get_all_grimmory_books_rows_detached_after_session_close(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="detached.epub",
+            title="Detached Title",
+            authors="Detached Author",
+            raw_metadata=json.dumps({"id": "detached"}),
+            server_id="server-a",
+        )
+    )
+
+    rows = repository.get_all_grimmory_books(server_id="server-a")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.title == "Detached Title"
+    assert row.authors == "Detached Author"
+    assert row.raw_metadata_dict["id"] == "detached"
+
+
 def test_save_grimmory_book_distinguishes_by_server_id(repository):
     repository.save_grimmory_book(
         GrimmoryBook(filename="shared.epub", title="Server A", server_id="a")


### PR DESCRIPTION
## Stage 22: consolidate Grimmory filtered list getter

This is **Stage 22** of the backend cleanup. It consolidates the manual `.all()` + expunge boilerplate in a single getter.

**Base branch:** `cleanup/backend-cleanup-2026-06-29`
**This does NOT merge to `dev`.**

### Change

`GrimmoryRepository.get_all_grimmory_books(server_id=...)` previously hand-rolled the filtered branch:

```python
with self.get_session() as session:
    rows = session.query(GrimmoryBook).filter(GrimmoryBook.server_id == server_id).all()
    for r in rows:
        session.expunge(r)
    return rows
```

It now delegates to the existing `_get_all` helper:

```python
return self._get_all(GrimmoryBook, GrimmoryBook.server_id == server_id)
```

`_get_all` builds `session.query(GrimmoryBook)`, applies `.filter(GrimmoryBook.server_id == server_id)`, adds no `order_by`, then runs `_query_and_expunge(one=False)` (`.all()` + per-row expunge). This is byte-for-byte the same behavior as the removed loop.

### Behavior preserved

- `server_id=None` still returns all rows via `_get_all(GrimmoryBook)` (unchanged branch).
- A specific `server_id` filters exactly `GrimmoryBook.server_id == server_id`.
- `server_id=""` filters for empty-string server IDs rather than returning all rows.
- No ordering is introduced.
- Returns `[]` when no rows match.
- Returned rows are expunged/detached and usable after the session closes.
- Public signature and call sites unchanged.
- No new `BaseRepository` helpers; no changes to `_get_all`, `_query_and_expunge`, save/replace/delete, or `raw_metadata_dict`.

### Tests added

New focused tests in `tests/test_grimmory_repository.py`:

- `test_get_all_grimmory_books_none_returns_all_servers`
- `test_get_all_grimmory_books_filters_by_server_id`
- `test_get_all_grimmory_books_empty_string_filters_not_returns_all`
- `test_get_all_grimmory_books_missing_server_returns_empty`
- `test_get_all_grimmory_books_rows_detached_after_session_close`

### Verification

```
ruff check src/ tests/ alembic/ scripts/        -> All checks passed!
./run-tests.sh tests/test_grimmory_repository.py tests/test_models.py \
  tests/test_dashboard_errors.py tests/test_reading_routes.py
                                                 -> 50 passed
./run-tests.sh                                   -> 1113 passed, 3 skipped
```

No DB/fixture files, no frontend files, no routes/snapshots changed.

### Caveats

None. The refactor is behavior-exact.

### Next step

Proceed to the next stage only after this PR's checks/Macroscope are reviewed and it is merged. Do not merge to `dev`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `GrimmoryRepository.get_all_grimmory_books` filtered list getter
> Replaces manual session query/expunge logic in the `server_id` branch of `get_all_grimmory_books` with a delegation to `self._get_all(GrimmoryBook, GrimmoryBook.server_id == server_id)`, matching the pattern used for the `None` case. Adds tests covering no-filter, server_id filter, empty-string filter, missing server, and post-session row detachment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2640c4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->