### PR TITLE
Cleanup 27: consolidate simple repository counts

### DIFF
--- a/src/db/base_repository.py
+++ b/src/db/base_repository.py
@@ -74,6 +74,14 @@ class BaseRepository:
         with self.get_session() as session:
             return session.query(model).filter(*filters).first() is not None
 
+    def _count(self, model, *filters):
+        """Return the number of rows matching the filters (0 for none)."""
+        with self.get_session() as session:
+            query = session.query(model)
+            if filters:
+                query = query.filter(*filters)
+            return query.count()
+
     def _delete_one(self, model, *filters):
         """Find and delete a single row. Returns True if deleted."""
         with self.get_session() as session:

--- a/src/db/suggestion_repository.py
+++ b/src/db/suggestion_repository.py
@@ -53,8 +53,7 @@ class SuggestionRepository(BaseRepository):
         )
 
     def get_pending_suggestion_count(self):
-        with self.get_session() as session:
-            return session.query(PendingSuggestion).filter(PendingSuggestion.status == "pending").count()
+        return self._count(PendingSuggestion, PendingSuggestion.status == "pending")
 
     def get_all_pending_suggestions(self):
         return self._get_all(

--- a/src/db/tbr_repository.py
+++ b/src/db/tbr_repository.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from sqlalchemy import func
-
 from .base_repository import BaseRepository
 from .models import TbrItem
 
@@ -154,8 +152,7 @@ class TbrRepository(BaseRepository):
 
     def get_tbr_count(self):
         """Return the total number of TBR items."""
-        with self.get_session() as session:
-            return session.query(func.count(TbrItem.id)).scalar()
+        return self._count(TbrItem)
 
     def find_by_book_id(self, book_id):
         """Find a TBR item linked to a given library book."""

--- a/tests/test_database_service_integration.py
+++ b/tests/test_database_service_integration.py
@@ -2390,6 +2390,52 @@ class TestSuggestionSourceScoping(unittest.TestCase):
         self.assertEqual(kosync_saved.status, "pending")
         self.assertEqual(self.db_service.get_suggestion("id1", source="abs").status, "hidden")
 
+    def test_pending_suggestion_count_empty_database_returns_zero(self):
+        """get_pending_suggestion_count returns 0 when no suggestions exist."""
+        self.assertEqual(self.db_service.get_pending_suggestion_count(), 0)
+
+    def test_pending_suggestion_count_counts_pending_rows(self):
+        """get_pending_suggestion_count counts suggestions whose status is pending."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="A", source="abs")
+        )
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id2", title="B", source="abs")
+        )
+        self.assertEqual(self.db_service.get_pending_suggestion_count(), 2)
+
+    def test_pending_suggestion_count_excludes_non_pending_statuses(self):
+        """Hidden, ignored, and dismissed suggestions are excluded from the pending count."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="pending", title="P", source="abs")
+        )
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="hidden", title="H", source="abs")
+        )
+        self.assertTrue(self.db_service.hide_suggestion("hidden", source="abs"))
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="ignored", title="I", source="abs")
+        )
+        self.assertTrue(self.db_service.ignore_suggestion("ignored", source="abs"))
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="dismissed", title="D", source="abs", status="dismissed")
+        )
+
+        self.assertEqual(self.db_service.get_pending_suggestion_count(), 1)
+
+    def test_pending_suggestion_count_ignores_source_when_pending(self):
+        """Source value does not matter for the pending count as long as status is pending."""
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="ABS", source="abs")
+        )
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="KOSync", source="kosync")
+        )
+        self.db_service.save_pending_suggestion(
+            self.PendingSuggestion(source_id="id1", title="Storyteller", source="storyteller")
+        )
+        self.assertEqual(self.db_service.get_pending_suggestion_count(), 3)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed

Added a small shared `_count` helper to `BaseRepository` and routed the two simplest count methods through it:

- `TbrRepository.get_tbr_count()` -> `self._count(TbrItem)`
- `SuggestionRepository.get_pending_suggestion_count()` -> `self._count(PendingSuggestion, PendingSuggestion.status == "pending")`

The now-unused `from sqlalchemy import func` import was removed from `tbr_repository.py` (it was only used by the old `get_tbr_count`).

```python
def _count(self, model, *filters):
    """Return the number of rows matching the filters (0 for none)."""
    with self.get_session() as session:
        query = session.query(model)
        if filters:
            query = query.filter(*filters)
        return query.count()
```

## Why

A deliberately narrow, read-only count-helper pilot. These two methods each hand-rolled the same session + query + count boilerplate. Consolidating only the two simplest cases keeps them shorter and consistent with the existing `_get_one` / `_get_all` / `_exists` helpers, without touching any delete/statistics/aggregate logic.

## Behavior preserved

- Public method names, signatures, and defaults unchanged.
- Both methods still return Python integer counts; empty tables return `0`, not `None`.
- `get_tbr_count()` counts all `TbrItem` rows regardless of source, linked book, priority, or enrichment. `query(TbrItem).count()` is equivalent to the previous `func.count(TbrItem.id).scalar()` since `id` is the non-nullable primary key.
- `get_pending_suggestion_count()` counts only rows with status exactly `"pending"`; hidden/ignored/dismissed/non-pending rows are excluded.
- No ordering, pagination, object loading, expunging, mutation, or deletion introduced. `DatabaseService` dynamic/public access unchanged.

## Tests

The existing `tests/test_tbr_repository.py::test_count` already covers TBR empty/non-empty counts, so it was left untouched. Added four `get_pending_suggestion_count()` characterization tests to `TestSuggestionSourceScoping` in `tests/test_database_service_integration.py` (public API only, no private helper names):

- empty database returns `0`;
- pending suggestions are counted;
- hidden/ignored/dismissed/non-pending suggestions are excluded;
- source value does not matter for pending count when status is pending.

## Validation (actual outputs)

`ruff check src/ tests/ alembic/ scripts/`
```
All checks passed!
```

`git diff --check` -> no whitespace errors.

Targeted suites:
```
tests/test_tbr_repository.py ........................................    [ 28%]
tests/test_database_service_integration.py ...                          [ 48%] ... 
tests/test_suggestion_logic.py .......                                   [ 96%]
tests/test_suggestions_feature.py .....                                  [100%]
============================= 141 passed in 51.58s =============================
```

Full suite:
```
=========== 1137 passed, 3 skipped, 17 warnings in 140.72s (0:02:20) ===========
```

## Scope / risk note

Low risk: read-only, two methods only, behavior preserved exactly. This PR targets the long-lived cleanup integration branch `cleanup/backend-cleanup-2026-06-29`, **not `dev`**. Out of scope and untouched: delete methods, `BookRepository.get_statistics()`, grouped/dict count queries, and all save/upsert/transition paths.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate repository count queries into `BaseRepository._count` helper
> - Adds `BaseRepository._count` in [base_repository.py](https://github.com/serabi/pagekeeper/pull/111/files#diff-b524b275e70582a0f190cb4b5ed9a7fdeac1da4b366ee7736920f66da9433064), a shared helper that opens a session, applies optional filters, and returns a row count via the ORM.
> - Reimplements `SuggestionRepository.get_pending_suggestion_count` and `TbrRepository.get_tbr_count` to delegate to `_count`, removing inline session/filter boilerplate and the now-unused `sqlalchemy.func` import.
> - Adds four integration tests in [test_database_service_integration.py](https://github.com/serabi/pagekeeper/pull/111/files#diff-354128dd9d6dc5e5d57491f00f1cefe1992bf8195ac01776c2dadbe9a21d1b9e) covering empty database, multiple pending rows, non-pending status exclusion, and cross-source counting for `get_pending_suggestion_count`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8ff913.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->