### PR TITLE
Cleanup 24: consolidate Storyteller latest bulk getter

### DIFF
--- a/src/db/storyteller_repository.py
+++ b/src/db/storyteller_repository.py
@@ -81,18 +81,17 @@ class StorytellerRepository(BaseRepository):
                 .subquery()
             )
 
-            rows = (
+            query = (
                 session.query(StorytellerSubmission)
                 .join(
                     latest,
                     (StorytellerSubmission.book_id == latest.c.book_id)
                     & (StorytellerSubmission.submitted_at == latest.c.max_ts),
                 )
-                .all()
             )
+            rows = self._query_and_expunge(session, query, one=False)
 
             result = {}
             for sub in rows:
-                session.expunge(sub)
                 result[sub.book_id] = sub
             return result

--- a/tests/test_storyteller_repository.py
+++ b/tests/test_storyteller_repository.py
@@ -114,3 +114,50 @@ def test_returned_submission_is_detached_after_session_closes(repository):
     # (the row is expunged/detached, with values already loaded).
     assert sub.book_id == 1
     assert sub.status == "processing"
+
+
+def test_bulk_latest_returns_empty_dict_when_no_submissions(repository):
+    assert repository.get_all_storyteller_submissions_latest() == {}
+
+
+def test_bulk_latest_returns_newest_submission_per_book(repository):
+    _make_book(repository, 1)
+    _make_book(repository, 2)
+    _insert_submission(repository, 1, "queued", _ts(1))
+    _insert_submission(repository, 1, "ready", _ts(4))
+    _insert_submission(repository, 2, "processing", _ts(2))
+    _insert_submission(repository, 2, "failed", _ts(3))
+
+    latest = repository.get_all_storyteller_submissions_latest()
+
+    assert set(latest) == {1, 2}
+    assert latest[1].status == "ready"
+    assert latest[1].submitted_at == _ts(4)
+    assert latest[2].status == "failed"
+    assert latest[2].submitted_at == _ts(3)
+
+
+def test_bulk_latest_keeps_books_isolated(repository):
+    _make_book(repository, 1)
+    _make_book(repository, 2)
+    _insert_submission(repository, 1, "ready", _ts(2))
+    _insert_submission(repository, 2, "queued", _ts(5))
+
+    latest = repository.get_all_storyteller_submissions_latest()
+
+    assert latest[1].book_id == 1
+    assert latest[1].status == "ready"
+    assert latest[2].book_id == 2
+    assert latest[2].status == "queued"
+
+
+def test_bulk_latest_rows_are_detached_after_session_closes(repository):
+    _make_book(repository, 1)
+    _insert_submission(repository, 1, "processing", _ts(1))
+
+    latest = repository.get_all_storyteller_submissions_latest()
+
+    # Accessing attributes after the session is closed must not raise
+    # (the rows are expunged/detached, with values already loaded).
+    assert latest[1].book_id == 1
+    assert latest[1].status == "processing"


### PR DESCRIPTION
## What Changed

Stage 24 of the backend cleanup series: consolidated the Storyteller bulk latest getter.

- `StorytellerRepository.get_all_storyteller_submissions_latest()` now keeps the existing grouped latest-submission query and dict construction, while delegating the terminal `.all()` + expunge loop to `BaseRepository._query_and_expunge(..., one=False)`.
- Added focused characterization tests in `tests/test_storyteller_repository.py`.

## Why

This removes one remaining hand-rolled query/expunge pattern without changing Storyteller save/update/single-getter behavior or dashboard call sites.

## Behavior Preserved

- Groups by `StorytellerSubmission.book_id`.
- Filters to `book_id IS NOT NULL` in the same subquery.
- Selects rows whose `submitted_at` equals the per-book max timestamp.
- Preserves no-ordering behavior and existing dict construction semantics.
- Returns `{}` when no submissions exist.
- Returned `StorytellerSubmission` rows remain detached/usable after session close.

## Validation

Actual local results:

- `ruff check src/ tests/ alembic/ scripts/` → All checks passed
- `./run-tests.sh tests/test_storyteller_repository.py tests/test_storyteller_submission.py tests/test_dashboard_errors.py` → 50 passed
- `./run-tests.sh` → 1123 passed, 3 skipped, 17 warnings
- `git diff --check` → passed

## Scope / Risk

Base branch: `cleanup/backend-cleanup-2026-06-29`

This PR does **not** target or merge to `dev`.

Out of scope and untouched:

- Storyteller save/update/single-getter behavior
- BookRepository save/state/migration/delete/statistics
- Sync orchestration/background jobs
- Routes/frontend/schema/migrations/dependencies
- DB/local fixture files

Next stage should proceed only after this PR's checks/Macroscope are reviewed and this PR is merged into the cleanup integration branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `StorytellerRepository.get_all_storyteller_submissions_latest` to use shared query helper
> - Replaces direct `.all()` materialization and manual `session.expunge()` per row with a call to `self._query_and_expunge(session, query, one=False)` in [storyteller_repository.py](https://github.com/serabi/pagekeeper/pull/108/files#diff-e034cf3fc09d93cf2e8861f377d449a34d121939d5e4229a7d8f72810ecc15fa).
> - Adds four tests in [test_storyteller_repository.py](https://github.com/serabi/pagekeeper/pull/108/files#diff-ea6306a33eb39d85e51b73dd8b0ed68e0cd4ac51d4378a5495572886a8c1419a) covering empty results, newest-per-book selection, book isolation, and row detachment after session closure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d045fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->