### PR TITLE
Cleanup 26: consolidate suggestion existence checks

### DIFF
--- a/src/db/base_repository.py
+++ b/src/db/base_repository.py
@@ -69,6 +69,11 @@ class BaseRepository:
                 query = query.order_by(order_by)
             return self._query_and_expunge(session, query, one=False)
 
+    def _exists(self, model, *filters):
+        """Return True if any row matches the filters, without exposing it."""
+        with self.get_session() as session:
+            return session.query(model).filter(*filters).first() is not None
+
     def _delete_one(self, model, *filters):
         """Find and delete a single row. Returns True if deleted."""
         with self.get_session() as session:

--- a/src/db/suggestion_repository.py
+++ b/src/db/suggestion_repository.py
@@ -23,29 +23,19 @@ class SuggestionRepository(BaseRepository):
         )
 
     def suggestion_exists(self, source_id, source="abs"):
-        with self.get_session() as session:
-            return (
-                session.query(PendingSuggestion)
-                .filter(
-                    PendingSuggestion.source_id == source_id,
-                    PendingSuggestion.source == source,
-                )
-                .first()
-                is not None
-            )
+        return self._exists(
+            PendingSuggestion,
+            PendingSuggestion.source_id == source_id,
+            PendingSuggestion.source == source,
+        )
 
     def is_suggestion_ignored(self, source_id, source="abs"):
-        with self.get_session() as session:
-            return (
-                session.query(PendingSuggestion)
-                .filter(
-                    PendingSuggestion.source_id == source_id,
-                    PendingSuggestion.source == source,
-                    PendingSuggestion.status == "ignored",
-                )
-                .first()
-                is not None
-            )
+        return self._exists(
+            PendingSuggestion,
+            PendingSuggestion.source_id == source_id,
+            PendingSuggestion.source == source,
+            PendingSuggestion.status == "ignored",
+        )
 
     def save_pending_suggestion(self, suggestion):
         """Upsert a suggestion, preserving hidden status if already hidden."""

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -2219,6 +2219,54 @@ class TestSuggestionSourceScoping(unittest.TestCase):
         self.assertTrue(self.db_service.suggestion_exists("id1", source="kosync"))
         self.assertFalse(self.db_service.suggestion_exists("id1", source="abs"))
 
+    def test_suggestion_exists_true_regardless_of_status(self):
+        """suggestion_exists returns True for any row, including hidden and ignored."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Test", source="abs")
+        )
+        self.assertTrue(self.db_service.suggestion_exists("id1", source="abs"))
+
+        self.assertTrue(self.db_service.hide_suggestion("id1", source="abs"))
+        self.assertEqual(self.db_service.get_suggestion("id1", source="abs").status, "hidden")
+        self.assertTrue(self.db_service.suggestion_exists("id1", source="abs"))
+
+        self.assertTrue(self.db_service.ignore_suggestion("id1", source="abs"))
+        self.assertEqual(self.db_service.get_suggestion("id1", source="abs").status, "ignored")
+        self.assertTrue(self.db_service.suggestion_exists("id1", source="abs"))
+
+    def test_suggestion_exists_false_when_missing(self):
+        """suggestion_exists returns False when no matching row exists."""
+        self.assertFalse(self.db_service.suggestion_exists("missing", source="abs"))
+
+    def test_is_suggestion_ignored_only_for_ignored_status(self):
+        """is_suggestion_ignored returns True only when the row's status is exactly 'ignored'."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Test", source="abs")
+        )
+        self.assertFalse(self.db_service.is_suggestion_ignored("id1", source="abs"))
+
+        self.assertTrue(self.db_service.hide_suggestion("id1", source="abs"))
+        self.assertFalse(self.db_service.is_suggestion_ignored("id1", source="abs"))
+
+        self.assertTrue(self.db_service.ignore_suggestion("id1", source="abs"))
+        self.assertTrue(self.db_service.is_suggestion_ignored("id1", source="abs"))
+
+    def test_is_suggestion_ignored_scoped_by_source(self):
+        """is_suggestion_ignored only matches the row under the given source."""
+        s_abs = self.PendingSuggestion(source_id="id1", title="ABS", source="abs")
+        s_kosync = self.PendingSuggestion(source_id="id1", title="KOSync", source="kosync")
+        self.db_service.save_pending_suggestion(s_abs)
+        self.db_service.save_pending_suggestion(s_kosync)
+
+        self.assertTrue(self.db_service.ignore_suggestion("id1", source="kosync"))
+
+        self.assertTrue(self.db_service.is_suggestion_ignored("id1", source="kosync"))
+        self.assertFalse(self.db_service.is_suggestion_ignored("id1", source="abs"))
+
+    def test_is_suggestion_ignored_false_when_missing(self):
+        """is_suggestion_ignored returns False when no matching row exists."""
+        self.assertFalse(self.db_service.is_suggestion_ignored("missing", source="abs"))
+
     def test_upsert_different_source_creates_two_rows(self):
         """save_pending_suggestion with same source_id but different source creates distinct rows."""
         s1 = self.PendingSuggestion(source_id="id1", title="ABS Title", source="abs")


