### PR TITLE
Harden settings encryption migration safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,26 @@ environment:
 
 Existing plaintext secrets are migrated to encrypted form automatically on the
 next startup — no manual steps are needed, and the migration is idempotent.
+Before that one-way migration encrypts the first secret, PageKeeper writes a
+timestamped backup of the database next to it
+(`database.db.pre-settings-encryption-YYYYMMDD-HHMMSS`). If the backup cannot be
+written the migration is skipped and your plaintext secrets are left untouched,
+so an upgrade never encrypts without leaving a recovery point. The backup is
+only created when there is at least one plaintext secret to migrate.
 
-**Key loss is unrecoverable.** If you lose the master secret, encrypted secrets
-cannot be decrypted and must be re-entered in **Settings**. Back the key up
-alongside your `data/` directory.
+Setting a dedicated `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY` is **strongly
+recommended**: it keeps your encryption key independent of the Flask session
+secret, so rotating or regenerating the session secret never strands your stored
+secrets. The active key source is logged at startup (the source class only,
+never the key value) to help diagnose wrong-key errors.
+
+**Key loss still means re-entering secrets.** If you lose the master secret,
+encrypted secret *values* cannot be decrypted and must be re-entered in
+**Settings**. The pre-encryption backup gives you an upgrade recovery path (the
+pre-migration plaintext), but it is not a substitute for backing the key up
+alongside your `data/` directory. PageKeeper preserves undecryptable secret rows
+rather than overwriting them, and logs which secrets could not be decrypted (by
+name only) so the condition is visible.
 
 **Key rotation:** to rotate the master secret, move the old value to
 `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS` and set the new value in

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -15,10 +15,14 @@ services:
       - TZ=America/New_York
       # - LOG_LEVEL=INFO
       # - KOSYNC_PORT=5758 # Enable Split-Port Mode (Safe for Internet Exposure)
-      # Encrypts API secrets at rest in the database. Generate with:
+      # Encrypts API secrets at rest in the database. Strongly recommended.
+      # Generate with:
       #   python -c "import secrets; print(secrets.token_urlsafe(32))"
-      # Losing this key makes stored secrets unrecoverable (re-enter them in Settings).
+      # Losing this key means stored secret values must be re-entered in Settings.
       # If unset, the persistent Flask secret in /data is used as a fallback.
+      # On first run a pre-encryption DB backup
+      # (database.db.pre-settings-encryption-*) is created before the one-way
+      # migration, giving an upgrade recovery path.
       # - PAGEKEEPER_SETTINGS_ENCRYPTION_KEY=replace-with-a-strong-random-secret
       # For key rotation, keep the old value here while setting a new key above:
       # - PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS=previous-secret

--- a/src/app_runtime.py
+++ b/src/app_runtime.py
@@ -268,8 +268,65 @@ def get_settings_previous_secret() -> str:
     return get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY_PREVIOUS", "").strip()
 
 
