### PR TITLE
Cleanup 23: consolidate KoSync orphaned books getter

### DIFF
--- a/src/db/kosync_repository.py
+++ b/src/db/kosync_repository.py
@@ -61,7 +61,5 @@ class KoSyncRepository(BaseRepository):
         """Get books with kosync_doc_id set but no matching KosyncDocument."""
         with self.get_session() as session:
             subq = session.query(KosyncDocument.document_hash)
-            results = session.query(Book).filter(Book.kosync_doc_id != None).filter(~Book.kosync_doc_id.in_(subq)).all()
-            for r in results:
-                session.expunge(r)
-            return results
+            query = session.query(Book).filter(Book.kosync_doc_id != None).filter(~Book.kosync_doc_id.in_(subq))
+            return self._query_and_expunge(session, query, one=False)

--- a/tests/test_kosync_repository.py
+++ b/tests/test_kosync_repository.py
@@ -1,0 +1,79 @@
+import pytest
+
+from src.db.kosync_repository import KoSyncRepository
+from src.db.models import Base, Book, DatabaseManager, KosyncDocument
+
+
+@pytest.fixture()
+def repository(tmp_path):
+    manager = DatabaseManager(str(tmp_path / "kosync_repository.db"))
+    Base.metadata.create_all(manager.engine)
+    try:
+        yield KoSyncRepository(manager)
+    finally:
+        manager.close()
+
+
+def _make_book(repository, book_id, kosync_doc_id):
+    with repository.get_session() as session:
+        book = Book(abs_id=f"abs-{book_id}", title=f"Book {book_id}", kosync_doc_id=kosync_doc_id)
+        book.id = book_id
+        session.add(book)
+
+
+def _make_document(repository, document_hash):
+    with repository.get_session() as session:
+        session.add(KosyncDocument(document_hash=document_hash))
+
+
+def test_book_with_null_kosync_doc_id_is_excluded(repository):
+    _make_book(repository, 1, None)
+
+    assert repository.get_orphaned_kosync_books() == []
+
+
+def test_book_with_matching_document_is_excluded(repository):
+    _make_document(repository, "hash-1")
+    _make_book(repository, 1, "hash-1")
+
+    assert repository.get_orphaned_kosync_books() == []
+
+
+def test_book_without_matching_document_is_included(repository):
+    _make_book(repository, 1, "hash-orphan")
+
+    orphaned = repository.get_orphaned_kosync_books()
+
+    assert [b.id for b in orphaned] == [1]
+    assert orphaned[0].kosync_doc_id == "hash-orphan"
+
+
+def test_only_orphaned_books_returned_among_mixed_rows(repository):
+    _make_document(repository, "hash-linked")
+    _make_book(repository, 1, None)
+    _make_book(repository, 2, "hash-linked")
+    _make_book(repository, 3, "hash-orphan-a")
+    _make_book(repository, 4, "hash-orphan-b")
+
+    orphaned = repository.get_orphaned_kosync_books()
+
+    assert sorted(b.id for b in orphaned) == [3, 4]
+
+
+def test_no_orphaned_books_returns_empty_list(repository):
+    _make_document(repository, "hash-1")
+    _make_book(repository, 1, "hash-1")
+    _make_book(repository, 2, None)
+
+    assert repository.get_orphaned_kosync_books() == []
+
+
+def test_returned_books_are_detached_after_session_closes(repository):
+    _make_book(repository, 1, "hash-orphan")
+
+    orphaned = repository.get_orphaned_kosync_books()
+
+    # Accessing attributes after the session is closed must not raise
+    # (the rows are expunged/detached, with values already loaded).
+    assert orphaned[0].id == 1
+    assert orphaned[0].kosync_doc_id == "hash-orphan"


### PR DESCRIPTION
## What Changed

Stage 23 of the backend cleanup series: consolidated the read-only KoSync orphaned-books getter.

- `KoSyncRepository.get_orphaned_kosync_books()` now keeps the existing subquery/filter construction and delegates the terminal `.all()` + expunge loop to `BaseRepository._query_and_expunge(..., one=False)`.
- Added focused characterization tests in `tests/test_kosync_repository.py`.

## Why

This removes one remaining hand-rolled query/expunge pattern without changing KoSync save/link/unlink/delete behavior or any BookRepository/state/migration/statistics logic.

## Behavior Preserved

- Returns only `Book` rows with `kosync_doc_id` set/non-null.
- Excludes books whose `kosync_doc_id` has a matching `KosyncDocument.document_hash`.
- Preserves the existing local `KosyncDocument.document_hash` subquery.
- Preserves `Book.kosync_doc_id != None` filter semantics exactly.
- Preserves `~Book.kosync_doc_id.in_(subq)` behavior.
- Preserves no-ordering behavior.
- Returns `[]` when no rows match.
- Returned `Book` rows remain detached/usable after session close.

## Validation

Actual local results:

- `ruff check src/ tests/ alembic/ scripts/` → All checks passed
- `./run-tests.sh tests/test_kosync_repository.py tests/test_kosync_service.py tests/test_background_job_service.py` → 60 passed
- `./run-tests.sh` → 1119 passed, 3 skipped, 17 warnings
- `git diff --check` → passed

## Scope / Risk

Base branch: `cleanup/backend-cleanup-2026-06-29`

This PR does **not** target or merge to `dev`.

Out of scope and untouched:

- KoSync save/link/unlink/delete methods
- BookRepository save/state/migration/delete/statistics
- Sync orchestration/background jobs
- Routes/frontend/schema/migrations/dependencies
- DB/local fixture files

Next stage should proceed only after this PR's checks/Macroscope are reviewed and this PR is merged into the cleanup integration branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `KoSyncRepository.get_orphaned_kosync_books` to use `_query_and_expunge`
> Refactors `get_orphaned_kosync_books` in [kosync_repository.py](https://github.com/serabi/pagekeeper/pull/107/files#diff-ddf2b7bbf66fdcc61525d0ce0197125954436af2357ea4baff1bba4be07a0315) to delegate result fetching and session expunging to the shared `_query_and_expunge` helper, replacing an explicit `.all()` call and manual per-row expunge loop. Adds a new test module in [test_kosync_repository.py](https://github.com/serabi/pagekeeper/pull/107/files#diff-92c628bbf5d32eed2c915f0b069f0e11ac5c3a0857366fff66463efa7947da47) covering orphan detection logic and verifying that returned rows are detached after the session closes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9eec14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->