### PR TITLE
Cleanup 25: consolidate TBR add dedupe queries

### DIFF
--- a/src/db/tbr_repository.py
+++ b/src/db/tbr_repository.py
@@ -63,16 +63,16 @@ class TbrRepository(BaseRepository):
         with self.get_session() as session:
             # Dedup by Hardcover book ID
             if hardcover_book_id:
-                existing = session.query(TbrItem).filter(TbrItem.hardcover_book_id == hardcover_book_id).first()
+                query = session.query(TbrItem).filter(TbrItem.hardcover_book_id == hardcover_book_id)
+                existing = self._query_and_expunge(session, query, one=True)
                 if existing:
-                    session.expunge(existing)
                     return existing, False
 
             # Dedup by Open Library work key
             if ol_work_key:
-                existing = session.query(TbrItem).filter(TbrItem.ol_work_key == ol_work_key).first()
+                query = session.query(TbrItem).filter(TbrItem.ol_work_key == ol_work_key)
+                existing = self._query_and_expunge(session, query, one=True)
                 if existing:
-                    session.expunge(existing)
                     return existing, False
 
             extras = {k: v for k, v in enrichment.items() if k in ENRICHMENT_FIELDS and v is not None}

--- a/tests/test_tbr_repository.py
+++ b/tests/test_tbr_repository.py
@@ -112,6 +112,60 @@ class TestTbrRepository(unittest.TestCase):
         self.assertTrue(created2)
         self.assertNotEqual(item1.id, item2.id)
 
+    def test_dedup_by_hardcover_id_returns_detached_existing(self):
+        """A Hardcover-ID duplicate returns a detached existing row usable after the session closes."""
+        self.db.add_tbr_item("Dune", author="Frank Herbert", hardcover_book_id=42)
+        existing, created = self.db.add_tbr_item("Dune (dup)", hardcover_book_id=42)
+
+        self.assertFalse(created)
+        # Accessing attributes must not raise DetachedInstanceError.
+        self.assertEqual(existing.title, "Dune")
+        self.assertEqual(existing.author, "Frank Herbert")
+        self.assertEqual(existing.hardcover_book_id, 42)
+
+    def test_dedup_by_ol_work_key_returns_detached_existing(self):
+        """An Open Library duplicate returns a detached existing row usable after the session closes."""
+        self.db.add_tbr_item("Neuromancer", author="William Gibson", ol_work_key="/works/OL123")
+        existing, created = self.db.add_tbr_item("Neuromancer dup", ol_work_key="/works/OL123")
+
+        self.assertFalse(created)
+        # Accessing attributes must not raise DetachedInstanceError.
+        self.assertEqual(existing.title, "Neuromancer")
+        self.assertEqual(existing.author, "William Gibson")
+        self.assertEqual(existing.ol_work_key, "/works/OL123")
+
+    def test_dedup_hardcover_wins_over_ol_work_key(self):
+        """When both keys match different existing rows, the Hardcover match wins."""
+        hc_row, _ = self.db.add_tbr_item("By Hardcover", hardcover_book_id=42)
+        ol_row, _ = self.db.add_tbr_item("By Open Library", ol_work_key="/works/OL123")
+        self.assertNotEqual(hc_row.id, ol_row.id)
+
+        existing, created = self.db.add_tbr_item(
+            "Matches Both", hardcover_book_id=42, ol_work_key="/works/OL123"
+        )
+
+        self.assertFalse(created)
+        self.assertEqual(existing.id, hc_row.id)
+        self.assertEqual(existing.title, "By Hardcover")
+
+    def test_falsey_hardcover_id_does_not_trigger_dedup(self):
+        """hardcover_book_id=0 is falsey, so it never triggers a duplicate lookup."""
+        item1, created1 = self.db.add_tbr_item("Zero One", hardcover_book_id=0)
+        item2, created2 = self.db.add_tbr_item("Zero Two", hardcover_book_id=0)
+
+        self.assertTrue(created1)
+        self.assertTrue(created2)
+        self.assertNotEqual(item1.id, item2.id)
+
+    def test_falsey_ol_work_key_does_not_trigger_dedup(self):
+        """ol_work_key="" is falsey, so it never triggers a duplicate lookup."""
+        item1, created1 = self.db.add_tbr_item("Empty One", ol_work_key="")
+        item2, created2 = self.db.add_tbr_item("Empty Two", ol_work_key="")
+
+        self.assertTrue(created1)
+        self.assertTrue(created2)
+        self.assertNotEqual(item1.id, item2.id)
+
     # -- Linking --
 
     def test_link_tbr_to_book(self):