### PR DESCRIPTION
## What changed

Added a small shared helper `BaseRepository._exists(model, *filters)` and rewrote two `SuggestionRepository` methods to use it:

- `suggestion_exists(source_id, source="abs")`
- `is_suggestion_ignored(source_id, source="abs")`

Both previously opened a session, built a query, called `.first()`, and returned `is not None`. They now delegate to `_exists`, matching the existing `_get_one`/`_get_all`/`_delete_one` helper pattern in `BaseRepository`.

## Why

Removes two copies of the same boolean-existence query boilerplate and keeps the method bodies consistent with the other repository-wide query helpers. Single-line method bodies are easier to read and reduce drift between the two checks.

## Behavior preserved

- Public method names, signatures, and `source="abs"` defaults unchanged.
- `suggestion_exists()` returns `True` for any matching `(source_id, source)` row regardless of status; remains source-scoped.
- `is_suggestion_ignored()` returns `True` only for a matching `(source_id, source)` row with status exactly `"ignored"`; remains source-scoped.
- Missing rows return `False` for both.
- No objects returned/exposed, no ordering added, no status normalization or transition changes, no save/upsert/delete/clear-stale changes.
- `_exists` uses the same `get_session()` context manager, so transaction/session semantics are unchanged.

## Validation (actual outputs)

`ruff check src/ tests/ alembic/ scripts/`
```
All checks passed!
```

`git diff --check` — clean.

Targeted: `./run-tests.sh tests/test_database_service_integration.py tests/test_suggestion_logic.py tests/test_suggestions_feature.py`
```
collected 97 items
...
97 passed in 34.23s
```

Full suite: `./run-tests.sh`
```
1133 passed, 3 skipped, 17 warnings in 123.34s
```

Tests added (in `TestSuggestionSourceScoping`, via the public `DatabaseService` API):
- `test_suggestion_exists_true_regardless_of_status` (pending/hidden/ignored)
- `test_suggestion_exists_false_when_missing`
- `test_is_suggestion_ignored_only_for_ignored_status` (not pending/hidden)
- `test_is_suggestion_ignored_scoped_by_source`
- `test_is_suggestion_ignored_false_when_missing`

## Scope / risk

Narrow refactor touching only `src/db/base_repository.py`, `src/db/suggestion_repository.py`, and one test file. No behavior change. This PR targets `cleanup/backend-cleanup-2026-06-29`, **not `dev`**.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate suggestion existence checks into `BaseRepository._exists`
> - Adds `BaseRepository._exists` in [base_repository.py](https://github.com/serabi/pagekeeper/pull/110/files#diff-b524b275e70582a0f190cb4b5ed9a7fdeac1da4b366ee7736920f66da9433064), a shared helper that opens a session, applies filters, and returns a boolean based on `.first()`.
> - Refactors `suggestion_exists` and `is_suggestion_ignored` in [suggestion_repository.py](https://github.com/serabi/pagekeeper/pull/110/files#diff-ddd214ce1b0b558e1fb9ecf6e8522f15745aaa61da676e84c6b35122a0a723bd) to delegate to `_exists` instead of duplicating session/query logic.
> - Adds integration tests covering status transitions, source scoping, and missing-row cases for both methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dac4ee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->