+# Stable, non-secret labels for the source of the settings-encryption master
+# secret. These describe *where* the key comes from, never its value.
+KEY_SOURCE_EXPLICIT = "PAGEKEEPER_SETTINGS_ENCRYPTION_KEY"
+KEY_SOURCE_FLASK_ENV = "FLASK_SECRET_KEY"
+KEY_SOURCE_FLASK_FILE = "persistent /data/.flask_secret_key file"
+KEY_SOURCE_NONE = "unavailable (no key source resolvable)"
+
+
+def get_settings_key_source() -> str:
+    """Return a non-secret label for which master-secret source is active.
+
+    Mirrors the discovery order in :func:`get_settings_master_secret` and
+    returns only the *class* of the key source, never the key material, so
+    it is safe to log. Helps users diagnose wrong-key startup errors (e.g.
+    "decryption fails and the source is the file fallback, not the env var
+    I thought I set").
+    """
+    if get_str("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "").strip():
+        return KEY_SOURCE_EXPLICIT
+    if get_str("FLASK_SECRET_KEY", "").strip():
+        return KEY_SOURCE_FLASK_ENV
+    try:
+        get_or_create_secret_key(persist_only=True)
+        return KEY_SOURCE_FLASK_FILE
+    except EphemeralSecretKeyError:
+        return KEY_SOURCE_NONE
+
+
+_key_source_logged = False
+
+
+def log_settings_key_source() -> None:
+    """Log the active settings-encryption key source once, without its value.
+
+    Logged at most once per process to avoid repeating the line on every
+    settings reload. When the explicit dedicated key is not in use, the log
+    nudges toward setting ``PAGEKEEPER_SETTINGS_ENCRYPTION_KEY``.
+    """
+    global _key_source_logged
+    if _key_source_logged:
+        return
+    _key_source_logged = True
+
+    source = get_settings_key_source()
+    if source == KEY_SOURCE_EXPLICIT:
+        logger.info("Settings encryption key source: %s", source)
+    else:
+        logger.warning(
+            "Settings encryption key source: %s. Setting a dedicated "
+            "PAGEKEEPER_SETTINGS_ENCRYPTION_KEY is strongly recommended so the "
+            "key survives changes to the Flask session secret.",
+            source,
+        )
+
+
 def log_security_warnings():
     """Log warnings for common security misconfigurations at startup."""
+    log_settings_key_source()
+
     kosync_user = get_str("KOSYNC_USER", "")
     kosync_key = get_str("KOSYNC_KEY", "")
     kosync_port = get_str("KOSYNC_PORT", "")

--- a/src/db/settings_repository.py
+++ b/src/db/settings_repository.py
@@ -9,6 +9,9 @@ and returned verbatim.
 """
 
 import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
 
 from sqlalchemy.dialects.sqlite import insert
 
@@ -19,6 +22,8 @@ from .base_repository import BaseRepository
 from .models import Setting
 
 logger = logging.getLogger(__name__)
+
+BACKUP_SUFFIX = "pre-settings-encryption"
 
 
 class SettingsRepository(BaseRepository):
@@ -86,6 +91,30 @@ class SettingsRepository(BaseRepository):
         """Delete a setting by key."""
         return self._delete_one(Setting, Setting.key == key)
 
+    def get_undecryptable_secret_keys(self):
+        """Return the names of secret settings that fail to decrypt.
+
+        Used for safe diagnostics: it reports *which* secret rows cannot be
+        read under the current key (e.g. wrong/lost master secret) without
+        ever exposing a value. Non-secret settings and successfully
+        decrypting secrets are excluded.
+        """
+        from src.utils.secret_settings import SECRET_SETTING_KEYS
+        from src.utils.settings_crypto import SettingsCrypto
+
+        undecryptable = []
+        with self.get_session() as session:
+            query = session.query(Setting).filter(Setting.key.in_(SECRET_SETTING_KEYS))
+            rows = self._query_and_expunge(session, query, one=False)
+            for row in rows:
+                if not SettingsCrypto.is_encrypted(row.value):
+                    continue
+                try:
+                    self._decrypt_from_storage(row.key, row.value)
+                except SettingsCryptoError:
+                    undecryptable.append(row.key)
+        return undecryptable
+
     def encrypt_plaintext_secrets(self):
         """Encrypt any plaintext secret values stored in the table.
 
@@ -93,17 +122,65 @@ class SettingsRepository(BaseRepository):
         empty/None values are skipped, so this is safe to run on every
         startup and never double-encrypts. Returns the number of values
         newly encrypted.
+
+        This is a one-way migration: once a plaintext secret becomes an
+        encrypted row, the value can only be recovered with the master
+        secret. To make an upgrade recoverable, a timestamped backup of
+        the database is taken *before* the first row is mutated. If the
+        backup cannot be created the migration fails closed — plaintext
+        secrets are left untouched — rather than encrypting without a
+        recovery path.
         """
         from src.utils.secret_settings import SECRET_SETTING_KEYS
         from src.utils.settings_crypto import SettingsCrypto
 
         crypto = get_settings_crypto()
-        migrated = 0
         with self.get_session() as session:
             rows = session.query(Setting).filter(Setting.key.in_(SECRET_SETTING_KEYS)).all()
-            for row in rows:
-                if not row.value or SettingsCrypto.is_encrypted(row.value):
-                    continue
+            pending = [row for row in rows if row.value and not SettingsCrypto.is_encrypted(row.value)]
+
+            # Nothing to migrate: skip the backup entirely so already-encrypted
+            # installs never accumulate a backup on every startup.
+            if not pending:
+                return 0
+
+            # Fail closed: create the backup before mutating any row. A failure
+            # here aborts the transaction with plaintext secrets intact.
+            backup_path = self._backup_database_before_encryption()
+            logger.info(
+                "Created pre-encryption database backup before encrypting %d secret(s): %s",
+                len(pending),
+                backup_path,
+            )
+
+            for row in pending:
                 row.value = crypto.encrypt_value(row.key, row.value)
-                migrated += 1
-        return migrated
+        return len(pending)
+
+    def _backup_database_before_encryption(self) -> str:
+        """Back up the SQLite database before the one-way encryption migration.
+
+        Returns the backup path on success. Raises on failure so the caller
+        can fail closed and leave plaintext secrets untouched.
+
+        Uses the SQLite online backup API (``sqlite3.Connection.backup``),
+        which produces a single, internally consistent snapshot file. Unlike a
+        naive file copy it accounts for the WAL: committed transactions still
+        sitting in the ``-wal`` file are folded into the backup, so the result
+        is a standalone ``database.db`` with no companion ``-wal``/``-shm``
+        files required to restore it.
+        """
+        db_path = Path(self.db_manager.db_path)
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = db_path.with_name(f"{db_path.name}.{BACKUP_SUFFIX}-{timestamp}")
+
+        source = sqlite3.connect(str(db_path))
+        try:
+            destination = sqlite3.connect(str(backup_path))
+            try:
+                source.backup(destination)
+            finally:
+                destination.close()
+        finally:
+            source.close()
+        return str(backup_path)

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -239,6 +239,36 @@ class ConfigLoader:
             logger.error("Error encrypting plaintext secrets: %s", e)
 
     @staticmethod
+    def _warn_undecryptable_secrets(db_service: DatabaseService):
+        """Log an actionable warning when stored secrets cannot be decrypted.
+
+        Surfaces the wrong/lost-key case as an aggregate, names-only warning
+        (never values). The affected rows are left intact and fail closed —
+        this only makes the condition visible so users can fix the key
+        instead of silently re-entering credentials over good ciphertext.
+        """
+        try:
+            undecryptable = db_service.get_undecryptable_secret_keys()
+        except Exception as exc:
+            logger.debug("Could not check for undecryptable secrets: %s", exc)
+            return
+
+        if not undecryptable:
+            return
+
+        from src.app_runtime import get_settings_key_source
+
+        logger.warning(
+            "%d encrypted secret setting(s) could not be decrypted with the current key "
+            "(source: %s): %s. The stored values are preserved, not overwritten. Restore the "
+            "correct PAGEKEEPER_SETTINGS_ENCRYPTION_KEY (or set *_PREVIOUS for rotation), or "
+            "re-enter these secrets in Settings.",
+            len(undecryptable),
+            get_settings_key_source(),
+            ", ".join(sorted(undecryptable)),
+        )
+
+    @staticmethod
     def load_settings(db_service: DatabaseService):
         """
         Load all settings from database and update os.environ.
@@ -247,6 +277,8 @@ class ConfigLoader:
             db_service: Initialized DatabaseService instance
         """
         try:
+            ConfigLoader._warn_undecryptable_secrets(db_service)
+
             settings = db_service.get_all_settings()
             count = 0
 

--- a/tests/test_settings_repository_encryption.py
+++ b/tests/test_settings_repository_encryption.py
@@ -130,6 +130,128 @@ class TestMigration:
         assert _raw_value(db_service, "ABS_SERVER") == "https://abs.example"
 
 
+class TestPreEncryptionBackup:
+    """The one-way encryption migration must back up the DB before mutating."""
+
+    def _backups(self, db_service):
+        db_path = Path(db_service.db_manager.db_path)
+        return sorted(db_path.parent.glob(f"{db_path.name}.pre-settings-encryption-*"))
+
+    def _seed_plaintext(self, db_service, key, value):
+        with db_service.get_session() as session:
+            session.add(Setting(key=key, value=value))
+
+    def test_backup_created_before_encrypting(self, encryption_key, db_service):
+        self._seed_plaintext(db_service, "ABS_KEY", "dummy-abs-key")
+
+        assert self._backups(db_service) == []
+        migrated = db_service.encrypt_plaintext_secrets()
+
+        assert migrated == 1
+        backups = self._backups(db_service)
+        assert len(backups) == 1
+
+        # The backup is a standalone SQLite DB still holding the PLAINTEXT secret,
+        # proving it was taken before the row was encrypted.
+        backup_service = DatabaseService(str(backups[0]))
+        assert _raw_value(backup_service, "ABS_KEY") == "dummy-abs-key"
+        # Live DB is now encrypted.
+        assert SettingsCrypto.is_encrypted(_raw_value(db_service, "ABS_KEY"))
+
+    def test_no_plaintext_means_no_backup(self, encryption_key, db_service):
+        # Already-encrypted secret only — nothing pending.
+        db_service.set_setting("ABS_KEY", "dummy-abs-key")
+        assert SettingsCrypto.is_encrypted(_raw_value(db_service, "ABS_KEY"))
+
+        assert db_service.encrypt_plaintext_secrets() == 0
+        assert self._backups(db_service) == []
+
+    def test_empty_db_means_no_backup(self, encryption_key, db_service):
+        assert db_service.encrypt_plaintext_secrets() == 0
+        assert self._backups(db_service) == []
+
+    def test_backup_failure_fails_closed(self, encryption_key, db_service, monkeypatch):
+        self._seed_plaintext(db_service, "ABS_KEY", "dummy-abs-key")
+
+        def boom(self):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "src.db.settings_repository.SettingsRepository._backup_database_before_encryption",
+            boom,
+        )
+
+        with pytest.raises(OSError):
+            db_service.encrypt_plaintext_secrets()
+
+        # Plaintext is untouched (not partially encrypted) and no backup remains.
+        assert _raw_value(db_service, "ABS_KEY") == "dummy-abs-key"
+        assert self._backups(db_service) == []
+
+
+class TestUndecryptableSecretDiagnostics:
+    def test_lists_only_undecryptable_secret_keys(self, encryption_key, db_service, monkeypatch):
+        db_service.set_setting("ABS_KEY", "dummy-abs-key")  # good
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")  # will break
+        db_service.set_setting("ABS_SERVER", "https://abs.example")  # non-secret
+
+        with db_service.get_session() as session:
+            row = session.query(Setting).filter(Setting.key == "HARDCOVER_TOKEN").one()
+            row.value = row.value + "tampered"
+
+        undecryptable = db_service.get_undecryptable_secret_keys()
+        assert undecryptable == ["HARDCOVER_TOKEN"]
+
+    def test_no_undecryptable_returns_empty(self, encryption_key, db_service):
+        db_service.set_setting("ABS_KEY", "dummy-abs-key")
+        assert db_service.get_undecryptable_secret_keys() == []
+
+
+class TestKeySourceDiagnostics:
+    def test_explicit_env_var_source(self, monkeypatch):
+        from src import app_runtime
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "dummy-explicit")
+        assert app_runtime.get_settings_key_source() == app_runtime.KEY_SOURCE_EXPLICIT
+
+    def test_flask_env_source(self, monkeypatch):
+        from src import app_runtime
+
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setenv("FLASK_SECRET_KEY", "dummy-flask-secret")
+        assert app_runtime.get_settings_key_source() == app_runtime.KEY_SOURCE_FLASK_ENV
+
+    def test_flask_file_source(self, monkeypatch, tmp_path):
+        from src import app_runtime
+
+        monkeypatch.delenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        assert app_runtime.get_settings_key_source() == app_runtime.KEY_SOURCE_FLASK_FILE
+
+    def test_source_label_never_contains_secret_value(self, monkeypatch):
+        from src import app_runtime
+
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "super-secret-value-xyz")
+        label = app_runtime.get_settings_key_source()
+        assert "super-secret-value-xyz" not in label
+
+    def test_log_emitted_once(self, monkeypatch, caplog):
+        import logging
+
+        from src import app_runtime
+
+        monkeypatch.setattr(app_runtime, "_key_source_logged", False)
+        monkeypatch.setenv("PAGEKEEPER_SETTINGS_ENCRYPTION_KEY", "dummy-explicit")
+
+        with caplog.at_level(logging.INFO):
+            app_runtime.log_settings_key_source()
+            app_runtime.log_settings_key_source()
+
+        source_logs = [r for r in caplog.records if "Settings encryption key source" in r.message]
+        assert len(source_logs) == 1
+
+
 class TestWrongKeyFailsClosed:
     def test_read_with_wrong_key_raises(self, encryption_key, db_service, monkeypatch):
         db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
@@ -160,6 +282,60 @@ class TestWrongKeyFailsClosed:
         # Targeted reads still fail closed for the bad key.
         with pytest.raises(SettingsDecryptionError):
             db_service.get_setting("HARDCOVER_TOKEN")
+
+
+class TestUndecryptableSecretNotOverwritten:
+    """A blank secret submission must not clobber an undecryptable secret row.
+
+    Mirrors the settings-route save logic: secret keys submitted blank are
+    skipped so the stored ciphertext is preserved. This guards against a
+    wrong-key startup leading to silent data loss when the user saves the
+    Settings form (whose secret fields render blank) without re-entering
+    every credential.
+    """
+
+    def _apply_settings_save(self, db_service, submitted):
+        """Replicate the settings route's persist loop for *submitted* values."""
+        from src.utils.secret_settings import SECRET_SETTING_KEYS
+
+        current_settings = {}
+        try:
+            current_settings = db_service.get_all_settings()
+        except Exception:
+            current_settings = {}
+
+        for key, value in submitted.items():
+            clean_value = value.strip()
+            if not clean_value and key in SECRET_SETTING_KEYS:
+                continue  # preserve existing secret
+            if clean_value:
+                db_service.set_setting(key, clean_value)
+            elif key in current_settings:
+                db_service.set_setting(key, "")
+
+    def test_blank_secret_post_preserves_undecryptable_row(self, encryption_key, db_service):
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-hardcover-token")
+
+        # Simulate a wrong/lost key: corrupt the stored ciphertext so it cannot decrypt.
+        with db_service.get_session() as session:
+            row = session.query(Setting).filter(Setting.key == "HARDCOVER_TOKEN").one()
+            row.value = row.value + "tampered"
+        corrupted_raw = _raw_value(db_service, "HARDCOVER_TOKEN")
+
+        # User saves the settings form with the secret field left blank.
+        self._apply_settings_save(db_service, {"HARDCOVER_TOKEN": "", "ABS_SERVER": "https://abs.example"})
+
+        # The undecryptable secret row is untouched (not blanked, not re-encrypted).
+        assert _raw_value(db_service, "HARDCOVER_TOKEN") == corrupted_raw
+        # A non-secret submitted alongside it still persists normally.
+        assert _raw_value(db_service, "ABS_SERVER") == "https://abs.example"
+
+    def test_explicit_new_secret_overwrites(self, encryption_key, db_service):
+        db_service.set_setting("HARDCOVER_TOKEN", "dummy-old-token")
+
+        self._apply_settings_save(db_service, {"HARDCOVER_TOKEN": "dummy-new-token"})
+
+        assert db_service.get_setting("HARDCOVER_TOKEN") == "dummy-new-token"
 
 
 class TestKeyRotationThroughRepository:


### PR DESCRIPTION
## What Changed

Adds safety rails around the existing one-way plaintext-to-encrypted settings migration. No changes to the crypto, key derivation, or key-source discovery themselves — only recoverability and diagnostics.

- **Pre-encryption database backup** (`SettingsRepository.encrypt_plaintext_secrets`): before the migration encrypts the first plaintext secret, a timestamped backup `database.db.pre-settings-encryption-YYYYMMDD-HHMMSS` is written next to the DB via the SQLite online backup API (`sqlite3.Connection.backup`). The backup is created only when at least one plaintext secret is actually pending, and only once (already-encrypted installs never accumulate backups). If the backup cannot be written, the migration **fails closed**: plaintext secrets are left untouched rather than encrypted without a recovery point.
- **Safe key-source diagnostics** (`app_runtime.get_settings_key_source` / `log_settings_key_source`): logs which master-secret source is active (`PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`, `FLASK_SECRET_KEY`, or the persistent `/data/.flask_secret_key` file) — the source class only, never the value — once per process, wired into the existing `log_security_warnings()` startup path. Nudges toward setting a dedicated key when the fallback is in use.
- **Decryption-failure surfacing** (`config_loader._warn_undecryptable_secrets` + `SettingsRepository.get_undecryptable_secret_keys`): at settings load, logs an aggregate, names-only warning when stored secrets cannot be decrypted under the current key, confirming the rows are preserved and pointing at the key/rotation fix. Existing per-row fail-closed behavior in `get_all_settings()` is unchanged.
- **Docs**: README and `docker-compose.example.yml` updated for the auto-backup, the dedicated-key recommendation, the rotation flow, and the recovery path.

## Why

PageKeeper auto-encrypts legacy plaintext secret settings on startup. This is a one-way migration: if the encryption key source later changes or is lost, encrypted secret rows become unreadable. Smoke-testing the integration branch surfaced this as a shipping risk — after upgrade, a user whose key source shifts could lose access to saved API keys, passwords, and tokens with no recovery path. These rails make the upgrade recoverable (pre-migration backup), the key source visible (diagnostics), and the failure mode non-destructive (fail closed, preserve rows).

## Data / Migration Risk

- **Low.** The migration path already existed; this only adds a backup before it and makes failures non-destructive.
- The backup uses the SQLite online backup API, which folds committed WAL contents into a single standalone snapshot — no `-wal`/`-shm` sidecars are needed to restore. It runs before any row is mutated, so it captures the pre-migration plaintext.
- Backup is gated on at least one pending plaintext secret, so already-encrypted and fresh installs create no backup and incur no extra startup I/O.
- Undecryptable secret rows are never overwritten; a blank secret submitted via the Settings form preserves the stored value (existing route behavior, now regression-tested).

## Validation

All run on this branch.

- `ruff check src/ tests/ alembic/ scripts/` — All checks passed.
- `git diff --check` — clean.
- Focused tests in Docker (`./run-tests.sh tests/test_settings_crypto.py tests/test_settings_repository_encryption.py tests/test_settings_comprehensive.py tests/test_test_connection.py`) — **65 passed, 1 skipped** (the skip is a root-euid guard).
- Full suite in Docker (`./run-tests.sh`) — **1150 passed, 3 skipped, 0 failures**.

New tests cover: backup created before encrypting (and the backup holds the plaintext while the live DB is encrypted); no plaintext / empty DB → no backup; backup failure fails closed and leaves plaintext intact; undecryptable-secret listing (names only); key-source labels never contain the value and log once; blank-secret POST preserves an undecryptable row while a new explicit secret overwrites.

Note: running the full suite in the local non-Docker venv shows 16 pre-existing `jinja2 TemplateNotFound` failures unrelated to this change (confirmed identical on the clean integration branch via `git stash`). The Docker environment — the project's canonical test path — is fully green.

## Follow-ups

- Surface the undecryptable-secret condition as a banner on the Settings GET page (currently logged only). Left out to keep this PR focused on the data-safety rails; the save path is already proven non-destructive by tests.
- Optional retention/cleanup policy for accumulated `pre-settings-encryption-*` backups (currently one per actual migration event, which is rare).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden settings encryption migration with pre-encryption backups and key-source logging
> - `SettingsRepository.encrypt_plaintext_secrets` now creates a timestamped SQLite backup (`database.db.pre-settings-encryption-YYYYMMDD-HHMMSS`) before encrypting any plaintext secrets; if the backup fails, no encryption is performed and the exception propagates.
> - Skips backup creation entirely when no plaintext secrets are pending, avoiding unnecessary side effects.
> - Adds `get_undecryptable_secret_keys` to detect secrets that cannot be decrypted with the current key, and `_warn_undecryptable_secrets` logs an aggregated warning naming affected keys.
> - Adds `log_settings_key_source` to emit a one-time startup log identifying whether the encryption key comes from `PAGEKEEPER_SETTINGS_ENCRYPTION_KEY`, `FLASK_SECRET_KEY`, or a persisted secret key file; logs INFO for the explicit env key and WARNING otherwise.
> - Risk: migration is fail-closed — a backup I/O error blocks encryption and surfaces as an unhandled exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8bde5af. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->