### PR DESCRIPTION
## What changed

Consolidated the duplicate-detection early-return boilerplate inside `TbrRepository.add_tbr_item()`. The two dedup branches (Hardcover book ID, Open Library work key) previously each did `query.first()` followed by a manual `session.expunge(existing)`. Both now use the shared `BaseRepository._query_and_expunge(session, query, one=True)` helper, which performs the same `.first()` + expunge-if-found and returns the row or `None`.

## Why

Removes duplicated query/expunge boilerplate and reuses the same helper already used by other getters in this repository (`get_tbr_items`, `get_unlinked_items`, `_get_one`). Continues the backend cleanup series.

## Behavior preserved

- Public signature unchanged; return shape remains `(item, created_bool)`.
- Hardcover-ID duplicate returns the existing item and `False`; Open Library duplicate returns the existing item and `False`.
- Hardcover check still runs before the Open Library check, so when both keys match different existing rows the Hardcover match wins.
- Truthiness gates unchanged (`if hardcover_book_id:` / `if ol_work_key:`), so falsey values (`0`, `""`, `None`) do not trigger a duplicate lookup.
- No ordering added to either dedup query.
- When no duplicate is found, item creation, enrichment filtering, all `TbrItem(...)` fields, and the flush/refresh/expunge of new items are unchanged.
- Duplicate-returned existing rows remain detached and usable after session close.

## Validation (actual outputs)

```
git status --short --branch
## cleanup/25-tbr-add-dedupe-query-helper

ruff check src/ tests/ alembic/ scripts/
All checks passed!

git diff --check
(no output)

./run-tests.sh tests/test_tbr_repository.py tests/test_tbr_routes.py
78 passed in 17.17s

./run-tests.sh
1128 passed, 3 skipped, 17 warnings in 138.40s
```

Tests added (in `tests/test_tbr_repository.py`):
- `test_dedup_by_hardcover_id_returns_detached_existing` — Hardcover duplicate returns a detached row usable after session close.
- `test_dedup_by_ol_work_key_returns_detached_existing` — Open Library duplicate returns a detached row usable after session close.
- `test_dedup_hardcover_wins_over_ol_work_key` — when both keys match different rows, the Hardcover match wins.
- `test_falsey_hardcover_id_does_not_trigger_dedup` — `hardcover_book_id=0` does not trigger dedup (creates separate rows).
- `test_falsey_ol_work_key_does_not_trigger_dedup` — `ol_work_key=""` does not trigger dedup (creates separate rows).

## Scope / risk note

Low risk: behavior-preserving substitution of existing boilerplate with an existing helper. Only `src/db/tbr_repository.py` and `tests/test_tbr_repository.py` changed.

This PR targets `cleanup/backend-cleanup-2026-06-29`, **not `dev`**.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate duplicate-check queries in `TbrRepository.add_tbr_item` to use shared helper
> - Replaces inline `Session.query(...).first()` + `session.expunge()` calls with `self._query_and_expunge()` for both `hardcover_book_id` and `ol_work_key` dedup checks in [tbr_repository.py](https://github.com/serabi/pagekeeper/pull/109/files#diff-aba27a20ab254c01c02110b1e6413f62ebce5324b77080f3dda7c738e95ae0da).
> - Adds five new tests covering: detached row returned on hardcover/OL dedup, hardcover match taking precedence over OL match, and falsey values (0, empty string) not triggering dedup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b49d5f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->