### PR TITLE
Add exact Grimmory audiobook support

### DIFF
--- a/alembic/versions/aa8b9c0d1e2f_add_grimmory_audiobook_identity.py
+++ b/alembic/versions/aa8b9c0d1e2f_add_grimmory_audiobook_identity.py
@@ -1,0 +1,38 @@
+"""add Grimmory audiobook identity
+
+Revision ID: aa8b9c0d1e2f
+Revises: z7a8b9c0d1e2
+Create Date: 2026-07-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "aa8b9c0d1e2f"
+down_revision: str | Sequence[str] | None = "z7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("books", sa.Column("grimmory_audio_source_id", sa.String(length=255), nullable=True))
+    op.create_index(
+        "ix_books_grimmory_audio_source_id",
+        "books",
+        ["grimmory_audio_source_id"],
+        unique=True,
+    )
+    op.add_column(
+        "detected_books",
+        sa.Column("media_format", sa.String(length=20), nullable=False, server_default="ebook"),
+    )
+    op.execute("UPDATE detected_books SET media_format = 'audiobook' WHERE source = 'abs'")
+
+
+def downgrade() -> None:
+    op.drop_column("detected_books", "media_format")
+    op.drop_index("ix_books_grimmory_audio_source_id", table_name="books")
+    op.drop_column("books", "grimmory_audio_source_id")

--- a/alembic/versions/bb9c0d1e2f3a_use_grimmory_remote_file_identity.py
+++ b/alembic/versions/bb9c0d1e2f3a_use_grimmory_remote_file_identity.py
@@ -1,0 +1,75 @@
+"""use Grimmory remote file identity
+
+Revision ID: bb9c0d1e2f3a
+Revises: aa8b9c0d1e2f
+Create Date: 2026-07-16
+"""
+
+import json
+from collections import Counter
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "bb9c0d1e2f3a"
+down_revision: str | Sequence[str] | None = "aa8b9c0d1e2f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("grimmory_books") as batch_op:
+        batch_op.drop_constraint("uq_grimmory_server_filename", type_="unique")
+        batch_op.add_column(sa.Column("remote_book_id", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("remote_file_id", sa.String(length=255), nullable=True))
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT id, server_id, raw_metadata FROM grimmory_books")).mappings().all()
+    parsed = []
+    for row in rows:
+        try:
+            metadata = json.loads(row["raw_metadata"] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            continue
+        book_id = metadata.get("id")
+        file_id = metadata.get("bookFileId")
+        if book_id is not None and file_id is not None:
+            parsed.append((row["id"], str(row["server_id"]), str(book_id), str(file_id)))
+
+    counts = Counter((server_id, book_id, file_id) for _, server_id, book_id, file_id in parsed)
+    for row_id, server_id, book_id, file_id in parsed:
+        if counts[(server_id, book_id, file_id)] == 1:
+            connection.execute(
+                sa.text(
+                    "UPDATE grimmory_books SET remote_book_id = :book_id, remote_file_id = :file_id WHERE id = :row_id"
+                ),
+                {"book_id": book_id, "file_id": file_id, "row_id": row_id},
+            )
+
+    op.create_index(
+        "uq_grimmory_remote_file",
+        "grimmory_books",
+        ["server_id", "remote_book_id", "remote_file_id"],
+        unique=True,
+        sqlite_where=sa.text("remote_book_id IS NOT NULL AND remote_file_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    duplicate = connection.execute(
+        sa.text(
+            "SELECT server_id, filename FROM grimmory_books "
+            "GROUP BY server_id, filename HAVING COUNT(*) > 1 LIMIT 1"
+        )
+    ).first()
+    if duplicate:
+        raise RuntimeError("Cannot downgrade while distinct Grimmory remote files share a filename")
+
+    op.drop_index("uq_grimmory_remote_file", table_name="grimmory_books")
+    with op.batch_alter_table("grimmory_books") as batch_op:
+        batch_op.drop_column("remote_file_id")
+        batch_op.drop_column("remote_book_id")
+        batch_op.create_unique_constraint("uq_grimmory_server_filename", ["server_id", "filename"])

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -30,6 +30,8 @@ class GrimmoryClient:
         self._book_case_insensitive_filenames = {}
         self._book_id_cache = {}
         self._book_file_cache = {}
+        self._book_identity_cache = {}
+        self._filename_identities = {}
         self._cache_timestamp = 0
 
         self._token = None
@@ -136,11 +138,17 @@ class GrimmoryClient:
                     if not book_info:
                         book_info = {"fileName": db_book.filename, "title": db_book.title, "authors": db_book.authors}
 
-                    self._cache_book_info(db_book.filename, book_info)
+                    remote_book_id = getattr(db_book, "remote_book_id", None)
+                    remote_file_id = getattr(db_book, "remote_file_id", None)
+                    if isinstance(remote_book_id, (str, int)):
+                        book_info.setdefault("id", remote_book_id)
+                    if isinstance(remote_file_id, (str, int)):
+                        book_info.setdefault("bookFileId", remote_file_id)
+                    self._cache_book_info(db_book.filename, book_info, legacy_row_id=db_book.id)
 
                 # Set to 0 to force a refresh/validation against API on next access
                 self._cache_timestamp = 0
-                logger.info(f"Grimmory: Loaded {len(self._book_cache)} books from database")
+                logger.info(f"Grimmory: Loaded {len(self._book_identity_cache)} books from database")
             except Exception as e:
                 logger.error(f"Failed to load Grimmory cache from DB: {e}")
                 self._reset_book_caches()
@@ -151,47 +159,70 @@ class GrimmoryClient:
         self._book_case_insensitive_filenames = {}
         self._book_id_cache = {}
         self._book_file_cache = {}
+        self._book_identity_cache = {}
+        self._filename_identities = {}
 
-    def _cache_book_info(self, filename, book_info):
+    def _cache_book_info(self, filename, book_info, legacy_row_id=None):
         cache_key = str(filename)
-        if cache_key in self._book_cache:
-            self._remove_cached_filename(cache_key)
-        self._book_cache[cache_key] = book_info
-        lookup_key = cache_key.lower()
-        self._book_case_insensitive_filenames.setdefault(lookup_key, set()).add(cache_key)
-        self._update_case_insensitive_cache_entry(lookup_key)
-
         bid = book_info.get("id")
         file_id = book_info.get("bookFileId")
-        if bid is not None:
-            if book_info.get("isPrimary") or bid not in self._book_id_cache:
-                self._book_id_cache[bid] = book_info
-            if file_id is not None:
-                self._book_file_cache[(str(bid), str(file_id))] = book_info
+        if bid is not None and file_id is not None:
+            identity = ("remote", str(bid), str(file_id))
+        else:
+            identity = ("legacy", str(legacy_row_id if legacy_row_id is not None else id(book_info)))
+
+        if identity in self._book_identity_cache:
+            self._remove_cached_identity(identity)
+        self._book_identity_cache[identity] = book_info
+        if bid is not None and file_id is not None:
+            self._book_file_cache[(str(bid), str(file_id))] = book_info
+        self._filename_identities.setdefault(cache_key, set()).add(identity)
+        self._refresh_filename_cache(cache_key)
+
+        if bid is not None and (book_info.get("isPrimary") or bid not in self._book_id_cache):
+            self._book_id_cache[bid] = book_info
+
+    def _refresh_filename_cache(self, filename):
+        identities = self._filename_identities.get(filename, set())
+        books = [self._book_identity_cache[identity] for identity in identities if identity in self._book_identity_cache]
+        if len(books) == 1:
+            self._book_cache[filename] = books[0]
+        else:
+            self._book_cache.pop(filename, None)
+        lookup_key = filename.lower()
+        self._book_case_insensitive_filenames.setdefault(lookup_key, set()).add(filename)
+        self._update_case_insensitive_cache_entry(lookup_key)
+
+    def _remove_cached_identity(self, identity):
+        removed = self._book_identity_cache.pop(identity, None)
+        if not removed:
+            return
+        filename = str(removed.get("fileName", ""))
+        identities = self._filename_identities.get(filename)
+        if identities is not None:
+            identities.discard(identity)
+            if not identities:
+                self._filename_identities.pop(filename, None)
+        bid = removed.get("id")
+        file_id = removed.get("bookFileId")
+        if bid is not None and file_id is not None:
+            self._book_file_cache.pop((str(bid), str(file_id)), None)
+        if bid is not None and self._book_id_cache.get(bid) is removed:
+            replacement = next(
+                (book for book in self._book_identity_cache.values() if book.get("id") == bid),
+                None,
+            )
+            if replacement:
+                self._book_id_cache[bid] = replacement
+            else:
+                self._book_id_cache.pop(bid, None)
+        self._refresh_filename_cache(filename)
 
     def _remove_cached_filename(self, filename):
         cache_key = str(filename)
-        removed = self._book_cache.pop(cache_key, None)
-        if removed:
-            bid = removed.get("id")
-            file_id = removed.get("bookFileId")
-            if bid is not None and file_id is not None:
-                key = (str(bid), str(file_id))
-                if self._book_file_cache.get(key) is removed:
-                    self._book_file_cache.pop(key, None)
-            if bid is not None and self._book_id_cache.get(bid) is removed:
-                replacement = next((book for book in self._book_cache.values() if book.get("id") == bid), None)
-                if replacement:
-                    self._book_id_cache[bid] = replacement
-                else:
-                    self._book_id_cache.pop(bid, None)
-        lookup_key = cache_key.lower()
-        filenames = self._book_case_insensitive_filenames.get(lookup_key)
-        if filenames is not None:
-            filenames.discard(cache_key)
-            if not filenames:
-                self._book_case_insensitive_filenames.pop(lookup_key, None)
-        self._update_case_insensitive_cache_entry(lookup_key)
+        identities = self._filename_identities.get(cache_key, set())
+        if len(identities) == 1:
+            self._remove_cached_identity(next(iter(identities)))
 
     def _update_case_insensitive_cache_entry(self, lookup_key):
         filenames = self._book_case_insensitive_filenames.get(lookup_key, set())
@@ -368,6 +399,12 @@ class GrimmoryClient:
             elif isinstance(data, dict) and "content" in data:
                 current_batch = data["content"]
 
+            raw_batch_size = len(current_batch)
+            is_last_page = isinstance(data, dict) and (
+                data.get("last") is True
+                or (isinstance(data.get("totalPages"), int) and page + 1 >= data["totalPages"])
+            )
+
             if not current_batch:
                 break
 
@@ -388,7 +425,7 @@ class GrimmoryClient:
             all_books_list.extend(current_batch)
             logger.debug(f"Grimmory: Fetched page {page} ({len(current_batch)} items)")
 
-            if len(current_batch) != batch_size:
+            if is_last_page or raw_batch_size != batch_size:
                 break
 
             page += 1
@@ -415,7 +452,8 @@ class GrimmoryClient:
         }
 
         stale_count = 0
-        for filename, book_info in list(self._book_cache.items()):
+        for identity, book_info in list(self._book_identity_cache.items()):
+            filename = str(book_info.get("fileName", ""))
             book_id = book_info.get("id")
             file_id = book_info.get("bookFileId")
             cached_filename = str(book_info.get("fileName", filename)).strip()
@@ -428,10 +466,15 @@ class GrimmoryClient:
             if not is_stale:
                 continue
             stale_count += 1
-            self._remove_cached_filename(filename)
+            self._remove_cached_identity(identity)
             if self.db:
                 try:
-                    self.db.delete_grimmory_book(filename, server_id=self.instance_id)
+                    self.db.delete_grimmory_book(
+                        filename,
+                        server_id=self.instance_id,
+                        book_id=book_id,
+                        file_id=file_id,
+                    )
                 except Exception as e:
                     logger.error(f"Failed to prune stale book {filename}: {e}")
 
@@ -520,6 +563,8 @@ class GrimmoryClient:
                             authors=author_str,
                             raw_metadata=json.dumps(book_info),
                             server_id=self.instance_id,
+                            remote_book_id=detail.get("id"),
+                            remote_file_id=book_file.get("id"),
                         )
                     )
                 except Exception as e:
@@ -577,7 +622,7 @@ class GrimmoryClient:
         """Refresh the in-memory book cache if it is empty or older than an hour."""
         if not allow_refresh:
             return
-        if not self._book_cache or time.time() - self._cache_timestamp > 3600:
+        if not self._book_identity_cache or time.time() - self._cache_timestamp > 3600:
             self._refresh_book_cache()
 
     def find_book_by_filename(self, ebook_filename, allow_refresh=True):
@@ -639,20 +684,20 @@ class GrimmoryClient:
     def get_all_books(self):
         """Get all books from cache, refreshing if necessary."""
         self._ensure_fresh_cache()
-        return list(self._book_cache.values())
+        return list(self._book_identity_cache.values())
 
     def search_books(self, search_term):
         """Search books by title, author, or filename. Returns list of matching books."""
         self._ensure_fresh_cache()
 
         if not search_term:
-            return list(self._book_cache.values())
+            return list(self._book_identity_cache.values())
 
         search_lower = search_term.lower()
         search_norm = self._normalize_string(search_term)
 
         results = []
-        for book_info in list(self._book_cache.values()):
+        for book_info in list(self._book_identity_cache.values()):
             title = (book_info.get("title") or "").lower()
             authors = (book_info.get("authors") or "").lower()
             filename = (book_info.get("fileName") or "").lower()
@@ -808,10 +853,10 @@ class GrimmoryClient:
             return False
 
     def get_recent_activity(self, min_progress=0.01):
-        if not self._book_cache:
+        if not self._book_identity_cache:
             self._refresh_book_cache()
         results = []
-        for _filename, book in list(self._book_cache.items()):
+        for book in list(self._book_identity_cache.values()):
             progress, _ = self.extract_progress(book)
             if progress is not None and progress >= min_progress:
                 results.append(

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -16,6 +16,7 @@ from src.utils.logging_utils import sanitize_log_data
 logger = logging.getLogger(__name__)
 
 GRIMMORY_AUDIO_BOOK_TYPES = {"AUDIOBOOK"}
+GRIMMORY_MAX_PAGES = 1000
 
 
 class GrimmoryClient:
@@ -378,12 +379,13 @@ class GrimmoryClient:
             return
 
         all_books_list = []
+        seen_page_identities = set()
         page = 0
         batch_size = 200
 
         logger.info("Grimmory: Starting full library scan...")
 
-        while True:
+        while page < GRIMMORY_MAX_PAGES:
             endpoint = f"/api/v1/books?page={page}&size={batch_size}"
             response = self._make_request("GET", endpoint)
 
@@ -408,6 +410,17 @@ class GrimmoryClient:
             if not current_batch:
                 break
 
+            raw_identities = {
+                (str(book.get("id")), str(book_file.get("id") or book_file.get("fileName")))
+                for book in current_batch
+                for book_file, _is_primary in self._iter_book_files(book)
+                if book.get("id") is not None and (book_file.get("id") is not None or book_file.get("fileName"))
+            }
+            if isinstance(data, list) and page > 0 and not (raw_identities - seen_page_identities):
+                logger.warning("Grimmory: Stopping pagination after repeated raw list page %s", page)
+                break
+            seen_page_identities.update(raw_identities)
+
             if self.target_library_id and current_batch:
                 filtered_batch = []
                 for b in current_batch:
@@ -430,9 +443,17 @@ class GrimmoryClient:
 
             page += 1
 
+        if page >= GRIMMORY_MAX_PAGES:
+            logger.warning("Grimmory: Stopped library scan at the %s-page safety ceiling", GRIMMORY_MAX_PAGES)
+
         if not all_books_list:
             logger.debug("Grimmory: No books found in library")
             self._reset_book_caches()
+            if self.db:
+                try:
+                    self.db.reconcile_grimmory_books(self.instance_id, [])
+                except Exception as e:
+                    logger.error(f"Failed to reconcile empty Grimmory book cache: {e}")
             self._cache_timestamp = time.time()
             return True
 
@@ -467,22 +488,18 @@ class GrimmoryClient:
                 continue
             stale_count += 1
             self._remove_cached_identity(identity)
-            if self.db:
-                try:
-                    self.db.delete_grimmory_book(
-                        filename,
-                        server_id=self.instance_id,
-                        book_id=book_id,
-                        file_id=file_id,
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to prune stale book {filename}: {e}")
 
         if stale_count:
             logger.info(f"Grimmory: Pruned {stale_count} stale books from database.")
 
+        persisted_books = []
         for book in all_books_list:
-            self._process_book_detail(book)
+            persisted_books.extend(self._process_book_detail(book, persist=False))
+        if self.db:
+            try:
+                self.db.reconcile_grimmory_books(self.instance_id, persisted_books)
+            except Exception as e:
+                logger.error(f"Failed to reconcile Grimmory book cache: {e}")
 
         self._cache_timestamp = time.time()
         return True
@@ -512,12 +529,14 @@ class GrimmoryClient:
             seen.add(identity)
             yield book_file, is_primary
 
-    def _process_book_detail(self, detail):
+    def _process_book_detail(self, detail, persist=True):
         """Cache every actual file attached to one Grimmory Book DTO."""
         if self.target_library_id:
             lid = detail.get("libraryId")
             if lid is not None and str(lid) != str(self.target_library_id):
-                return
+                return []
+
+        persisted_books = []
 
         metadata = detail.get("metadata") or {}
         authors = metadata.get("authors") or []
@@ -554,21 +573,22 @@ class GrimmoryClient:
             }
 
             self._cache_book_info(filename, book_info)
-            if self.db:
+            model = GrimmoryBook(
+                filename=filename,
+                title=title,
+                authors=author_str,
+                raw_metadata=json.dumps(book_info),
+                server_id=self.instance_id,
+                remote_book_id=detail.get("id"),
+                remote_file_id=book_file.get("id"),
+            )
+            persisted_books.append(model)
+            if self.db and persist:
                 try:
-                    self.db.save_grimmory_book(
-                        GrimmoryBook(
-                            filename=filename,
-                            title=title,
-                            authors=author_str,
-                            raw_metadata=json.dumps(book_info),
-                            server_id=self.instance_id,
-                            remote_book_id=detail.get("id"),
-                            remote_file_id=book_file.get("id"),
-                        )
-                    )
+                    self.db.save_grimmory_book(model)
                 except Exception as e:
                     logger.error(f"Failed to persist book {filename} to DB: {e}")
+        return persisted_books
 
     def extract_progress(self, book_info: dict) -> tuple[float | None, str | None]:
         """Extract (percentage_as_fraction, cfi) from any book type's progress."""
@@ -587,14 +607,18 @@ class GrimmoryClient:
         """Return the exact instance/book/file identity for a Grimmory audiobook."""
         if (book_info.get("bookType") or "").upper() not in GRIMMORY_AUDIO_BOOK_TYPES:
             return None
+        return self.book_file_source_id(book_info)
+
+    def book_file_source_id(self, book_info: dict) -> str | None:
+        """Return the exact instance/book/file identity for any Grimmory BookFile."""
         book_id = book_info.get("id")
         file_id = book_info.get("bookFileId")
         if book_id is None or file_id is None:
             return None
         return f"{getattr(self, 'instance_id', 'default')}:{book_id}:{file_id}"
 
-    def find_audiobook_by_source_id(self, source_id, allow_refresh=True):
-        """Resolve an exact qualified audiobook identity without filename matching."""
+    def find_book_file_by_source_id(self, source_id, allow_refresh=True):
+        """Resolve any exact qualified BookFile identity without filename matching."""
         try:
             instance_id, book_id, file_id = str(source_id).split(":", 2)
         except ValueError:
@@ -604,9 +628,20 @@ class GrimmoryClient:
 
         self._ensure_fresh_cache(allow_refresh)
         book = self._book_file_cache.get((book_id, file_id))
-        if not book or self.audio_source_id(book) != str(source_id):
+        if not book or self.book_file_source_id(book) != str(source_id):
             return None
         return book
+
+    def find_audiobook_by_source_id(self, source_id, allow_refresh=True):
+        """Resolve an exact qualified audiobook identity without filename matching."""
+        book = self.find_book_file_by_source_id(source_id, allow_refresh=allow_refresh)
+        if not book or (book.get("bookType") or "").upper() not in GRIMMORY_AUDIO_BOOK_TYPES:
+            return None
+        return book
+
+    def get_book_file_progress(self, source_id):
+        book = self.find_book_file_by_source_id(source_id)
+        return self.extract_progress(book) if book else (None, None)
 
     def get_audiobook_progress(self, source_id):
         book = self.find_audiobook_by_source_id(source_id)
@@ -725,6 +760,9 @@ class GrimmoryClient:
         headers = {"Authorization": f"Bearer {token}"}
         if file_id is not None:
             selected = self._book_file_cache.get((str(book_id), str(file_id)))
+            if not selected:
+                self._refresh_book_cache()
+                selected = self._book_file_cache.get((str(book_id), str(file_id)))
             if not selected or str(selected.get("id")) != str(book_id) or str(selected.get("bookFileId")) != str(file_id):
                 logger.warning("Grimmory: Refusing download for stale book/file identity %s/%s", book_id, file_id)
                 return None
@@ -1005,6 +1043,20 @@ class GrimmoryClientGroup:
             if book:
                 return {**book, "_instance_id": client.instance_id}
         return None
+
+    def find_book_file_by_source_id(self, source_id, allow_refresh=True):
+        for client in self._active:
+            book = client.find_book_file_by_source_id(source_id, allow_refresh=allow_refresh)
+            if book:
+                return {**book, "_instance_id": client.instance_id}
+        return None
+
+    def get_book_file_progress(self, source_id):
+        for client in self._active:
+            pct, locator = client.get_book_file_progress(source_id)
+            if pct is not None:
+                return pct, locator
+        return None, None
 
     def get_audiobook_progress(self, source_id):
         for client in self._active:

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -15,6 +15,8 @@ from src.utils.logging_utils import sanitize_log_data
 
 logger = logging.getLogger(__name__)
 
+GRIMMORY_AUDIO_BOOK_TYPES = {"M4B", "M4A", "MP3", "OPUS"}
+
 
 class GrimmoryClient:
     def __init__(self, database_service=None, env_prefix="GRIMMORY", instance_id="default"):
@@ -472,6 +474,7 @@ class GrimmoryClient:
             "pdfProgress": detail.get("pdfProgress"),
             "cbxProgress": detail.get("cbxProgress"),
             "koreaderProgress": detail.get("koreaderProgress"),
+            "audiobookProgress": detail.get("audiobookProgress"),
         }
 
         self._cache_book_info(filename, book_info)
@@ -495,7 +498,7 @@ class GrimmoryClient:
         if not cached:
             return
         primary_file = detail.get("primaryFile", {})
-        for key in ("epubProgress", "pdfProgress", "cbxProgress", "koreaderProgress"):
+        for key in ("epubProgress", "pdfProgress", "cbxProgress", "koreaderProgress", "audiobookProgress"):
             val = detail.get(key)
             if val is not None:
                 cached[key] = val
@@ -506,12 +509,45 @@ class GrimmoryClient:
 
     def extract_progress(self, book_info: dict) -> tuple[float | None, str | None]:
         """Extract (percentage_as_fraction, cfi) from any book type's progress."""
+        if (book_info.get("bookType") or "").upper() in GRIMMORY_AUDIO_BOOK_TYPES:
+            progress = book_info.get("audiobookProgress")
+            if progress is not None and progress.get("percentage") is not None:
+                return progress["percentage"] / 100.0, None
         for key in ("epubProgress", "pdfProgress", "cbxProgress"):
             progress = book_info.get(key)
             if progress is not None and progress.get("percentage") is not None:
                 pct = progress["percentage"]
                 return (pct / 100.0, progress.get("cfi"))
         return None, None
+
+    def audio_source_id(self, book_info: dict) -> str | None:
+        """Return the exact instance/book/file identity for a Grimmory audiobook."""
+        if (book_info.get("bookType") or "").upper() not in GRIMMORY_AUDIO_BOOK_TYPES:
+            return None
+        book_id = book_info.get("id")
+        file_id = book_info.get("bookFileId")
+        if book_id is None or file_id is None:
+            return None
+        return f"{getattr(self, 'instance_id', 'default')}:{book_id}:{file_id}"
+
+    def find_audiobook_by_source_id(self, source_id, allow_refresh=True):
+        """Resolve an exact qualified audiobook identity without filename matching."""
+        try:
+            instance_id, book_id, file_id = str(source_id).split(":", 2)
+        except ValueError:
+            return None
+        if instance_id != str(getattr(self, "instance_id", "default")):
+            return None
+
+        self._ensure_fresh_cache(allow_refresh)
+        book = next((value for key, value in self._book_id_cache.items() if str(key) == book_id), None)
+        if not book or str(book.get("bookFileId")) != file_id or self.audio_source_id(book) != str(source_id):
+            return None
+        return book
+
+    def get_audiobook_progress(self, source_id):
+        book = self.find_audiobook_by_source_id(source_id)
+        return self.extract_progress(book) if book else (None, None)
 
     def _normalize_string(self, s):
         """Remove non-alphanumeric characters and lowercase."""
@@ -658,6 +694,16 @@ class GrimmoryClient:
             logger.debug(f"Grimmory: Book not found: {ebook_filename}")
             return False
 
+        return self._update_book_progress(book, ebook_filename, percentage, rich_locator)
+
+    def update_audiobook_progress(self, source_id, percentage):
+        book = self.find_audiobook_by_source_id(source_id)
+        if not book:
+            logger.debug("Grimmory: Audiobook identity no longer matches: %s", sanitize_log_data(source_id))
+            return False
+        return self._update_book_progress(book, source_id, percentage)
+
+    def _update_book_progress(self, book, display_name, percentage, rich_locator: LocatorResult | None = None):
         book_id = book["id"]
         book_type = (book.get("bookType") or "").upper()
         book_file_id = book.get("bookFileId")
@@ -683,16 +729,21 @@ class GrimmoryClient:
             progress_key = f"{book_type.lower()}Progress"
             payload = {"bookId": book_id, progress_key: {"percentage": pct_display}}
         else:
-            logger.warning(f"Grimmory: Unknown book type {book_type} for {sanitize_log_data(ebook_filename)}")
+            logger.warning(f"Grimmory: Unknown book type {book_type} for {sanitize_log_data(display_name)}")
             return False
 
         response = self._make_request("POST", "/api/v1/books/progress", payload)
         if response and response.status_code in [200, 201, 204]:
-            logger.info(f"Grimmory: {sanitize_log_data(ebook_filename)} -> {pct_display:.1f}%")
+            logger.info(f"Grimmory: {sanitize_log_data(display_name)} -> {pct_display:.1f}%")
             try:
                 cached = self._book_id_cache.get(book_id)
                 if cached:
-                    progress_keys = {"EPUB": "epubProgress", "PDF": "pdfProgress", "CBX": "cbxProgress"}
+                    progress_keys = {
+                        "EPUB": "epubProgress",
+                        "PDF": "pdfProgress",
+                        "CBX": "cbxProgress",
+                        **{kind: "audiobookProgress" for kind in GRIMMORY_AUDIO_BOOK_TYPES},
+                    }
                     cached_type = (cached.get("bookType") or "").upper()
                     pk = progress_keys.get(cached_type)
                     if pk:
@@ -877,6 +928,26 @@ class GrimmoryClientGroup:
             for book in c.search_books(search_term):
                 results.append({**book, "_instance_id": c.instance_id})
         return results
+
+    def find_audiobook_by_source_id(self, source_id, allow_refresh=True):
+        for client in self._active:
+            book = client.find_audiobook_by_source_id(source_id, allow_refresh=allow_refresh)
+            if book:
+                return {**book, "_instance_id": client.instance_id}
+        return None
+
+    def get_audiobook_progress(self, source_id):
+        for client in self._active:
+            pct, locator = client.get_audiobook_progress(source_id)
+            if pct is not None:
+                return pct, locator
+        return None, None
+
+    def update_audiobook_progress(self, source_id, percentage):
+        for client in self._active:
+            if client.find_audiobook_by_source_id(source_id):
+                return client.update_audiobook_progress(source_id, percentage)
+        return False
 
     def download_book(self, book_id):
         """Download from whichever client owns the book.

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -15,7 +15,7 @@ from src.utils.logging_utils import sanitize_log_data
 
 logger = logging.getLogger(__name__)
 
-GRIMMORY_AUDIO_BOOK_TYPES = {"M4B", "M4A", "MP3", "OPUS"}
+GRIMMORY_AUDIO_BOOK_TYPES = {"AUDIOBOOK"}
 
 
 class GrimmoryClient:
@@ -29,6 +29,7 @@ class GrimmoryClient:
         self._book_case_insensitive_cache = {}
         self._book_case_insensitive_filenames = {}
         self._book_id_cache = {}
+        self._book_file_cache = {}
         self._cache_timestamp = 0
 
         self._token = None
@@ -149,21 +150,41 @@ class GrimmoryClient:
         self._book_case_insensitive_cache = {}
         self._book_case_insensitive_filenames = {}
         self._book_id_cache = {}
+        self._book_file_cache = {}
 
     def _cache_book_info(self, filename, book_info):
         cache_key = str(filename)
+        if cache_key in self._book_cache:
+            self._remove_cached_filename(cache_key)
         self._book_cache[cache_key] = book_info
         lookup_key = cache_key.lower()
         self._book_case_insensitive_filenames.setdefault(lookup_key, set()).add(cache_key)
         self._update_case_insensitive_cache_entry(lookup_key)
 
         bid = book_info.get("id")
-        if bid:
-            self._book_id_cache[bid] = book_info
+        file_id = book_info.get("bookFileId")
+        if bid is not None:
+            if book_info.get("isPrimary") or bid not in self._book_id_cache:
+                self._book_id_cache[bid] = book_info
+            if file_id is not None:
+                self._book_file_cache[(str(bid), str(file_id))] = book_info
 
     def _remove_cached_filename(self, filename):
         cache_key = str(filename)
-        self._book_cache.pop(cache_key, None)
+        removed = self._book_cache.pop(cache_key, None)
+        if removed:
+            bid = removed.get("id")
+            file_id = removed.get("bookFileId")
+            if bid is not None and file_id is not None:
+                key = (str(bid), str(file_id))
+                if self._book_file_cache.get(key) is removed:
+                    self._book_file_cache.pop(key, None)
+            if bid is not None and self._book_id_cache.get(bid) is removed:
+                replacement = next((book for book in self._book_cache.values() if book.get("id") == bid), None)
+                if replacement:
+                    self._book_id_cache[bid] = replacement
+                else:
+                    self._book_id_cache.pop(bid, None)
         lookup_key = cache_key.lower()
         filenames = self._book_case_insensitive_filenames.get(lookup_key)
         if filenames is not None:
@@ -380,70 +401,80 @@ class GrimmoryClient:
 
         logger.info(f"Grimmory: Scan complete. Found {len(all_books_list)} total books.")
 
-        # Prune stale data
-        if self.db and all_books_list:
-            live_map = {str(b["id"]): b for b in all_books_list if b.get("id")}
+        live_files = {
+            (str(book.get("id")), str(book_file.get("id"))): str(book_file.get("fileName", "")).strip()
+            for book in all_books_list
+            for book_file, _is_primary in self._iter_book_files(book)
+            if book.get("id") is not None and book_file.get("id") is not None
+        }
+        live_legacy_files = {
+            (str(book.get("id")), str(book_file.get("fileName", "")).strip())
+            for book in all_books_list
+            for book_file, _is_primary in self._iter_book_files(book)
+            if book.get("id") is not None and book_file.get("fileName")
+        }
 
-            cached_filenames = list(self._book_cache.keys())
-            stale_count = 0
+        stale_count = 0
+        for filename, book_info in list(self._book_cache.items()):
+            book_id = book_info.get("id")
+            file_id = book_info.get("bookFileId")
+            cached_filename = str(book_info.get("fileName", filename)).strip()
+            if file_id is not None:
+                live_filename = live_files.get((str(book_id), str(file_id)))
+                is_stale = live_filename is None or live_filename != cached_filename
+            else:
+                is_stale = (str(book_id), cached_filename) not in live_legacy_files
 
-            for fname in cached_filenames:
-                book_info = self._book_cache[fname]
-                bid = book_info.get("id")
+            if not is_stale:
+                continue
+            stale_count += 1
+            self._remove_cached_filename(filename)
+            if self.db:
+                try:
+                    self.db.delete_grimmory_book(filename, server_id=self.instance_id)
+                except Exception as e:
+                    logger.error(f"Failed to prune stale book {filename}: {e}")
 
-                is_stale = False
-
-                if not bid or str(bid) not in live_map:
-                    is_stale = True
-                    logger.debug(f"   Pruning {fname}: ID {bid} not in live map")
-                else:
-                    live_book = live_map[str(bid)]
-                    raw_live_filename = live_book.get("primaryFile", {}).get("fileName", live_book.get("fileName", ""))
-                    live_filename = str(raw_live_filename).strip() if raw_live_filename else ""
-                    cached_real_filename = book_info.get("fileName", fname)
-
-                    if live_filename and live_filename != str(cached_real_filename).strip():
-                        is_stale = True
-                        logger.debug(
-                            f"   Pruning {fname}: Filename mismatch. Live: {repr(raw_live_filename)} vs Cache: {repr(cached_real_filename)}"
-                        )
-
-                if is_stale:
-                    stale_count += 1
-                    self._remove_cached_filename(fname)
-                    if bid:
-                        self._book_id_cache.pop(bid, None)
-
-                    try:
-                        self.db.delete_grimmory_book(fname, server_id=self.instance_id)
-                    except Exception as e:
-                        logger.error(f"Failed to prune stale book {fname}: {e}")
-
-            if stale_count > 0:
-                logger.info(f"Grimmory: Pruned {stale_count} stale books from database.")
+        if stale_count:
+            logger.info(f"Grimmory: Pruned {stale_count} stale books from database.")
 
         for book in all_books_list:
-            if book["id"] not in self._book_id_cache:
-                self._process_book_detail(book)
-            else:
-                self._update_cached_progress(book)
+            self._process_book_detail(book)
 
         self._cache_timestamp = time.time()
         return True
 
+    @staticmethod
+    def _iter_book_files(detail):
+        """Yield the primary and alternative BookFile DTOs once each."""
+        candidates = []
+        primary = detail.get("primaryFile")
+        if isinstance(primary, dict):
+            candidates.append((primary, True))
+        alternatives = detail.get("alternativeFormats") or []
+        if isinstance(alternatives, dict):
+            alternatives = list(alternatives.values())
+        candidates.extend((book_file, False) for book_file in alternatives if isinstance(book_file, dict))
+        if not candidates and detail.get("fileName"):
+            candidates.append((detail, True))
+
+        seen = set()
+        for book_file, is_primary in candidates:
+            filename = book_file.get("fileName")
+            if not filename:
+                continue
+            identity = (book_file.get("id"), filename)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            yield book_file, is_primary
+
     def _process_book_detail(self, detail):
-        """Process a book detail response and add to cache."""
+        """Cache every actual file attached to one Grimmory Book DTO."""
         if self.target_library_id:
             lid = detail.get("libraryId")
             if lid is not None and str(lid) != str(self.target_library_id):
                 return
-
-        primary_file = detail.get("primaryFile", {})
-        filename = primary_file.get("fileName", detail.get("fileName", ""))
-        filepath = primary_file.get("filePath", detail.get("filePath", ""))
-        book_type = primary_file.get("bookType", detail.get("bookType", ""))
-        if not filename:
-            return
 
         metadata = detail.get("metadata") or {}
         authors = metadata.get("authors") or []
@@ -458,54 +489,41 @@ class GrimmoryClient:
 
         author_str = ", ".join(author_list)
         subtitle = metadata.get("subtitle") or ""
-        title = metadata.get("title") or detail.get("title") or filename
+        for book_file, is_primary in self._iter_book_files(detail):
+            filename = book_file["fileName"]
+            title = metadata.get("title") or detail.get("title") or filename
+            book_info = {
+                "id": detail.get("id"),
+                "fileName": filename,
+                "filePath": book_file.get("filePath", ""),
+                "title": title,
+                "subtitle": subtitle,
+                "authors": author_str,
+                "bookType": book_file.get("bookType", ""),
+                "bookFileId": book_file.get("id"),
+                "isPrimary": is_primary,
+                "lastReadTime": detail.get("lastReadTime"),
+                "epubProgress": detail.get("epubProgress"),
+                "pdfProgress": detail.get("pdfProgress"),
+                "cbxProgress": detail.get("cbxProgress"),
+                "koreaderProgress": detail.get("koreaderProgress"),
+                "audiobookProgress": detail.get("audiobookProgress"),
+            }
 
-        book_info = {
-            "id": detail.get("id"),
-            "fileName": filename,
-            "filePath": filepath,
-            "title": title,
-            "subtitle": subtitle,
-            "authors": author_str,
-            "bookType": book_type,
-            "bookFileId": primary_file.get("id"),
-            "lastReadTime": detail.get("lastReadTime"),
-            "epubProgress": detail.get("epubProgress"),
-            "pdfProgress": detail.get("pdfProgress"),
-            "cbxProgress": detail.get("cbxProgress"),
-            "koreaderProgress": detail.get("koreaderProgress"),
-            "audiobookProgress": detail.get("audiobookProgress"),
-        }
-
-        self._cache_book_info(filename, book_info)
-
-        if self.db:
-            try:
-                b_model = GrimmoryBook(
-                    filename=filename,
-                    title=title,
-                    authors=author_str,
-                    raw_metadata=json.dumps(book_info),
-                    server_id=self.instance_id,
-                )
-                self.db.save_grimmory_book(b_model)
-            except Exception as e:
-                logger.error(f"Failed to persist book {filename} to DB: {e}")
-
-    def _update_cached_progress(self, detail):
-        """Update progress fields on an already-cached book in-place."""
-        cached = self._book_id_cache.get(detail.get("id"))
-        if not cached:
-            return
-        primary_file = detail.get("primaryFile", {})
-        for key in ("epubProgress", "pdfProgress", "cbxProgress", "koreaderProgress", "audiobookProgress"):
-            val = detail.get(key)
-            if val is not None:
-                cached[key] = val
-        if primary_file.get("id"):
-            cached["bookFileId"] = primary_file["id"]
-        if detail.get("lastReadTime"):
-            cached["lastReadTime"] = detail["lastReadTime"]
+            self._cache_book_info(filename, book_info)
+            if self.db:
+                try:
+                    self.db.save_grimmory_book(
+                        GrimmoryBook(
+                            filename=filename,
+                            title=title,
+                            authors=author_str,
+                            raw_metadata=json.dumps(book_info),
+                            server_id=self.instance_id,
+                        )
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to persist book {filename} to DB: {e}")
 
     def extract_progress(self, book_info: dict) -> tuple[float | None, str | None]:
         """Extract (percentage_as_fraction, cfi) from any book type's progress."""
@@ -540,8 +558,8 @@ class GrimmoryClient:
             return None
 
         self._ensure_fresh_cache(allow_refresh)
-        book = next((value for key, value in self._book_id_cache.items() if str(key) == book_id), None)
-        if not book or str(book.get("bookFileId")) != file_id or self.audio_source_id(book) != str(source_id):
+        book = self._book_file_cache.get((book_id, file_id))
+        if not book or self.audio_source_id(book) != str(source_id):
             return None
         return book
 
@@ -736,7 +754,7 @@ class GrimmoryClient:
         if response and response.status_code in [200, 201, 204]:
             logger.info(f"Grimmory: {sanitize_log_data(display_name)} -> {pct_display:.1f}%")
             try:
-                cached = self._book_id_cache.get(book_id)
+                cached = book
                 if cached:
                     progress_keys = {
                         "EPUB": "epubProgress",

--- a/src/api/grimmory_client.py
+++ b/src/api/grimmory_client.py
@@ -716,20 +716,27 @@ class GrimmoryClient:
 
         return results
 
-    def download_book(self, book_id):
-        """Download book content by ID. Returns bytes or None."""
+    def download_book(self, book_id, file_id=None):
+        """Download a primary book file or an exact selected alternative."""
         token = self._get_fresh_token()
         if not token:
             return None
 
         headers = {"Authorization": f"Bearer {token}"}
-        url = f"{self.base_url}/api/v1/books/{book_id}/download"
+        if file_id is not None:
+            selected = self._book_file_cache.get((str(book_id), str(file_id)))
+            if not selected or str(selected.get("id")) != str(book_id) or str(selected.get("bookFileId")) != str(file_id):
+                logger.warning("Grimmory: Refusing download for stale book/file identity %s/%s", book_id, file_id)
+                return None
+            url = f"{self.base_url}/api/v1/books/{book_id}/files/{file_id}/download"
+        else:
+            url = f"{self.base_url}/api/v1/books/{book_id}/download"
         logger.debug(f"Downloading book from {url}")
 
         try:
             response = self.session.get(url, headers=headers, timeout=60)
 
-            if response.status_code == 404:
+            if file_id is None and response.status_code == 404:
                 file_url = f"{self.base_url}/api/v1/books/{book_id}/file"
                 logger.debug(f"404 on /download, trying fallback: {file_url}")
                 response = self.session.get(file_url, headers=headers, timeout=60)
@@ -1012,7 +1019,7 @@ class GrimmoryClientGroup:
                 return client.update_audiobook_progress(source_id, percentage)
         return False
 
-    def download_book(self, book_id):
+    def download_book(self, book_id, file_id=None):
         """Download from whichever client owns the book.
 
         book_id may be a plain int/str (legacy, tries all clients) or
@@ -1023,11 +1030,11 @@ class GrimmoryClientGroup:
             target_instance, raw_id = bid_str.split(":", 1)
             for c in self._active:
                 if c.instance_id == target_instance:
-                    return c.download_book(raw_id)
+                    return c.download_book(raw_id, file_id=file_id)
             return None
 
         for c in self._active:
-            result = c.download_book(book_id)
+            result = c.download_book(book_id, file_id=file_id)
             if result:
                 return result
         return None

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -477,7 +477,13 @@ def api_grimmory_link(book_ref):
     bl_book, bl_client = find_in_grimmory(filename)
     if bl_book:
         grimmory_id = bl_book.get("id")
-    kosync_doc_id = get_kosync_id_for_ebook(filename, grimmory_id, bl_client=bl_client)
+    grimmory_file_id = bl_book.get("bookFileId") if bl_book and bl_book.get("isPrimary") is False else None
+    kosync_doc_id = get_kosync_id_for_ebook(
+        filename,
+        grimmory_id,
+        bl_client=bl_client,
+        grimmory_file_id=grimmory_file_id,
+    )
     if kosync_doc_id:
         book.kosync_doc_id = kosync_doc_id
     book.original_ebook_filename = book.original_ebook_filename or filename

--- a/src/blueprints/books.py
+++ b/src/blueprints/books.py
@@ -174,9 +174,14 @@ def update_hash(book_ref):
         bl_book, matched_bl_client = find_in_grimmory(target_filename)
         if bl_book:
             grimmory_id = bl_book.get("id")
+        grimmory_file_id = bl_book.get("bookFileId") if bl_book and bl_book.get("isPrimary") is False else None
 
         recalc_hash = get_kosync_id_for_ebook(
-            target_filename, grimmory_id, original_filename=book.ebook_filename, bl_client=matched_bl_client
+            target_filename,
+            grimmory_id,
+            original_filename=book.ebook_filename,
+            bl_client=matched_bl_client,
+            grimmory_file_id=grimmory_file_id,
         )
 
         if recalc_hash:

--- a/src/blueprints/helpers.py
+++ b/src/blueprints/helpers.py
@@ -176,7 +176,13 @@ def find_ebook_file(filename, ebook_dir=None):
     return matches[0] if matches else None
 
 
-def get_kosync_id_for_ebook(ebook_filename, grimmory_id=None, original_filename=None, bl_client=None):
+def get_kosync_id_for_ebook(
+    ebook_filename,
+    grimmory_id=None,
+    original_filename=None,
+    bl_client=None,
+    grimmory_file_id=None,
+):
     """Get KOSync document ID for an ebook.
     Tries Grimmory API first (if configured and grimmory_id provided),
     falls back to filesystem if needed.
@@ -187,7 +193,10 @@ def get_kosync_id_for_ebook(ebook_filename, grimmory_id=None, original_filename=
     # Try Grimmory API first — use the specific client that reported the ID
     if grimmory_id and bl_client and bl_client.is_configured():
         try:
-            content = bl_client.download_book(grimmory_id)
+            if grimmory_file_id is not None:
+                content = bl_client.download_book(grimmory_id, file_id=grimmory_file_id)
+            else:
+                content = bl_client.download_book(grimmory_id)
             if content:
                 kosync_id = container.ebook_parser().get_kosync_id_from_bytes(ebook_filename, content)
                 if kosync_id:

--- a/src/blueprints/helpers.py
+++ b/src/blueprints/helpers.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from flask import abort, current_app
 
+from src.utils.path_utils import is_safe_path_within, sanitize_filename
 from src.utils.service_url_helper import get_hardcover_book_url, get_service_web_url  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -170,10 +171,15 @@ def audiobook_matches_search(ab, search_term):
 
 
 def find_ebook_file(filename, ebook_dir=None):
+    if sanitize_filename(filename) != filename:
+        logger.warning("Rejected unsafe ebook filename")
+        return None
     base = ebook_dir if ebook_dir is not None else get_ebook_dir()
     escaped_filename = glob_module.escape(filename)
-    matches = list(base.rglob(escaped_filename))
-    return matches[0] if matches else None
+    for match in base.rglob(escaped_filename):
+        if match.is_file() and is_safe_path_within(match, base):
+            return match
+    return None
 
 
 def get_kosync_id_for_ebook(
@@ -187,6 +193,12 @@ def get_kosync_id_for_ebook(
     Tries Grimmory API first (if configured and grimmory_id provided),
     falls back to filesystem if needed.
     """
+    if sanitize_filename(ebook_filename) != ebook_filename:
+        logger.warning("Rejected unsafe ebook filename while computing KoSync ID")
+        return None
+    if original_filename and sanitize_filename(original_filename) != original_filename:
+        original_filename = None
+
     container = get_container()
     EBOOK_DIR = get_ebook_dir()
 
@@ -217,7 +229,7 @@ def get_kosync_id_for_ebook(
     # Check Epub Cache explicitly
     epub_cache = container.epub_cache_dir()
     cached_path = epub_cache / ebook_filename
-    if cached_path.exists():
+    if is_safe_path_within(cached_path, epub_cache) and cached_path.is_file():
         return container.ebook_parser().get_kosync_id(cached_path)
 
     # On-Demand Fetching: ABS

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -44,11 +44,12 @@ _BOOK_MERGE_METADATA_ATTRS = (
     "finished_at",
     "rating",
     "read_count",
+    "grimmory_audio_source_id",
 )
 
 # A freshly created target book never carries these alignment/UX hints, so a
 # falsy value must not clobber the canonical book that already holds them.
-_BOOK_MERGE_PRESERVE_IF_EMPTY = {"transcript_file", "activity_flag"}
+_BOOK_MERGE_PRESERVE_IF_EMPTY = {"transcript_file", "activity_flag", "grimmory_audio_source_id"}
 
 
 class BookRepository(BaseRepository):
@@ -137,6 +138,7 @@ class BookRepository(BaseRepository):
             "finished_at",
             "rating",
             "read_count",
+            "grimmory_audio_source_id",
         ]
         if book.id:
             return self._upsert(Book, [Book.id == book.id], book, update_attrs)

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -3,6 +3,7 @@
 import logging
 
 from sqlalchemy import func, or_
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
 from .base_repository import BaseRepository
@@ -23,6 +24,10 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 _UNSET = object()
+
+
+class KoSyncOwnershipConflict(Exception):
+    """A KoSync document is already or ambiguously owned by another Book."""
 
 _BOOK_MERGE_METADATA_ATTRS = (
     "title",
@@ -50,6 +55,7 @@ _BOOK_MERGE_METADATA_ATTRS = (
 # A freshly created target book never carries these alignment/UX hints, so a
 # falsy value must not clobber the canonical book that already holds them.
 _BOOK_MERGE_PRESERVE_IF_EMPTY = {"transcript_file", "activity_flag", "grimmory_audio_source_id"}
+_BOOK_SAVE_ATTRS = list(_BOOK_MERGE_METADATA_ATTRS)
 
 
 class BookRepository(BaseRepository):
@@ -123,34 +129,64 @@ class BookRepository(BaseRepository):
         return self._save_new(book)
 
     def save_book(self, book):
-        update_attrs = [
-            "title",
-            "author",
-            "subtitle",
-            "ebook_filename",
-            "original_ebook_filename",
-            "kosync_doc_id",
-            "transcript_file",
-            "status",
-            "duration",
-            "sync_mode",
-            "storyteller_uuid",
-            "abs_ebook_item_id",
-            "ebook_item_id",
-            "activity_flag",
-            "custom_cover_url",
-            "started_at",
-            "finished_at",
-            "rating",
-            "read_count",
-            "grimmory_audio_source_id",
-        ]
         if book.id:
-            return self._upsert(Book, [Book.id == book.id], book, update_attrs)
+            return self._upsert(Book, [Book.id == book.id], book, _BOOK_SAVE_ATTRS)
         elif book.abs_id:
-            return self._upsert(Book, [Book.abs_id == book.abs_id], book, update_attrs)
+            return self._upsert(Book, [Book.abs_id == book.abs_id], book, _BOOK_SAVE_ATTRS)
         else:
             return self._save_new(book)
+
+    def save_book_with_kosync_ownership(self, book):
+        """Atomically persist a Book and claim its KoSync document.
+
+        The no-op insert is deliberately the transaction's first statement: on
+        SQLite it obtains the database write reservation, serializing competing
+        claims for the same primary-keyed KoSync document before either can
+        create a Book row.
+        """
+        if not book.kosync_doc_id:
+            raise ValueError("KoSync ownership requires a document hash")
+
+        with self.get_session() as session:
+            session.execute(
+                sqlite_insert(KosyncDocument)
+                .values(document_hash=book.kosync_doc_id)
+                .on_conflict_do_nothing(index_elements=[KosyncDocument.document_hash])
+            )
+            document = session.query(KosyncDocument).filter(KosyncDocument.document_hash == book.kosync_doc_id).one()
+            matching_books = session.query(Book).filter(Book.kosync_doc_id == book.kosync_doc_id).limit(2).all()
+            if len(matching_books) > 1:
+                raise KoSyncOwnershipConflict("Multiple existing Books already use this KoSync document")
+
+            existing = matching_books[0] if matching_books else None
+            if existing and book.id is None:
+                raise KoSyncOwnershipConflict("KoSync document is already used by another Book")
+            if document.linked_book_id and (not existing or document.linked_book_id != existing.id):
+                raise KoSyncOwnershipConflict("KoSync document is already owned by another Book")
+            if existing and book.id not in (None, existing.id):
+                raise KoSyncOwnershipConflict("KoSync document is already used by another Book")
+            if document.linked_book_id and book.id not in (None, document.linked_book_id):
+                raise KoSyncOwnershipConflict("KoSync document is already owned by another Book")
+
+            target = existing
+            if target is None and book.id:
+                target = session.query(Book).filter(Book.id == book.id).one_or_none()
+            if target is None:
+                target = book
+                session.add(target)
+            else:
+                for attr in _BOOK_SAVE_ATTRS:
+                    setattr(target, attr, getattr(book, attr))
+
+            session.flush()
+            document.linked_book_id = target.id
+            document.linked_abs_id = target.abs_id
+            if not document.filename:
+                document.filename = target.ebook_filename
+            session.flush()
+            session.refresh(target)
+            session.expunge(target)
+            return target
 
     def _mutate_first_and_detach(self, query_factory, mutate):
         """Load the first row from ``query_factory``, mutate it, and return it detached.

--- a/src/db/book_repository.py
+++ b/src/db/book_repository.py
@@ -94,6 +94,11 @@ class BookRepository(BaseRepository):
     def get_book_by_storyteller_uuid(self, uuid):
         return self._get_one(Book, Book.storyteller_uuid == uuid)
 
+    def get_book_by_grimmory_audio_source_id(self, source_id):
+        if not source_id:
+            return None
+        return self._get_one(Book, Book.grimmory_audio_source_id == source_id)
+
     def get_all_books(self):
         return self._get_all(Book)
 

--- a/src/db/detected_repository.py
+++ b/src/db/detected_repository.py
@@ -55,6 +55,7 @@ class DetectedRepository(BaseRepository):
         "processing_started_at",
         "last_seen_at",
         "first_detected_at",
+        "media_format",
     )
 
     def save_detected_book(self, detected_book):
@@ -93,7 +94,7 @@ class DetectedRepository(BaseRepository):
         if existing.status in {"dismissed", "resolved"} and detected_book.status == "detected":
             detected_book.status = existing.status
 
-        for attr in ("title", "author", "cover_url", "device", "ebook_filename"):
+        for attr in ("title", "author", "cover_url", "device", "ebook_filename", "media_format"):
             if not getattr(detected_book, attr):
                 setattr(detected_book, attr, getattr(existing, attr))
 

--- a/src/db/grimmory_repository.py
+++ b/src/db/grimmory_repository.py
@@ -100,9 +100,10 @@ class GrimmoryRepository(BaseRepository):
             for row in legacy_rows:
                 try:
                     metadata = json.loads(row.raw_metadata or "{}")
-                except (TypeError, json.JSONDecodeError):
+                    legacy_key = (str(metadata.get("id")), row.filename)
+                except (AttributeError, TypeError, json.JSONDecodeError):
+                    session.delete(row)
                     continue
-                legacy_key = (str(metadata.get("id")), row.filename)
                 if legacy_filename_counts[row.filename] == 1 and legacy_key not in live_legacy_keys:
                     session.delete(row)
 

--- a/src/db/grimmory_repository.py
+++ b/src/db/grimmory_repository.py
@@ -1,5 +1,6 @@
 """Repository for Grimmory integration: book metadata cache."""
 
+import json
 import logging
 
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -61,6 +62,51 @@ class GrimmoryRepository(BaseRepository):
             session.refresh(target)
             session.expunge(target)
             return target
+
+    def reconcile_grimmory_books(self, server_id, incoming_books):
+        """Upsert a complete remote snapshot and prune stale rows in one transaction."""
+        with self.get_session() as session:
+            existing = session.query(GrimmoryBook).filter(GrimmoryBook.server_id == server_id).all()
+            exact_existing = {
+                (row.remote_book_id, row.remote_file_id): row
+                for row in existing
+                if row.remote_book_id is not None and row.remote_file_id is not None
+            }
+            desired = {
+                (str(book.remote_book_id), str(book.remote_file_id)): book
+                for book in incoming_books
+                if book.remote_book_id is not None and book.remote_file_id is not None
+            }
+
+            for identity, incoming in desired.items():
+                target = exact_existing.get(identity)
+                if target is None:
+                    target = incoming
+                    session.add(target)
+                for attr in ("filename", "title", "authors", "raw_metadata", "remote_book_id", "remote_file_id"):
+                    setattr(target, attr, getattr(incoming, attr))
+
+            for identity, row in exact_existing.items():
+                if identity not in desired:
+                    session.delete(row)
+
+            live_legacy_keys = {(book.remote_book_id, book.filename) for book in incoming_books}
+            legacy_rows = [
+                row for row in existing if row.remote_book_id is None or row.remote_file_id is None
+            ]
+            legacy_filename_counts = {}
+            for row in legacy_rows:
+                legacy_filename_counts[row.filename] = legacy_filename_counts.get(row.filename, 0) + 1
+            for row in legacy_rows:
+                try:
+                    metadata = json.loads(row.raw_metadata or "{}")
+                except (TypeError, json.JSONDecodeError):
+                    continue
+                legacy_key = (str(metadata.get("id")), row.filename)
+                if legacy_filename_counts[row.filename] == 1 and legacy_key not in live_legacy_keys:
+                    session.delete(row)
+
+            session.flush()
 
     def replace_grimmory_book_filename(self, old_filename, grimmory_book):
         """Atomically upsert *grimmory_book* and remove the old filename row.

--- a/src/db/grimmory_repository.py
+++ b/src/db/grimmory_repository.py
@@ -12,10 +12,24 @@ logger = logging.getLogger(__name__)
 
 class GrimmoryRepository(BaseRepository):
     def get_grimmory_book(self, filename, server_id="default"):
+        with self.get_session() as session:
+            rows = (
+                session.query(GrimmoryBook)
+                .filter(GrimmoryBook.filename == filename, GrimmoryBook.server_id == server_id)
+                .limit(2)
+                .all()
+            )
+            if len(rows) != 1:
+                return None
+            session.expunge(rows[0])
+            return rows[0]
+
+    def get_grimmory_book_by_remote_id(self, book_id, file_id, server_id="default"):
         return self._get_one(
             GrimmoryBook,
-            GrimmoryBook.filename == filename,
             GrimmoryBook.server_id == server_id,
+            GrimmoryBook.remote_book_id == str(book_id),
+            GrimmoryBook.remote_file_id == str(file_id),
         )
 
     def get_all_grimmory_books(self, server_id=None):
@@ -24,15 +38,29 @@ class GrimmoryRepository(BaseRepository):
         return self._get_all(GrimmoryBook, GrimmoryBook.server_id == server_id)
 
     def save_grimmory_book(self, grimmory_book):
-        return self._upsert(
-            GrimmoryBook,
-            [
-                GrimmoryBook.server_id == grimmory_book.server_id,
-                GrimmoryBook.filename == grimmory_book.filename,
-            ],
-            grimmory_book,
-            ["title", "authors", "raw_metadata"],
-        )
+        exact_identity = grimmory_book.remote_book_id is not None and grimmory_book.remote_file_id is not None
+        with self.get_session() as session:
+            query = session.query(GrimmoryBook).filter(GrimmoryBook.server_id == grimmory_book.server_id)
+            if exact_identity:
+                query = query.filter(
+                    GrimmoryBook.remote_book_id == str(grimmory_book.remote_book_id),
+                    GrimmoryBook.remote_file_id == str(grimmory_book.remote_file_id),
+                )
+            else:
+                query = query.filter(GrimmoryBook.filename == grimmory_book.filename)
+
+            matches = query.limit(2).all()
+            if len(matches) > 1:
+                raise ValueError("Ambiguous legacy Grimmory filename cannot be updated without remote IDs")
+            target = matches[0] if matches else grimmory_book
+            if not matches:
+                session.add(target)
+            for attr in ("filename", "title", "authors", "raw_metadata", "remote_book_id", "remote_file_id"):
+                setattr(target, attr, getattr(grimmory_book, attr))
+            session.flush()
+            session.refresh(target)
+            session.expunge(target)
+            return target
 
     def replace_grimmory_book_filename(self, old_filename, grimmory_book):
         """Atomically upsert *grimmory_book* and remove the old filename row.
@@ -110,17 +138,20 @@ class GrimmoryRepository(BaseRepository):
             session.expunge(target)
             return target
 
-    def delete_grimmory_book(self, filename, server_id="default"):
+    def delete_grimmory_book(self, filename, server_id="default", book_id=None, file_id=None):
         try:
             with self.get_session() as session:
-                deleted = (
-                    session.query(GrimmoryBook)
-                    .filter(
-                        GrimmoryBook.server_id == server_id,
-                        GrimmoryBook.filename == filename,
+                query = session.query(GrimmoryBook).filter(GrimmoryBook.server_id == server_id)
+                if book_id is not None and file_id is not None:
+                    query = query.filter(
+                        GrimmoryBook.remote_book_id == str(book_id),
+                        GrimmoryBook.remote_file_id == str(file_id),
                     )
-                    .delete(synchronize_session=False)
-                )
+                else:
+                    query = query.filter(GrimmoryBook.filename == filename)
+                    if query.limit(2).count() != 1:
+                        return False
+                deleted = query.delete(synchronize_session=False)
                 return deleted > 0
         except SQLAlchemyError as e:
             logger.error(f"Failed to delete Grimmory book '{filename}': {e}")

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -867,13 +867,24 @@ class GrimmoryBook(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     server_id = Column(String(50), nullable=False, default="default")
+    remote_book_id = Column(String(255), nullable=True)
+    remote_file_id = Column(String(255), nullable=True)
     filename = Column(String(500), nullable=False)
     title = Column(String(500))
     authors = Column(String(500))
     raw_metadata = Column(Text)
     last_updated = Column(DateTime, default=utc_now, onupdate=utc_now)
 
-    __table_args__ = (UniqueConstraint("server_id", "filename", name="uq_grimmory_server_filename"),)
+    __table_args__ = (
+        sa.Index(
+            "uq_grimmory_remote_file",
+            "server_id",
+            "remote_book_id",
+            "remote_file_id",
+            unique=True,
+            sqlite_where=sa.text("remote_book_id IS NOT NULL AND remote_file_id IS NOT NULL"),
+        ),
+    )
 
     @property
     def raw_metadata_dict(self):
@@ -891,8 +902,12 @@ class GrimmoryBook(Base):
         authors: str | None = None,
         raw_metadata: str | None = None,
         server_id: str = "default",
+        remote_book_id: str | None = None,
+        remote_file_id: str | None = None,
     ):
         self.server_id = server_id
+        self.remote_book_id = str(remote_book_id) if remote_book_id is not None else None
+        self.remote_file_id = str(remote_file_id) if remote_file_id is not None else None
         self.filename = filename
         self.title = title
         self.authors = authors

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -117,6 +117,7 @@ class Book(Base):
     subtitle = Column(String(500), nullable=True)
     title_override = Column(String(500), nullable=True)
     author_override = Column(String(500), nullable=True)
+    grimmory_audio_source_id = Column(String(255), nullable=True, unique=True, index=True)
 
     # Reading tracker fields
     started_at = Column(String(10), nullable=True)  # YYYY-MM-DD
@@ -164,6 +165,7 @@ class Book(Base):
         subtitle: str = None,
         title_override: str = None,
         author_override: str = None,
+        grimmory_audio_source_id: str = None,
         started_at: str = None,
         finished_at: str = None,
         rating: float = None,
@@ -186,6 +188,7 @@ class Book(Base):
         self.subtitle = subtitle
         self.title_override = title_override
         self.author_override = author_override
+        self.grimmory_audio_source_id = grimmory_audio_source_id
         self.started_at = started_at
         self.finished_at = finished_at
         self.rating = rating
@@ -576,6 +579,7 @@ class DetectedBook(Base):
     matches_json = Column(Text, nullable=True)
     device = Column(String(128), nullable=True)
     ebook_filename = Column(String(500), nullable=True)
+    media_format = Column(String(20), default="ebook", nullable=False)
 
     def __init__(
         self,
@@ -590,6 +594,7 @@ class DetectedBook(Base):
         device: str = None,
         ebook_filename: str = None,
         source_updated_at=None,
+        media_format: str = "ebook",
     ):
         self.source = source
         self.source_id = source_id
@@ -602,6 +607,7 @@ class DetectedBook(Base):
         self.device = device
         self.ebook_filename = ebook_filename
         self.source_updated_at = source_updated_at
+        self.media_format = media_format
         self.first_detected_at = utc_now()
         self.last_seen_at = utc_now()
 

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from sqlalchemy.exc import IntegrityError
+
 from src.db.models import Book, StorytellerSubmission
 from src.services.kosync_service import ensure_kosync_document
 from src.utils.logging_utils import sanitize_log_data
@@ -312,6 +314,136 @@ class BookIntakeService:
                     detected_source_id, processing_token, source=detected_source
                 )
             raise
+
+    def link_grimmory_audiobook_ebook(
+        self,
+        *,
+        audio_source_id,
+        ebook_filename,
+        ebook_source_id=None,
+        expected_ebook_kosync_id=None,
+        detected_source,
+        detected_source_id,
+    ) -> IntakeResult:
+        """Link an exact Grimmory audiobook to an ebook without ABS side effects."""
+        if not audio_source_id or not ebook_filename or not detected_source or not detected_source_id:
+            return IntakeResult(error="An audiobook, ebook, and detected source are required", status_code=400)
+
+        audio_group = self.container.grimmory_client_group()
+        audio_info = audio_group.find_audiobook_by_source_id(audio_source_id)
+        if not audio_info:
+            return IntakeResult(error="The selected Grimmory audiobook is no longer available", status_code=409)
+
+        prepared = self._prepare_mapping(None, ebook_filename, ebook_source_id, expected_ebook_kosync_id)
+        if isinstance(prepared, IntakeResult):
+            return prepared
+        initial_kosync_id = prepared.kosync_doc_id
+        target, conflict = self._grimmory_audio_target(audio_source_id, prepared.merge_book, prepared.kosync_doc_id)
+        if conflict:
+            return conflict
+
+        processing_token = self.database_service.claim_detected_book(detected_source_id, source=detected_source)
+        if not processing_token:
+            detected = self.database_service.get_detected_book(detected_source_id, source=detected_source)
+            if getattr(detected, "status", None) == "resolved" and target:
+                return IntakeResult(book=target)
+            return IntakeResult(error="This match is already being processed or is no longer active", status_code=409)
+
+        def restore_claim():
+            self.database_service.restore_detected_book(
+                detected_source_id,
+                processing_token,
+                source=detected_source,
+            )
+
+        try:
+            audio_info = audio_group.find_audiobook_by_source_id(audio_source_id)
+            if not audio_info:
+                restore_claim()
+                return IntakeResult(error="The selected Grimmory audiobook changed. Review the match again.", status_code=409)
+
+            prepared = self._prepare_mapping(
+                None,
+                ebook_filename,
+                ebook_source_id,
+                expected_ebook_kosync_id or initial_kosync_id,
+            )
+            if isinstance(prepared, IntakeResult):
+                restore_claim()
+                return prepared
+            target, conflict = self._grimmory_audio_target(
+                audio_source_id,
+                prepared.merge_book,
+                prepared.kosync_doc_id,
+            )
+            if conflict:
+                restore_claim()
+                return conflict
+            if not self.database_service.renew_detected_book_claim(
+                detected_source_id,
+                processing_token,
+                source=detected_source,
+            ):
+                return IntakeResult(error="This match lost its processing lease. Try again.", status_code=409)
+
+            if target:
+                target.ebook_filename = prepared.ebook_filename
+                target.kosync_doc_id = prepared.kosync_doc_id
+                target.grimmory_audio_source_id = audio_source_id
+                target.sync_mode = "audiobook"
+                book = self.database_service.save_book(target)
+            else:
+                book = self.database_service.save_book(
+                    Book(
+                        title=audio_info.get("title") or Path(prepared.ebook_filename).stem,
+                        author=audio_info.get("authors") or None,
+                        ebook_filename=prepared.ebook_filename,
+                        kosync_doc_id=prepared.kosync_doc_id,
+                        grimmory_audio_source_id=audio_source_id,
+                        status="pending",
+                        sync_mode="audiobook",
+                    ),
+                    is_new=True,
+                )
+        except IntegrityError:
+            restore_claim()
+            return IntakeResult(error="The audiobook or ebook was linked by another request", status_code=409)
+        except Exception:
+            restore_claim()
+            raise
+
+        try:
+            completed = self.database_service.complete_detected_book(
+                detected_source_id,
+                processing_token,
+                source=detected_source,
+            )
+        except Exception as exc:
+            logger.warning("Grimmory audiobook link committed but its detection could not be completed: %s", exc)
+            completed = False
+        if not completed:
+            return IntakeResult(book=book)
+
+        try:
+            self._record_grimmory_source(prepared.kosync_doc_id, prepared.ebook_source_id)
+            self.database_service.resolve_detected_book(audio_source_id, source="grimmory")
+            self.database_service.resolve_detected_book(prepared.kosync_doc_id, source="kosync")
+            self._resolve_grimmory_detection(prepared.ebook_filename, prepared.ebook_source_id)
+        except Exception as exc:
+            logger.warning("Grimmory audiobook link committed but companion cleanup failed: %s", exc)
+        return IntakeResult(book=book)
+
+    def _grimmory_audio_target(self, audio_source_id, ebook_book, kosync_doc_id):
+        audio_book = self.database_service.get_book_by_grimmory_audio_source_id(audio_source_id)
+        if audio_book and ebook_book and audio_book.id != ebook_book.id:
+            return None, IntakeResult(error="The audiobook and ebook already belong to different books", status_code=409)
+
+        target = audio_book or ebook_book
+        if target and getattr(target, "grimmory_audio_source_id", None) not in (None, audio_source_id):
+            return None, IntakeResult(error="The ebook already belongs to another Grimmory audiobook", status_code=409)
+        if target and getattr(target, "kosync_doc_id", None) not in (None, kosync_doc_id):
+            return None, IntakeResult(error="The audiobook already belongs to another ebook", status_code=409)
+        return target, None
 
     def inspect_audiobook_ebook(
         self,

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from sqlalchemy.exc import IntegrityError
 
+from src.db.book_repository import KoSyncOwnershipConflict
 from src.db.models import Book, StorytellerSubmission
 from src.services.kosync_service import ensure_kosync_document
 from src.utils.logging_utils import sanitize_log_data
@@ -391,9 +392,9 @@ class BookIntakeService:
                 target.kosync_doc_id = prepared.kosync_doc_id
                 target.grimmory_audio_source_id = audio_source_id
                 target.sync_mode = "audiobook"
-                book = self.database_service.save_book(target)
+                book = self.database_service.save_book_with_kosync_ownership(target)
             else:
-                book = self.database_service.save_book(
+                book = self.database_service.save_book_with_kosync_ownership(
                     Book(
                         title=audio_info.get("title") or Path(prepared.ebook_filename).stem,
                         author=audio_info.get("authors") or None,
@@ -402,10 +403,9 @@ class BookIntakeService:
                         grimmory_audio_source_id=audio_source_id,
                         status="pending",
                         sync_mode="audiobook",
-                    ),
-                    is_new=True,
+                    )
                 )
-        except IntegrityError:
+        except (IntegrityError, KoSyncOwnershipConflict):
             restore_claim()
             return IntakeResult(error="The audiobook or ebook was linked by another request", status_code=409)
         except Exception:

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -655,6 +655,7 @@ class BookIntakeService:
             "finished_at": existing_book.finished_at,
             "rating": existing_book.rating,
             "read_count": existing_book.read_count or 1,
+            "grimmory_audio_source_id": getattr(existing_book, "grimmory_audio_source_id", None),
         }
         if overrides:
             metadata.update({key: value for key, value in overrides.items() if value is not None})

--- a/src/services/book_intake_service.py
+++ b/src/services/book_intake_service.py
@@ -112,8 +112,7 @@ class BookIntakeService:
             bl_book, bl_client = self._find_grimmory_book(ebook_filename, ebook_source_id)
             if ebook_source_id and not bl_book:
                 return IntakeResult(error="Selected Grimmory book was not found", status_code=404)
-            grimmory_id = bl_book.get("id") if bl_book else None
-            kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
+            kosync_doc_id = self._get_kosync_id_for_mapping(ebook_filename, bl_book, bl_client)
             if not kosync_doc_id:
                 return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
             title = ebook_display_name or (bl_book.get("title") if bl_book else None) or Path(ebook_filename).stem
@@ -154,8 +153,7 @@ class BookIntakeService:
         bl_book, bl_client = self._find_grimmory_book(ebook_filename, ebook_source_id)
         if ebook_source_id and not bl_book:
             return IntakeResult(error="Selected Grimmory book was not found", status_code=404)
-        grimmory_id = bl_book.get("id") if bl_book else None
-        kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_client)
+        kosync_doc_id = self._get_kosync_id_for_mapping(ebook_filename, bl_book, bl_client)
         if not kosync_doc_id:
             return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
 
@@ -464,8 +462,7 @@ class BookIntakeService:
         bl_match, bl_match_client = self._find_grimmory_book(ebook_filename, ebook_source_id)
         if ebook_source_id and not bl_match:
             return IntakeResult(error="Selected Grimmory book was not found", status_code=404)
-        grimmory_id = bl_match.get("id") if bl_match else None
-        kosync_doc_id = self.get_kosync_id_for_ebook(ebook_filename, grimmory_id, bl_client=bl_match_client)
+        kosync_doc_id = self._get_kosync_id_for_mapping(ebook_filename, bl_match, bl_match_client)
         if not kosync_doc_id:
             logger.warning("Cannot compute KOSync ID for '%s'", sanitize_log_data(ebook_filename))
             return IntakeResult(error="Could not compute KOSync ID for ebook", status_code=404)
@@ -754,6 +751,13 @@ class BookIntakeService:
         if ebook_source_id:
             return self.find_in_grimmory(ebook_filename, ebook_source_id)
         return self.find_in_grimmory(ebook_filename)
+
+    def _get_kosync_id_for_mapping(self, ebook_filename, grimmory_book, grimmory_client):
+        book_id = grimmory_book.get("id") if grimmory_book else None
+        kwargs = {"bl_client": grimmory_client}
+        if grimmory_book and grimmory_book.get("isPrimary") is False:
+            kwargs["grimmory_file_id"] = grimmory_book.get("bookFileId")
+        return self.get_kosync_id_for_ebook(ebook_filename, book_id, **kwargs)
 
     def _record_grimmory_source(self, kosync_doc_id, ebook_source_id):
         if not kosync_doc_id or not ebook_source_id:

--- a/src/services/kosync_service.py
+++ b/src/services/kosync_service.py
@@ -4,7 +4,6 @@ Handles EPUB discovery, hash-to-book linking, auto-discovery, and
 document management. Route handlers in kosync_server.py delegate here.
 """
 
-import json
 import logging
 import re
 import threading
@@ -13,7 +12,7 @@ from pathlib import Path
 from src.db.models import Book, KosyncDocument
 from src.services.kosync_progress_service import KosyncProgressService
 from src.utils.logging_utils import sanitize_log_data
-from src.utils.path_utils import is_safe_path_within
+from src.utils.path_utils import is_safe_path_within, sanitize_filename
 
 logger = logging.getLogger(__name__)
 
@@ -257,32 +256,38 @@ class KosyncService:
 
             logger.info(f"Scanning {len(books)} books from Grimmory DB cache...")
 
+            checked_identities = set()
+            checked_count = 0
             for book in books:
-                raw_id = book.raw_metadata_dict.get("id") if getattr(book, "raw_metadata_dict", None) else None
-                book_id = str(raw_id) if raw_id is not None else None
-                if not book_id:
-                    try:
-                        meta = json.loads(book.raw_metadata)
-                        fallback_id = meta.get("id")
-                        book_id = str(fallback_id) if fallback_id is not None else None
-                    except (json.JSONDecodeError, AttributeError, TypeError) as e:
-                        logger.debug(f"Failed to parse raw_metadata JSON: {e}")
-                        continue
-
-                if not book_id:
+                metadata = book.raw_metadata_dict if getattr(book, "raw_metadata_dict", None) else {}
+                if (metadata.get("bookType") or "").upper() != "EPUB":
+                    continue
+                book_id = getattr(book, "remote_book_id", None)
+                file_id = getattr(book, "remote_file_id", None)
+                identity = (str(book.server_id), str(book_id), str(file_id))
+                if book_id is None or file_id is None or identity in checked_identities:
+                    continue
+                checked_identities.add(identity)
+                checked_count += 1
+                if sanitize_filename(book.filename) != book.filename:
+                    logger.warning("Rejected unsafe Grimmory EPUB filename")
                     continue
 
                 qualified_id = f"{book.server_id}:{book_id}"
+                qualified_file_id = f"{qualified_id}:{file_id}"
 
                 # Check if we have a KosyncDocument for this Grimmory ID
-                cached_doc = self._db.get_kosync_doc_by_grimmory_id(qualified_id)
+                cached_doc = self._db.get_kosync_doc_by_grimmory_id(qualified_file_id)
                 if cached_doc:
                     if cached_doc.document_hash == doc_hash:
+                        if sanitize_filename(cached_doc.filename) != cached_doc.filename:
+                            logger.warning("Rejected unsafe cached Grimmory EPUB filename")
+                            continue
                         logger.info(f"Matched EPUB via Grimmory ID in DB: {cached_doc.filename}")
                         return cached_doc.filename
 
                 try:
-                    book_content = bl_group.download_book(qualified_id)
+                    book_content = bl_group.download_book(qualified_id, file_id=file_id)
                     if book_content:
                         computed_hash = self._container.ebook_parser().get_kosync_id_from_bytes(
                             book.filename, book_content
@@ -301,7 +306,7 @@ class KosyncService:
                                 logger.info(f"Persisted Grimmory book to cache: {safe_title}")
 
                             self._upsert_kosync_metadata(
-                                computed_hash, safe_title, "grimmory", grimmory_id=qualified_id
+                                computed_hash, safe_title, "grimmory", grimmory_id=qualified_file_id
                             )
 
                             logger.info(f"Matched EPUB via Grimmory download: {safe_title}")
@@ -309,7 +314,7 @@ class KosyncService:
                 except Exception as e:
                     logger.warning(f"Failed to check Grimmory book '{sanitize_log_data(book.title)}': {e}")
 
-            logger.info(f"Grimmory search finished. Checked {len(books)} books. No match found")
+            logger.info(f"Grimmory search finished. Checked {checked_count} EPUB files. No match found")
 
         except Exception as e:
             logger.debug(f"Error querying Grimmory for EPUB matching: {e}")

--- a/src/sync_clients/grimmory_sync_client.py
+++ b/src/sync_clients/grimmory_sync_client.py
@@ -93,3 +93,62 @@ class GrimmorySyncClient(SyncClient):
                 pass
         updated_state = {"pct": pct}
         return SyncResult(pct, success, updated_state)
+
+
+class GrimmoryAudioSyncClient(GrimmorySyncClient):
+    """Sync one Grimmory instance's audiobook side by exact source identity."""
+
+    def fetch_bulk_state(self) -> dict | None:
+        if not self.is_configured():
+            return None
+        books = self.grimmory_client.get_all_books()
+        states = {
+            source_id: book
+            for book in books or []
+            if (source_id := self.grimmory_client.audio_source_id(book))
+        }
+        return states or None
+
+    def get_supported_sync_types(self) -> set:
+        return {"audiobook"}
+
+    def get_service_state(
+        self, book: Book, prev_state: State | None, title_snip: str = "", bulk_context: dict = None
+    ) -> ServiceState | None:
+        source_id = getattr(book, "grimmory_audio_source_id", None)
+        if not source_id:
+            return None
+
+        if bulk_context is not None:
+            book_info = bulk_context.get(source_id)
+            pct, _ = self.grimmory_client.extract_progress(book_info) if book_info else (None, None)
+        else:
+            pct, _ = self.grimmory_client.get_audiobook_progress(source_id)
+        if pct is None:
+            return None
+
+        # ponytail: Grimmory exposes audio percentage but no transcript timing;
+        # keep percentage sync until a reliable audio-to-text position exists.
+        previous = prev_state.percentage if prev_state and prev_state.percentage is not None else 0
+        return ServiceState(
+            current={"pct": pct},
+            previous_pct=previous,
+            delta=abs(pct - previous),
+            threshold=self.delta_kosync_thresh,
+            is_configured=True,
+            display=(self.client_name, "{prev:.4%} -> {curr:.4%}"),
+            value_formatter=lambda value: f"{value * 100:.4f}%",
+        )
+
+    def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
+        source_id = getattr(book, "grimmory_audio_source_id", None)
+        pct = request.locator_result.percentage
+        success = bool(source_id and self.grimmory_client.update_audiobook_progress(source_id, pct))
+        if success:
+            try:
+                from src.services.write_tracker import record_write
+
+                record_write(self.client_name, book.id)
+            except ImportError:
+                pass
+        return SyncResult(pct, success, {"pct": pct})

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -739,7 +739,7 @@ class SyncManager:
         leader_state_data = leader_state.current
 
         leader_state_model = State(
-            abs_id=book.abs_id,
+            abs_id=abs_id,
             book_id=book.id,
             client_name=leader.lower(),
             last_updated=current_time,
@@ -761,7 +761,7 @@ class SyncManager:
                 except ImportError:
                     pass
                 client_state_model = State(
-                    abs_id=book.abs_id,
+                    abs_id=abs_id,
                     book_id=book.id,
                     client_name=client_name.lower(),
                     last_updated=current_time,

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -525,6 +525,11 @@ class SyncManager:
         }
         if is_audio_only:
             audio_only_clients = {"ABS", "Hardcover"}
+            source_id = getattr(book, "grimmory_audio_source_id", None)
+            source_parts = str(source_id).split(":") if source_id else []
+            if len(source_parts) == 3:
+                instance_id = source_parts[0]
+                audio_only_clients.add("GrimmoryAudio" if instance_id == "default" else f"Grimmory{instance_id}Audio")
             active_clients = {name: client for name, client in active_clients.items() if name in audio_only_clients}
             logger.debug(f"'{abs_id}' '{title_snip}' Audio-only mode - using clients: {list(active_clients.keys())}")
         elif sync_type == "ebook":

--- a/src/utils/di_container.py
+++ b/src/utils/di_container.py
@@ -29,7 +29,7 @@ from src.services.storyteller_submission_service import StorytellerSubmissionSer
 from src.services.suggestion_service import SuggestionService
 from src.sync_clients.abs_ebook_sync_client import ABSEbookSyncClient
 from src.sync_clients.abs_sync_client import ABSSyncClient
-from src.sync_clients.grimmory_sync_client import GrimmorySyncClient
+from src.sync_clients.grimmory_sync_client import GrimmoryAudioSyncClient, GrimmorySyncClient
 from src.sync_clients.hardcover_sync_client import HardcoverSyncClient
 from src.sync_clients.kosync_sync_client import KoSyncSyncClient
 from src.sync_clients.storyteller_sync_client import StorytellerSyncClient
@@ -163,6 +163,14 @@ class Container(containers.DeclarativeContainer):
         GrimmorySyncClient, grimmory_client_2, ebook_parser, client_name="Grimmory2"
     )
 
+    grimmory_audio_sync_client = providers.Singleton(
+        GrimmoryAudioSyncClient, grimmory_client, ebook_parser, client_name="GrimmoryAudio"
+    )
+
+    grimmory_audio_sync_client_2 = providers.Singleton(
+        GrimmoryAudioSyncClient, grimmory_client_2, ebook_parser, client_name="Grimmory2Audio"
+    )
+
     abs_ebook_sync_client = providers.Singleton(ABSEbookSyncClient, abs_client, ebook_parser)
 
     hardcover_service = providers.Singleton(HardcoverService, hardcover_client, database_service, abs_client)
@@ -215,6 +223,8 @@ class Container(containers.DeclarativeContainer):
         Storyteller=storyteller_sync_client,
         Grimmory=grimmory_sync_client,
         Grimmory2=grimmory_sync_client_2,
+        GrimmoryAudio=grimmory_audio_sync_client,
+        Grimmory2Audio=grimmory_audio_sync_client_2,
         Hardcover=hardcover_sync_client,
     )
 

--- a/src/utils/epub_resolver.py
+++ b/src/utils/epub_resolver.py
@@ -62,7 +62,12 @@ def get_local_epub(ebook_filename, books_dir, epub_cache_dir, grimmory_client=No
                 if not book_id:
                     logger.warning("Grimmory returned book without ID")
                 else:
-                    content = grimmory_client.download_book(book_id)
+                    file_id = book.get("bookFileId") if book.get("isPrimary") is False else None
+                    content = (
+                        grimmory_client.download_book(book_id, file_id=file_id)
+                        if file_id is not None
+                        else grimmory_client.download_book(book_id)
+                    )
                     if content:
                         cached_path.parent.mkdir(parents=True, exist_ok=True)
                         tmp_fd, tmp_path = tempfile.mkstemp(dir=cached_path.parent, suffix=".tmp")

--- a/src/utils/epub_resolver.py
+++ b/src/utils/epub_resolver.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 
 from src.utils.logging_utils import sanitize_log_data
+from src.utils.path_utils import is_safe_path_within, sanitize_filename
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def get_local_epub(ebook_filename, books_dir, epub_cache_dir, grimmory_client=No
     epub_cache_dir = Path(epub_cache_dir) if epub_cache_dir else Path("/tmp/epub_cache")
 
     # Reject filenames with path traversal components
-    if os.sep in ebook_filename or "/" in ebook_filename or ".." in ebook_filename:
+    if sanitize_filename(ebook_filename) != ebook_filename:
         logger.error(f"Invalid ebook filename rejected: {sanitize_log_data(ebook_filename)}")
         return None
 
@@ -32,7 +33,7 @@ def get_local_epub(ebook_filename, books_dir, epub_cache_dir, grimmory_client=No
     resolved_search_dir = books_search_dir.resolve()
     filesystem_matches = list(books_search_dir.glob(f"**/{escaped_filename}"))
     for candidate in filesystem_matches:
-        if candidate.resolve().is_relative_to(resolved_search_dir):
+        if candidate.is_file() and is_safe_path_within(candidate, resolved_search_dir):
             logger.info(f"Found EPUB on filesystem: {candidate}")
             return candidate
     if filesystem_matches:
@@ -43,7 +44,7 @@ def get_local_epub(ebook_filename, books_dir, epub_cache_dir, grimmory_client=No
     cache_root = epub_cache_dir.resolve()
     cached_path = epub_cache_dir / ebook_filename
     # Prevent path traversal via untrusted filenames (e.g., ../../etc/passwd)
-    if not cached_path.resolve().is_relative_to(cache_root):
+    if not is_safe_path_within(cached_path, cache_root):
         logger.error(f"Invalid filename detected: {sanitize_log_data(ebook_filename)}")
         return None
     if cached_path.exists():

--- a/tests/test_book_identity_merge.py
+++ b/tests/test_book_identity_merge.py
@@ -118,6 +118,7 @@ class TestBookIdentityMerge(unittest.TestCase):
                 status="active",
                 sync_mode="ebook_only",
                 read_count=2,
+                grimmory_audio_source_id="default:10:42",
             )
         )
         self.db.save_state(
@@ -177,6 +178,9 @@ class TestBookIdentityMerge(unittest.TestCase):
         )
 
         self.db.migrate_book_data(source.abs_id, target.abs_id)
+
+        merged = self.db.get_book_by_abs_id(target.abs_id)
+        self.assertEqual(merged.grimmory_audio_source_id, "default:10:42")
 
         with self.db.get_session() as session:
             books = session.query(Book).all()

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -1,7 +1,7 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -142,6 +142,57 @@ def test_link_grimmory_audiobook_creates_book_without_abs_side_effects():
     db.resolve_detected_book.assert_any_call("ebook-hash", source="kosync")
     method_names = [call[0] for call in db.method_calls]
     assert method_names.index("save_book_with_kosync_ownership") < method_names.index("complete_detected_book")
+
+
+def test_link_grimmory_audiobook_hashes_selected_alternative_epub_file():
+    alternative_epub = {
+        "id": 10,
+        "bookFileId": 42,
+        "fileName": "book.epub",
+        "bookType": "EPUB",
+        "isPrimary": False,
+    }
+    service, db, _abs, bl_client, _hc = _make_service(
+        bl_match=alternative_epub,
+        kosync_id="alternative-hash",
+    )
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.return_value = {
+        "id": 10,
+        "bookFileId": 41,
+        "fileName": "book.m4b",
+        "bookType": "AUDIOBOOK",
+        "isPrimary": True,
+    }
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+    db.renew_detected_book_claim.return_value = True
+    db.complete_detected_book.return_value = True
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:41",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:41",
+    )
+
+    assert result.error is None
+    service.get_kosync_id_for_ebook.assert_has_calls(
+        [
+            call(
+                "book.epub",
+                10,
+                bl_client=bl_client,
+                grimmory_file_id=42,
+            ),
+            call(
+                "book.epub",
+                10,
+                bl_client=bl_client,
+                grimmory_file_id=42,
+            ),
+        ]
+    )
 
 
 def test_link_grimmory_audiobook_updates_ebook_book_and_preserves_abs():

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -1,9 +1,13 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from src.db.book_repository import BookRepository
+from src.db.models import Base, DatabaseManager
 from src.services.book_intake_service import BookIntakeService
 from src.services.storyteller_submission_service import SubmissionResult
 
@@ -52,6 +56,7 @@ def _make_service(*, db=None, abs_service=None, bl_match=None, bl_client=None, k
         return book
 
     db.save_book.side_effect = save_book
+    db.save_book_with_kosync_ownership.side_effect = save_book
 
     abs_service = abs_service or Mock()
     bl_client = bl_client or Mock()
@@ -136,7 +141,7 @@ def test_link_grimmory_audiobook_creates_book_without_abs_side_effects():
     db.resolve_detected_book.assert_any_call("default:10:42", source="grimmory")
     db.resolve_detected_book.assert_any_call("ebook-hash", source="kosync")
     method_names = [call[0] for call in db.method_calls]
-    assert method_names.index("save_book") < method_names.index("complete_detected_book")
+    assert method_names.index("save_book_with_kosync_ownership") < method_names.index("complete_detected_book")
 
 
 def test_link_grimmory_audiobook_updates_ebook_book_and_preserves_abs():
@@ -249,7 +254,7 @@ def test_link_grimmory_audiobook_returns_conflict_on_concurrent_unique_claim():
     db.get_book_by_kosync_id.return_value = None
     db.claim_detected_book.return_value = "owner-token"
     db.renew_detected_book_claim.return_value = True
-    db.save_book.side_effect = IntegrityError("unique", {}, None)
+    db.save_book_with_kosync_ownership.side_effect = IntegrityError("unique", {}, None)
 
     result = service.link_grimmory_audiobook_ebook(
         audio_source_id="default:10:42",
@@ -262,6 +267,52 @@ def test_link_grimmory_audiobook_returns_conflict_on_concurrent_unique_claim():
     db.restore_detected_book.assert_called_once_with(
         "default:10:42", "owner-token", source="grimmory"
     )
+
+
+def test_concurrent_grimmory_links_cannot_create_two_books_for_one_kosync_hash(tmp_path):
+    manager = DatabaseManager(str(tmp_path / "concurrent-intake.db"))
+    Base.metadata.create_all(manager.engine)
+    repository = BookRepository(manager)
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_kosync_doc_by_filename.return_value = None
+    db.get_kosync_document.return_value = None
+    db.claim_detected_book.side_effect = lambda source_id, source: f"claim-{source_id}"
+    db.renew_detected_book_claim.return_value = True
+    db.complete_detected_book.return_value = True
+    prepare_barrier = threading.Barrier(2)
+
+    def lookup_kosync(kosync_id):
+        prepare_barrier.wait(timeout=5)
+        return repository.get_book_by_kosync_id(kosync_id)
+
+    db.get_book_by_kosync_id.side_effect = lookup_kosync
+    service, _, _, _, _ = _make_service(db=db, kosync_id="shared-hash")
+    db.save_book_with_kosync_ownership.side_effect = repository.save_book_with_kosync_ownership
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.side_effect = (
+        lambda source_id: {"id": source_id.split(":")[1], "title": "Book"}
+    )
+
+    def link(audio_source_id):
+        return service.link_grimmory_audiobook_ebook(
+            audio_source_id=audio_source_id,
+            ebook_filename="shared.epub",
+            detected_source="grimmory",
+            detected_source_id=audio_source_id,
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(link, ["default:10:41", "default:20:42"]))
+
+        assert sorted(result.status_code for result in results) == [400, 409]
+        books = repository.get_all_books()
+        assert len(books) == 1
+        assert books[0].kosync_doc_id == "shared-hash"
+        db.restore_detected_book.assert_called_once()
+    finally:
+        manager.close()
 
 
 def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():

--- a/tests/test_book_intake_service.py
+++ b/tests/test_book_intake_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from src.services.book_intake_service import BookIntakeService
 from src.services.storyteller_submission_service import SubmissionResult
@@ -98,6 +99,169 @@ def test_map_audiobook_ebook_uses_selected_edition_hash_over_existing_abs_hash()
     assert result.error is None
     assert result.book.kosync_doc_id == "hash-new"
     db.resolve_suggestion.assert_any_call("hash-new")
+
+
+def test_link_grimmory_audiobook_creates_book_without_abs_side_effects():
+    service, db, abs_service, _bl, hc = _make_service(kosync_id="ebook-hash")
+    audio_group = service.container.grimmory_client_group.return_value
+    audio_group.find_audiobook_by_source_id.return_value = {
+        "id": 10,
+        "bookFileId": 42,
+        "title": "Audio Book",
+        "authors": "Author",
+    }
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+    db.renew_detected_book_claim.return_value = True
+    db.complete_detected_book.return_value = True
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:42",
+    )
+
+    assert result.error is None
+    assert result.book.abs_id is None
+    assert result.book.kosync_doc_id == "ebook-hash"
+    assert result.book.grimmory_audio_source_id == "default:10:42"
+    assert result.book.sync_mode == "audiobook"
+    abs_service.add_to_collection.assert_not_called()
+    hc.assert_not_called()
+    db.complete_detected_book.assert_called_once_with(
+        "default:10:42", "owner-token", source="grimmory"
+    )
+    db.resolve_detected_book.assert_any_call("default:10:42", source="grimmory")
+    db.resolve_detected_book.assert_any_call("ebook-hash", source="kosync")
+    method_names = [call[0] for call in db.method_calls]
+    assert method_names.index("save_book") < method_names.index("complete_detected_book")
+
+
+def test_link_grimmory_audiobook_updates_ebook_book_and_preserves_abs():
+    ebook_book = _book_ref(
+        id=22,
+        abs_id="abs-existing",
+        kosync_doc_id="ebook-hash",
+        grimmory_audio_source_id=None,
+        sync_mode="ebook_only",
+    )
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_kosync_id.return_value = ebook_book
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+    db.renew_detected_book_claim.return_value = True
+    db.complete_detected_book.return_value = True
+    service, db, abs_service, _bl, _hc = _make_service(db=db, kosync_id="ebook-hash")
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.return_value = {
+        "id": 10,
+        "bookFileId": 42,
+    }
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="kosync",
+        detected_source_id="ebook-hash",
+    )
+
+    assert result.book.id == 22
+    assert result.book.abs_id == "abs-existing"
+    assert result.book.grimmory_audio_source_id == "default:10:42"
+    assert result.book.sync_mode == "audiobook"
+    abs_service.add_to_collection.assert_not_called()
+
+
+def test_link_grimmory_audiobook_rejects_books_already_split_across_rows():
+    audio_book = _book_ref(id=11, grimmory_audio_source_id="default:10:42", kosync_doc_id=None)
+    ebook_book = _book_ref(id=22, grimmory_audio_source_id=None, kosync_doc_id="ebook-hash")
+    db = Mock()
+    db.get_book_by_ref.return_value = None
+    db.get_book_by_kosync_id.return_value = ebook_book
+    db.get_book_by_grimmory_audio_source_id.return_value = audio_book
+    service, db, _abs, _bl, _hc = _make_service(db=db, kosync_id="ebook-hash")
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.return_value = {"id": 10}
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:42",
+    )
+
+    assert result.status_code == 409
+    assert "different books" in result.error
+    db.claim_detected_book.assert_not_called()
+    db.save_book.assert_not_called()
+
+
+def test_link_grimmory_audiobook_restores_claim_when_exact_audio_changes():
+    service, db, _abs, _bl, _hc = _make_service(kosync_id="ebook-hash")
+    audio_group = service.container.grimmory_client_group.return_value
+    audio_group.find_audiobook_by_source_id.side_effect = [{"id": 10}, None]
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:42",
+    )
+
+    assert result.status_code == 409
+    db.restore_detected_book.assert_called_once_with(
+        "default:10:42", "owner-token", source="grimmory"
+    )
+    db.save_book.assert_not_called()
+
+
+def test_link_grimmory_audiobook_restores_claim_when_ebook_identity_changes():
+    service, db, _abs, _bl, _hc = _make_service(kosync_id="first-hash")
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.return_value = {"id": 10}
+    service.get_kosync_id_for_ebook.side_effect = ["first-hash", "second-hash"]
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:42",
+    )
+
+    assert result.status_code == 409
+    assert "no longer matches" in result.error
+    db.restore_detected_book.assert_called_once_with(
+        "default:10:42", "owner-token", source="grimmory"
+    )
+    db.save_book.assert_not_called()
+
+
+def test_link_grimmory_audiobook_returns_conflict_on_concurrent_unique_claim():
+    service, db, _abs, _bl, _hc = _make_service(kosync_id="ebook-hash")
+    service.container.grimmory_client_group.return_value.find_audiobook_by_source_id.return_value = {"id": 10}
+    db.get_book_by_grimmory_audio_source_id.return_value = None
+    db.get_book_by_kosync_id.return_value = None
+    db.claim_detected_book.return_value = "owner-token"
+    db.renew_detected_book_claim.return_value = True
+    db.save_book.side_effect = IntegrityError("unique", {}, None)
+
+    result = service.link_grimmory_audiobook_ebook(
+        audio_source_id="default:10:42",
+        ebook_filename="book.epub",
+        detected_source="grimmory",
+        detected_source_id="default:10:42",
+    )
+
+    assert result.status_code == 409
+    db.restore_detected_book.assert_called_once_with(
+        "default:10:42", "owner-token", source="grimmory"
+    )
 
 
 def test_map_audiobook_ebook_merges_duplicate_book_data_and_metadata():

--- a/tests/test_epub_path_security.py
+++ b/tests/test_epub_path_security.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+from src.blueprints.helpers import find_ebook_file
+from src.utils.epub_resolver import get_local_epub
+
+
+def test_find_ebook_file_rejects_parent_traversal(tmp_path):
+    outside = tmp_path / "outside.epub"
+    outside.write_bytes(b"outside")
+    books = tmp_path / "books"
+    books.mkdir()
+
+    assert find_ebook_file("../outside.epub", ebook_dir=books) is None
+
+
+def test_find_ebook_file_rejects_symlink_escape(tmp_path):
+    outside = tmp_path / "outside.epub"
+    outside.write_bytes(b"outside")
+    books = tmp_path / "books"
+    books.mkdir()
+    (books / "linked.epub").symlink_to(outside)
+
+    assert find_ebook_file("linked.epub", ebook_dir=books) is None
+
+
+def test_epub_resolver_rejects_remote_traversal_filename(tmp_path):
+    grimmory = Mock()
+    grimmory.is_configured.return_value = True
+
+    result = get_local_epub("../outside.epub", tmp_path / "books", tmp_path / "cache", grimmory)
+
+    assert result is None
+    grimmory.find_book_by_filename.assert_not_called()
+
+
+def test_epub_resolver_rejects_cache_symlink_escape(tmp_path):
+    books = tmp_path / "books"
+    books.mkdir()
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    outside = tmp_path / "outside.epub"
+    outside.write_bytes(b"outside")
+    (cache / "book.epub").symlink_to(outside)
+    grimmory = Mock()
+    grimmory.is_configured.return_value = False
+
+    assert get_local_epub("book.epub", books, cache, grimmory) is None

--- a/tests/test_grimmory_audio_migration.py
+++ b/tests/test_grimmory_audio_migration.py
@@ -1,0 +1,46 @@
+import sqlite3
+from pathlib import Path
+
+from alembic.config import Config
+
+from alembic import command
+
+
+def _config(db_path):
+    root = Path(__file__).parent.parent
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "alembic"))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return config
+
+
+def test_grimmory_audio_identity_migration_round_trip(tmp_path):
+    db_path = tmp_path / "migration.db"
+    config = _config(db_path)
+    command.upgrade(config, "z7a8b9c0d1e2")
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "INSERT INTO detected_books (source, source_id, title, progress_percentage) VALUES (?, ?, ?, ?)",
+            ("abs", "abs-1", "Audio", 0.2),
+        )
+        connection.execute(
+            "INSERT INTO detected_books (source, source_id, title, progress_percentage) VALUES (?, ?, ?, ?)",
+            ("grimmory", "default:book.epub", "Ebook", 0.2),
+        )
+
+    command.upgrade(config, "head")
+    with sqlite3.connect(db_path) as connection:
+        assert dict(connection.execute("SELECT source, media_format FROM detected_books")) == {
+            "abs": "audiobook",
+            "grimmory": "ebook",
+        }
+        book_columns = {row[1] for row in connection.execute("PRAGMA table_info(books)")}
+        assert "grimmory_audio_source_id" in book_columns
+
+    command.downgrade(config, "z7a8b9c0d1e2")
+    with sqlite3.connect(db_path) as connection:
+        detected_columns = {row[1] for row in connection.execute("PRAGMA table_info(detected_books)")}
+        book_columns = {row[1] for row in connection.execute("PRAGMA table_info(books)")}
+        assert "media_format" not in detected_columns
+        assert "grimmory_audio_source_id" not in book_columns

--- a/tests/test_grimmory_audio_sync_client.py
+++ b/tests/test_grimmory_audio_sync_client.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from src.sync_clients.grimmory_sync_client import GrimmoryAudioSyncClient
+from src.sync_clients.sync_client_interface import LocatorResult, ServiceState, SyncResult, UpdateProgressRequest
+from src.sync_manager import SyncManager
+
+
+def _audio_book():
+    return {
+        "id": 10,
+        "fileName": "audio.m4b",
+        "bookType": "M4B",
+        "bookFileId": 42,
+        "audiobookProgress": {"percentage": 35},
+    }
+
+
+def test_grimmory_audio_sync_client_uses_exact_identity_for_read_and_write():
+    api = Mock()
+    api.is_configured.return_value = True
+    api.get_all_books.return_value = [_audio_book(), {"id": 20, "bookType": "EPUB"}]
+    api.audio_source_id.side_effect = lambda book: "default:10:42" if book.get("bookType") == "M4B" else None
+    api.extract_progress.return_value = (0.35, None)
+    api.update_audiobook_progress.return_value = True
+    client = GrimmoryAudioSyncClient(api, Mock(), client_name="GrimmoryAudio")
+    book = SimpleNamespace(id=7, grimmory_audio_source_id="default:10:42")
+
+    bulk = client.fetch_bulk_state()
+    state = client.get_service_state(book, None, bulk_context=bulk)
+    result = client.update_progress(book, UpdateProgressRequest(LocatorResult(percentage=0.6)))
+
+    assert set(bulk) == {"default:10:42"}
+    assert state.current["pct"] == pytest.approx(0.35)
+    assert client.get_supported_sync_types() == {"audiobook"}
+    api.update_audiobook_progress.assert_called_once_with("default:10:42", 0.6)
+    assert result == SyncResult(0.6, True, {"pct": 0.6})
+
+
+def test_sync_manager_uses_synthetic_state_identity_without_abs():
+    manager = object.__new__(SyncManager)
+    leader = Mock()
+    leader.get_text_from_current_state.return_value = "chapter text"
+    leader.get_locator_from_text.return_value = LocatorResult(percentage=0.4)
+    follower = Mock()
+    follower.update_progress.return_value = SyncResult(0.4, True, {"pct": 0.4})
+    manager.sync_clients = {"GrimmoryAudio": leader, "KoSync": follower}
+    manager.database_service = Mock()
+    manager._determine_leader = Mock(return_value=("GrimmoryAudio", 0.4))
+    book = SimpleNamespace(id=7, abs_id=None, title="Book", ebook_filename="book.epub")
+    config = {
+        "GrimmoryAudio": ServiceState(
+            current={"pct": 0.4},
+            previous_pct=0.2,
+            delta=0.2,
+            threshold=0.01,
+            is_configured=True,
+            display=("GrimmoryAudio", ""),
+            value_formatter=str,
+        ),
+        "KoSync": ServiceState(
+            current={"pct": 0.2},
+            previous_pct=0.2,
+            delta=0,
+            threshold=0.01,
+            is_configured=True,
+            display=("KoSync", ""),
+            value_formatter=str,
+        ),
+    }
+
+    manager._execute_sync_update(book, config, "book-7", "Book", manager.sync_clients)
+
+    saved_states = [call.args[0] for call in manager.database_service.save_state.call_args_list]
+    assert len(saved_states) == 2
+    assert {state.abs_id for state in saved_states} == {"book-7"}
+
+
+def test_di_registers_each_grimmory_audio_instance():
+    from src.utils.di_container import Container
+
+    assert {"GrimmoryAudio", "Grimmory2Audio"} <= set(Container.sync_clients.kwargs)

--- a/tests/test_grimmory_audio_sync_client.py
+++ b/tests/test_grimmory_audio_sync_client.py
@@ -12,7 +12,7 @@ def _audio_book():
     return {
         "id": 10,
         "fileName": "audio.m4b",
-        "bookType": "M4B",
+        "bookType": "AUDIOBOOK",
         "bookFileId": 42,
         "audiobookProgress": {"percentage": 35},
     }
@@ -22,7 +22,7 @@ def test_grimmory_audio_sync_client_uses_exact_identity_for_read_and_write():
     api = Mock()
     api.is_configured.return_value = True
     api.get_all_books.return_value = [_audio_book(), {"id": 20, "bookType": "EPUB"}]
-    api.audio_source_id.side_effect = lambda book: "default:10:42" if book.get("bookType") == "M4B" else None
+    api.audio_source_id.side_effect = lambda book: "default:10:42" if book.get("bookType") == "AUDIOBOOK" else None
     api.extract_progress.return_value = (0.35, None)
     api.update_audiobook_progress.return_value = True
     client = GrimmoryAudioSyncClient(api, Mock(), client_name="GrimmoryAudio")
@@ -76,6 +76,36 @@ def test_sync_manager_uses_synthetic_state_identity_without_abs():
     saved_states = [call.args[0] for call in manager.database_service.save_state.call_args_list]
     assert len(saved_states) == 2
     assert {state.abs_id for state in saved_states} == {"book-7"}
+
+
+@pytest.mark.parametrize(
+    ("source_id", "expected_audio_client"),
+    [("default:10:42", "GrimmoryAudio"), ("2:10:42", "Grimmory2Audio")],
+)
+def test_audio_only_sync_uses_only_the_qualified_grimmory_instance(source_id, expected_audio_client):
+    manager = object.__new__(SyncManager)
+    manager.alignment_service = None
+    manager.database_service = Mock()
+    manager.database_service.get_states_for_book.return_value = []
+    manager.sync_clients = {}
+    for name in ("ABS", "Hardcover", "GrimmoryAudio", "Grimmory2Audio", "KoSync"):
+        client = Mock()
+        client.get_supported_sync_types.return_value = {"audiobook"}
+        manager.sync_clients[name] = client
+    manager._fetch_states_parallel = Mock(return_value={})
+    book = SimpleNamespace(
+        id=7,
+        abs_id=None,
+        title="Book",
+        sync_mode="audiobook",
+        kosync_doc_id=None,
+        grimmory_audio_source_id=source_id,
+    )
+
+    manager._sync_single_book(book, {})
+
+    active_clients = manager._fetch_states_parallel.call_args.args[-1]
+    assert set(active_clients) == {"ABS", "Hardcover", expected_audio_client}
 
 
 def test_di_registers_each_grimmory_audio_instance():

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -137,7 +137,7 @@ def test_load_cache_populates_case_insensitive_index_without_full_rebuild(mock_d
     assert client.find_book_by_filename("TWO.epub", allow_refresh=False)["id"] == "second"
 
 
-def test_cache_book_info_updates_same_exact_filename_without_marking_ambiguous(mock_db):
+def test_cache_book_info_updates_same_remote_identity_without_marking_ambiguous(mock_db):
     mock_db.get_all_grimmory_books.return_value = []
 
     with patch.dict(
@@ -146,10 +146,14 @@ def test_cache_book_info_updates_same_exact_filename_without_marking_ambiguous(m
     ):
         client = GrimmoryClient(database_service=mock_db)
 
-    client._cache_book_info("Book.epub", {"id": "old", "fileName": "Book.epub", "title": "Old"})
-    client._cache_book_info("Book.epub", {"id": "new", "fileName": "Book.epub", "title": "New"})
+    client._cache_book_info(
+        "Book.epub", {"id": "book", "bookFileId": "file", "fileName": "Book.epub", "title": "Old"}
+    )
+    client._cache_book_info(
+        "Book.epub", {"id": "book", "bookFileId": "file", "fileName": "Book.epub", "title": "New"}
+    )
 
-    assert client.find_book_by_filename("book.epub", allow_refresh=False)["id"] == "new"
+    assert client.find_book_by_filename("book.epub", allow_refresh=False)["id"] == "book"
     assert client.find_book_by_filename("BOOK.epub", allow_refresh=False)["title"] == "New"
 
 
@@ -186,7 +190,9 @@ def test_refresh_migrates_cached_book_id_to_live_filename_casing(mock_db):
 
     assert set(client._book_cache) == {"Book.epub"}
     assert client.find_book_by_filename("book.epub", allow_refresh=False)["id"] == "777"
-    mock_db.delete_grimmory_book.assert_called_once_with("book.epub", server_id="default")
+    mock_db.delete_grimmory_book.assert_called_once_with(
+        "book.epub", server_id="default", book_id="777", file_id=None
+    )
     saved_book = mock_db.save_grimmory_book.call_args[0][0]
     assert saved_book.filename == "Book.epub"
 
@@ -392,25 +398,113 @@ def test_refresh_prunes_removed_alternative_without_removing_primary_ebook(grimm
     assert set(grimmory_client._book_cache) == {"book.epub"}
     assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
     assert grimmory_client.find_audiobook_by_source_id("default:10:42", allow_refresh=False) is None
-    mock_db.delete_grimmory_book.assert_called_once_with("book.m4b", server_id="default")
+    mock_db.delete_grimmory_book.assert_called_once_with(
+        "book.m4b", server_id="default", book_id=10, file_id=42
+    )
+
+
+def test_reload_retains_duplicate_filenames_by_remote_identity(mock_db):
+    rows = [
+        GrimmoryBook(
+            filename="shared.m4b",
+            raw_metadata=json.dumps(
+                {"id": 10, "bookFileId": 41, "fileName": "shared.m4b", "bookType": "AUDIOBOOK"}
+            ),
+            remote_book_id=10,
+            remote_file_id=41,
+        ),
+        GrimmoryBook(
+            filename="shared.m4b",
+            raw_metadata=json.dumps(
+                {"id": 20, "bookFileId": 42, "fileName": "shared.m4b", "bookType": "AUDIOBOOK"}
+            ),
+            remote_book_id=20,
+            remote_file_id=42,
+        ),
+    ]
+    rows[0].id, rows[1].id = 1, 2
+    mock_db.get_all_grimmory_books.return_value = rows
+
+    with patch.dict(
+        os.environ,
+        {"GRIMMORY_SERVER": "http://mock", "GRIMMORY_USER": "u", "GRIMMORY_PASSWORD": "p"},
+        clear=True,
+    ):
+        client = GrimmoryClient(database_service=mock_db)
+
+    assert len(client.get_all_books()) == 2
+    assert client.find_book_by_filename("shared.m4b", allow_refresh=False) is None
+    assert client.find_audiobook_by_source_id("default:10:41", allow_refresh=False)["id"] == 10
+    assert client.find_audiobook_by_source_id("default:20:42", allow_refresh=False)["id"] == 20
+
+
+def test_refresh_prunes_only_exact_same_filename_identity(grimmory_client, mock_db):
+    first = {
+        "id": 10,
+        "primaryFile": {"id": 41, "fileName": "shared.m4b", "bookType": "AUDIOBOOK"},
+    }
+    second = {
+        "id": 20,
+        "primaryFile": {"id": 42, "fileName": "shared.m4b", "bookType": "AUDIOBOOK"},
+    }
+    grimmory_client._process_book_detail(first)
+    grimmory_client._process_book_detail(second)
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"content": [second], "last": True}
+    grimmory_client._make_request = MagicMock(return_value=response)
+    mock_db.reset_mock()
+
+    assert grimmory_client._refresh_book_cache() is True
+
+    assert [book["id"] for book in grimmory_client.get_all_books()] == [20]
+    assert grimmory_client.find_book_by_filename("shared.m4b", allow_refresh=False)["id"] == 20
+    mock_db.delete_grimmory_book.assert_called_once_with(
+        "shared.m4b", server_id="default", book_id=10, file_id=41
+    )
+
+
+def test_target_library_filter_does_not_end_pagination_early(grimmory_client):
+    first_page = [
+        {
+            "id": index,
+            "libraryId": "other",
+            "primaryFile": {"id": index, "fileName": f"other-{index}.epub", "bookType": "EPUB"},
+        }
+        for index in range(200)
+    ]
+    target = {
+        "id": 999,
+        "libraryId": "target",
+        "primaryFile": {"id": 88, "fileName": "target.epub", "bookType": "EPUB"},
+    }
+    responses = [
+        MagicMock(status_code=200, **{"json.return_value": {"content": first_page, "last": False}}),
+        MagicMock(status_code=200, **{"json.return_value": {"content": [target], "last": True}}),
+    ]
+    grimmory_client._make_request = MagicMock(side_effect=responses)
+
+    with patch.dict(os.environ, {"GRIMMORY_LIBRARY_ID": "target"}):
+        assert grimmory_client._refresh_book_cache() is True
+
+    assert grimmory_client._make_request.call_count == 2
+    assert grimmory_client.find_book_by_filename("target.epub", allow_refresh=False)["id"] == 999
 
 
 def test_update_progress_file_progress(grimmory_client):
     """When bookFileId is present, use modern fileProgress payload."""
     from src.sync_clients.sync_client_interface import LocatorResult
 
-    grimmory_client._book_cache = {
-        "test.epub": {
-            "id": 10,
-            "fileName": "test.epub",
-            "bookType": "EPUB",
-            "bookFileId": 42,
-            "epubProgress": None,
-            "pdfProgress": None,
-            "cbxProgress": None,
-        }
+    book = {
+        "id": 10,
+        "fileName": "test.epub",
+        "bookType": "EPUB",
+        "bookFileId": 42,
+        "epubProgress": None,
+        "pdfProgress": None,
+        "cbxProgress": None,
     }
-    grimmory_client._book_id_cache = {10: grimmory_client._book_cache["test.epub"]}
+    grimmory_client._reset_book_caches()
+    grimmory_client._cache_book_info("test.epub", book)
     grimmory_client._cache_timestamp = 9999999999
 
     mock_resp = MagicMock()
@@ -432,17 +526,16 @@ def test_update_progress_file_progress(grimmory_client):
 
 def test_update_progress_legacy_fallback(grimmory_client):
     """When bookFileId is missing, fall back to legacy format."""
-    grimmory_client._book_cache = {
-        "test.epub": {
-            "id": 10,
-            "fileName": "test.epub",
-            "bookType": "EPUB",
-            "epubProgress": None,
-            "pdfProgress": None,
-            "cbxProgress": None,
-        }
+    book = {
+        "id": 10,
+        "fileName": "test.epub",
+        "bookType": "EPUB",
+        "epubProgress": None,
+        "pdfProgress": None,
+        "cbxProgress": None,
     }
-    grimmory_client._book_id_cache = {10: grimmory_client._book_cache["test.epub"]}
+    grimmory_client._reset_book_caches()
+    grimmory_client._cache_book_info("test.epub", book)
     grimmory_client._cache_timestamp = 9999999999
 
     mock_resp = MagicMock()
@@ -459,17 +552,16 @@ def test_update_progress_legacy_fallback(grimmory_client):
 
 def test_update_progress_no_page_field(grimmory_client):
     """PDF/CBX legacy payload must not include page field."""
-    grimmory_client._book_cache = {
-        "test.pdf": {
-            "id": 20,
-            "fileName": "test.pdf",
-            "bookType": "PDF",
-            "epubProgress": None,
-            "pdfProgress": None,
-            "cbxProgress": None,
-        }
+    book = {
+        "id": 20,
+        "fileName": "test.pdf",
+        "bookType": "PDF",
+        "epubProgress": None,
+        "pdfProgress": None,
+        "cbxProgress": None,
     }
-    grimmory_client._book_id_cache = {20: grimmory_client._book_cache["test.pdf"]}
+    grimmory_client._reset_book_caches()
+    grimmory_client._cache_book_info("test.pdf", book)
     grimmory_client._cache_timestamp = 9999999999
 
     mock_resp = MagicMock()

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -10,7 +10,7 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.api.grimmory_client import GrimmoryClient
+from src.api.grimmory_client import GrimmoryClient, GrimmoryClientGroup
 from src.db.models import GrimmoryBook
 
 
@@ -190,10 +190,8 @@ def test_refresh_migrates_cached_book_id_to_live_filename_casing(mock_db):
 
     assert set(client._book_cache) == {"Book.epub"}
     assert client.find_book_by_filename("book.epub", allow_refresh=False)["id"] == "777"
-    mock_db.delete_grimmory_book.assert_called_once_with(
-        "book.epub", server_id="default", book_id="777", file_id=None
-    )
-    saved_book = mock_db.save_grimmory_book.call_args[0][0]
+    mock_db.reconcile_grimmory_books.assert_called_once()
+    saved_book = mock_db.reconcile_grimmory_books.call_args.args[1][0]
     assert saved_book.filename == "Book.epub"
 
 
@@ -267,8 +265,8 @@ def test_save_to_db_on_fetch(mock_db):
         client._refresh_book_cache()
 
         # Verify processing happened
-        mock_db.save_grimmory_book.assert_called()
-        saved_book = mock_db.save_grimmory_book.call_args[0][0]
+        mock_db.reconcile_grimmory_books.assert_called_once()
+        saved_book = mock_db.reconcile_grimmory_books.call_args.args[1][0]
         assert saved_book.filename == "newbook.epub"
 
 
@@ -378,6 +376,14 @@ def test_processes_primary_and_alternative_formats_with_exact_file_identity(grim
     assert grimmory_client._book_id_cache[10]["fileName"] == detail["primaryFile"]["fileName"]
     assert grimmory_client.find_audiobook_by_source_id("default:10:42", allow_refresh=False)["fileName"] == "book.m4b"
     assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
+    ebook_source_id = "default:10:41"
+    assert grimmory_client.find_book_file_by_source_id(ebook_source_id, allow_refresh=False)["bookType"] == "EPUB"
+    assert grimmory_client.find_audiobook_by_source_id(ebook_source_id, allow_refresh=False) is None
+    assert grimmory_client.get_book_file_progress(ebook_source_id) == (pytest.approx(0.2), None)
+
+    group = GrimmoryClientGroup([grimmory_client])
+    assert group.find_book_file_by_source_id(ebook_source_id, allow_refresh=False)["_instance_id"] == "default"
+    assert group.get_book_file_progress(ebook_source_id) == (pytest.approx(0.2), None)
 
 
 def test_downloads_exact_alternative_file_and_rejects_stale_identity(grimmory_client):
@@ -397,7 +403,9 @@ def test_downloads_exact_alternative_file_and_rejects_stale_identity(grimmory_cl
     assert grimmory_client.session.get.call_args.args[0].endswith("/api/v1/books/10/files/42/download")
 
     grimmory_client.session.get.reset_mock()
+    grimmory_client._refresh_book_cache = MagicMock(return_value=False)
     assert grimmory_client.download_book(10, file_id=99) is None
+    grimmory_client._refresh_book_cache.assert_called_once_with()
     grimmory_client.session.get.assert_not_called()
 
     grimmory_client.session.get.side_effect = [
@@ -428,9 +436,8 @@ def test_refresh_prunes_removed_alternative_without_removing_primary_ebook(grimm
     assert set(grimmory_client._book_cache) == {"book.epub"}
     assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
     assert grimmory_client.find_audiobook_by_source_id("default:10:42", allow_refresh=False) is None
-    mock_db.delete_grimmory_book.assert_called_once_with(
-        "book.m4b", server_id="default", book_id=10, file_id=42
-    )
+    reconciled = mock_db.reconcile_grimmory_books.call_args.args[1]
+    assert [(book.remote_book_id, book.remote_file_id) for book in reconciled] == [("10", "41")]
 
 
 def test_reload_retains_duplicate_filenames_by_remote_identity(mock_db):
@@ -488,9 +495,8 @@ def test_refresh_prunes_only_exact_same_filename_identity(grimmory_client, mock_
 
     assert [book["id"] for book in grimmory_client.get_all_books()] == [20]
     assert grimmory_client.find_book_by_filename("shared.m4b", allow_refresh=False)["id"] == 20
-    mock_db.delete_grimmory_book.assert_called_once_with(
-        "shared.m4b", server_id="default", book_id=10, file_id=41
-    )
+    reconciled = mock_db.reconcile_grimmory_books.call_args.args[1]
+    assert [(book.remote_book_id, book.remote_file_id) for book in reconciled] == [("20", "42")]
 
 
 def test_target_library_filter_does_not_end_pagination_early(grimmory_client):
@@ -518,6 +524,66 @@ def test_target_library_filter_does_not_end_pagination_early(grimmory_client):
 
     assert grimmory_client._make_request.call_count == 2
     assert grimmory_client.find_book_by_filename("target.epub", allow_refresh=False)["id"] == 999
+
+
+def test_repeated_raw_list_page_stops_pagination(grimmory_client):
+    page = [
+        {
+            "id": index,
+            "primaryFile": {"id": index, "fileName": f"book-{index}.epub", "bookType": "EPUB"},
+        }
+        for index in range(200)
+    ]
+    response = MagicMock(status_code=200)
+    response.json.return_value = page
+    grimmory_client._make_request = MagicMock(return_value=response)
+
+    assert grimmory_client._refresh_book_cache() is True
+    assert grimmory_client._make_request.call_count == 2
+
+
+def test_pagination_has_hard_page_ceiling(grimmory_client):
+    responses = []
+    for page_number in range(2):
+        content = [
+            {
+                "id": page_number * 200 + index,
+                "primaryFile": {
+                    "id": page_number * 200 + index,
+                    "fileName": f"book-{page_number}-{index}.epub",
+                    "bookType": "EPUB",
+                },
+            }
+            for index in range(200)
+        ]
+        responses.append(MagicMock(status_code=200, **{"json.return_value": content}))
+    grimmory_client._make_request = MagicMock(side_effect=responses)
+
+    with patch("src.api.grimmory_client.GRIMMORY_MAX_PAGES", 2):
+        assert grimmory_client._refresh_book_cache() is True
+
+    assert grimmory_client._make_request.call_count == 2
+
+
+def test_large_refresh_uses_one_database_reconciliation_call(grimmory_client, mock_db):
+    content = [
+        {
+            "id": index,
+            "primaryFile": {"id": index, "fileName": f"book-{index}.epub", "bookType": "EPUB"},
+        }
+        for index in range(300)
+    ]
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"content": content, "last": True}
+    grimmory_client._make_request = MagicMock(return_value=response)
+    mock_db.reset_mock()
+
+    assert grimmory_client._refresh_book_cache() is True
+
+    mock_db.reconcile_grimmory_books.assert_called_once()
+    assert len(mock_db.reconcile_grimmory_books.call_args.args[1]) == 300
+    mock_db.save_grimmory_book.assert_not_called()
+    mock_db.delete_grimmory_book.assert_not_called()
 
 
 def test_update_progress_file_progress(grimmory_client):

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -311,6 +311,48 @@ def test_extract_progress_zero(grimmory_client):
     assert cfi is None
 
 
+@pytest.mark.parametrize("book_type", ["M4B", "M4A", "MP3", "OPUS"])
+def test_exact_audiobook_identity_and_progress(grimmory_client, book_type):
+    book = {
+        "id": 10,
+        "fileName": f"audio.{book_type.lower()}",
+        "bookType": book_type,
+        "bookFileId": 42,
+        "audiobookProgress": {"percentage": 37.5, "positionMs": 1200, "trackIndex": 1},
+    }
+    grimmory_client._book_cache = {book["fileName"]: book}
+    grimmory_client._book_id_cache = {10: book}
+    grimmory_client._cache_timestamp = 9999999999
+
+    assert grimmory_client.audio_source_id(book) == "default:10:42"
+    assert grimmory_client.find_audiobook_by_source_id("default:10:42") is book
+    assert grimmory_client.find_audiobook_by_source_id("2:10:42") is None
+    assert grimmory_client.find_audiobook_by_source_id("default:10:99") is None
+    assert grimmory_client.get_audiobook_progress("default:10:42") == (pytest.approx(0.375), None)
+
+
+def test_update_exact_audiobook_uses_file_progress(grimmory_client):
+    book = {
+        "id": 10,
+        "fileName": "audio.m4b",
+        "bookType": "M4B",
+        "bookFileId": 42,
+        "audiobookProgress": {"percentage": 10},
+    }
+    grimmory_client._book_cache = {book["fileName"]: book}
+    grimmory_client._book_id_cache = {10: book}
+    grimmory_client._cache_timestamp = 9999999999
+    response = MagicMock(status_code=200)
+    grimmory_client._make_request = MagicMock(return_value=response)
+
+    assert grimmory_client.update_audiobook_progress("default:10:42", 0.5) is True
+    assert grimmory_client._make_request.call_args.args[2] == {
+        "bookId": 10,
+        "fileProgress": {"bookFileId": 42, "progressPercent": 50.0},
+    }
+    assert book["audiobookProgress"]["percentage"] == 50.0
+
+
 def test_update_progress_file_progress(grimmory_client):
     """When bookFileId is present, use modern fileProgress payload."""
     from src.sync_clients.sync_client_interface import LocatorResult

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -380,6 +380,36 @@ def test_processes_primary_and_alternative_formats_with_exact_file_identity(grim
     assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
 
 
+def test_downloads_exact_alternative_file_and_rejects_stale_identity(grimmory_client):
+    grimmory_client._process_book_detail(
+        {
+            "id": 10,
+            "primaryFile": {"id": 41, "fileName": "book.m4b", "bookType": "AUDIOBOOK"},
+            "alternativeFormats": [{"id": 42, "fileName": "book.epub", "bookType": "EPUB"}],
+        }
+    )
+    grimmory_client._token = "token"
+    grimmory_client._token_timestamp = 9999999999
+    response = MagicMock(status_code=200, content=b"alternative epub")
+    grimmory_client.session.get = MagicMock(return_value=response)
+
+    assert grimmory_client.download_book(10, file_id=42) == b"alternative epub"
+    assert grimmory_client.session.get.call_args.args[0].endswith("/api/v1/books/10/files/42/download")
+
+    grimmory_client.session.get.reset_mock()
+    assert grimmory_client.download_book(10, file_id=99) is None
+    grimmory_client.session.get.assert_not_called()
+
+    grimmory_client.session.get.side_effect = [
+        MagicMock(status_code=404),
+        MagicMock(status_code=200, content=b"primary file"),
+    ]
+    assert grimmory_client.download_book(10) == b"primary file"
+    requested_urls = [call.args[0] for call in grimmory_client.session.get.call_args_list]
+    assert requested_urls[0].endswith("/api/v1/books/10/download")
+    assert requested_urls[1].endswith("/api/v1/books/10/file")
+
+
 def test_refresh_prunes_removed_alternative_without_removing_primary_ebook(grimmory_client, mock_db):
     detail = {
         "id": 10,

--- a/tests/test_grimmory_client.py
+++ b/tests/test_grimmory_client.py
@@ -311,17 +311,17 @@ def test_extract_progress_zero(grimmory_client):
     assert cfi is None
 
 
-@pytest.mark.parametrize("book_type", ["M4B", "M4A", "MP3", "OPUS"])
-def test_exact_audiobook_identity_and_progress(grimmory_client, book_type):
+@pytest.mark.parametrize("extension", ["m4b", "m4a", "mp3", "opus"])
+def test_exact_audiobook_identity_and_progress(grimmory_client, extension):
     book = {
         "id": 10,
-        "fileName": f"audio.{book_type.lower()}",
-        "bookType": book_type,
+        "fileName": f"audio.{extension}",
+        "bookType": "AUDIOBOOK",
         "bookFileId": 42,
         "audiobookProgress": {"percentage": 37.5, "positionMs": 1200, "trackIndex": 1},
     }
-    grimmory_client._book_cache = {book["fileName"]: book}
-    grimmory_client._book_id_cache = {10: book}
+    grimmory_client._reset_book_caches()
+    grimmory_client._cache_book_info(book["fileName"], book)
     grimmory_client._cache_timestamp = 9999999999
 
     assert grimmory_client.audio_source_id(book) == "default:10:42"
@@ -335,12 +335,12 @@ def test_update_exact_audiobook_uses_file_progress(grimmory_client):
     book = {
         "id": 10,
         "fileName": "audio.m4b",
-        "bookType": "M4B",
+        "bookType": "AUDIOBOOK",
         "bookFileId": 42,
         "audiobookProgress": {"percentage": 10},
     }
-    grimmory_client._book_cache = {book["fileName"]: book}
-    grimmory_client._book_id_cache = {10: book}
+    grimmory_client._reset_book_caches()
+    grimmory_client._cache_book_info(book["fileName"], book)
     grimmory_client._cache_timestamp = 9999999999
     response = MagicMock(status_code=200)
     grimmory_client._make_request = MagicMock(return_value=response)
@@ -351,6 +351,48 @@ def test_update_exact_audiobook_uses_file_progress(grimmory_client):
         "fileProgress": {"bookFileId": 42, "progressPercent": 50.0},
     }
     assert book["audiobookProgress"]["percentage"] == 50.0
+
+
+@pytest.mark.parametrize("audio_is_primary", [False, True])
+def test_processes_primary_and_alternative_formats_with_exact_file_identity(grimmory_client, audio_is_primary):
+    ebook = {"id": 41, "fileName": "book.epub", "bookType": "EPUB"}
+    audio = {"id": 42, "fileName": "book.m4b", "bookType": "AUDIOBOOK"}
+    detail = {
+        "id": 10,
+        "primaryFile": audio if audio_is_primary else ebook,
+        "alternativeFormats": [ebook if audio_is_primary else audio],
+        "metadata": {"title": "Book", "authors": [{"name": "Author"}]},
+        "epubProgress": {"percentage": 20},
+        "audiobookProgress": {"percentage": 35},
+    }
+
+    grimmory_client._process_book_detail(detail)
+
+    assert set(grimmory_client._book_cache) == {"book.epub", "book.m4b"}
+    assert grimmory_client._book_id_cache[10]["fileName"] == detail["primaryFile"]["fileName"]
+    assert grimmory_client.find_audiobook_by_source_id("default:10:42", allow_refresh=False)["fileName"] == "book.m4b"
+    assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
+
+
+def test_refresh_prunes_removed_alternative_without_removing_primary_ebook(grimmory_client, mock_db):
+    detail = {
+        "id": 10,
+        "primaryFile": {"id": 41, "fileName": "book.epub", "bookType": "EPUB"},
+        "alternativeFormats": [{"id": 42, "fileName": "book.m4b", "bookType": "AUDIOBOOK"}],
+        "metadata": {"title": "Book", "authors": ["Author"]},
+    }
+    grimmory_client._process_book_detail(detail)
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"content": [{**detail, "alternativeFormats": []}]}
+    grimmory_client._make_request = MagicMock(return_value=response)
+    mock_db.reset_mock()
+
+    assert grimmory_client._refresh_book_cache() is True
+
+    assert set(grimmory_client._book_cache) == {"book.epub"}
+    assert grimmory_client.find_book_by_filename("book.epub", allow_refresh=False)["bookFileId"] == 41
+    assert grimmory_client.find_audiobook_by_source_id("default:10:42", allow_refresh=False) is None
+    mock_db.delete_grimmory_book.assert_called_once_with("book.m4b", server_id="default")
 
 
 def test_update_progress_file_progress(grimmory_client):

--- a/tests/test_grimmory_repository.py
+++ b/tests/test_grimmory_repository.py
@@ -183,6 +183,53 @@ def test_remote_identity_retains_same_filename_rows_and_deletes_exactly_one(repo
     assert [(row.remote_book_id, row.remote_file_id) for row in rows] == [("20", "42")]
 
 
+def test_bulk_reconcile_upserts_snapshot_and_prunes_stale_exact_rows(repository):
+    repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="old.epub",
+            title="Old",
+            server_id="test",
+            remote_book_id="10",
+            remote_file_id="41",
+        )
+    )
+    repository.save_grimmory_book(
+        GrimmoryBook(
+            filename="stale.epub",
+            title="Stale",
+            server_id="test",
+            remote_book_id="20",
+            remote_file_id="42",
+        )
+    )
+
+    repository.reconcile_grimmory_books(
+        "test",
+        [
+            GrimmoryBook(
+                filename="renamed.epub",
+                title="Updated",
+                server_id="test",
+                remote_book_id="10",
+                remote_file_id="41",
+            ),
+            GrimmoryBook(
+                filename="new.epub",
+                title="New",
+                server_id="test",
+                remote_book_id="30",
+                remote_file_id="43",
+            ),
+        ],
+    )
+
+    rows = repository.get_all_grimmory_books(server_id="test")
+    assert sorted((row.remote_book_id, row.remote_file_id, row.filename) for row in rows) == [
+        ("10", "41", "renamed.epub"),
+        ("30", "43", "new.epub"),
+    ]
+
+
 def test_save_grimmory_book_updates_preexisting_row(repository):
     """A row already committed by another writer is updated in place rather
     than duplicated when save sees the same identity."""

--- a/tests/test_grimmory_repository.py
+++ b/tests/test_grimmory_repository.py
@@ -161,6 +161,28 @@ def test_save_grimmory_book_distinguishes_by_server_id(repository):
     assert repository.get_grimmory_book("shared.epub", server_id="b").title == "Server B"
 
 
+def test_remote_identity_retains_same_filename_rows_and_deletes_exactly_one(repository):
+    for book_id, file_id in (("10", "41"), ("20", "42")):
+        repository.save_grimmory_book(
+            GrimmoryBook(
+                filename="shared.m4b",
+                title=f"Book {book_id}",
+                raw_metadata=json.dumps({"id": book_id, "bookFileId": file_id}),
+                server_id="test",
+                remote_book_id=book_id,
+                remote_file_id=file_id,
+            )
+        )
+
+    assert repository.get_grimmory_book("shared.m4b", server_id="test") is None
+    assert repository.get_grimmory_book_by_remote_id("10", "41", server_id="test").title == "Book 10"
+    assert repository.delete_grimmory_book(
+        "shared.m4b", server_id="test", book_id="10", file_id="41"
+    )
+    rows = repository.get_all_grimmory_books(server_id="test")
+    assert [(row.remote_book_id, row.remote_file_id) for row in rows] == [("20", "42")]
+
+
 def test_save_grimmory_book_updates_preexisting_row(repository):
     """A row already committed by another writer is updated in place rather
     than duplicated when save sees the same identity."""

--- a/tests/test_grimmory_repository.py
+++ b/tests/test_grimmory_repository.py
@@ -230,6 +230,17 @@ def test_bulk_reconcile_upserts_snapshot_and_prunes_stale_exact_rows(repository)
     ]
 
 
+@pytest.mark.parametrize("raw_metadata", ["not-json", "[]"])
+def test_bulk_reconcile_prunes_malformed_legacy_rows(repository, raw_metadata):
+    repository.save_grimmory_book(
+        GrimmoryBook(filename="stale.epub", server_id="test", raw_metadata=raw_metadata)
+    )
+
+    repository.reconcile_grimmory_books("test", [])
+
+    assert repository.get_all_grimmory_books(server_id="test") == []
+
+
 def test_save_grimmory_book_updates_preexisting_row(repository):
     """A row already committed by another writer is updated in place rather
     than duplicated when save sees the same identity."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -60,6 +60,18 @@ def test_get_kosync_id_downloads_selected_alternative_file(flask_app, mock_conta
     )
 
 
+def test_get_kosync_id_rejects_untrusted_remote_filename(flask_app):
+    bl_client = Mock()
+    bl_client.is_configured.return_value = True
+
+    with flask_app.app_context():
+        from src.blueprints.helpers import get_kosync_id_for_ebook
+
+        assert get_kosync_id_for_ebook("../escape.epub", grimmory_id=10, bl_client=bl_client) is None
+
+    bl_client.download_book.assert_not_called()
+
+
 def test_get_kosync_id_abs_download_raises(flask_app, mock_container):
     """When ABS on-demand download raises, should return None gracefully."""
     mock_container.mock_abs_client.is_configured.return_value = True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -37,6 +37,29 @@ def test_get_kosync_id_grimmory_download_returns_none(flask_app, mock_container)
     assert result is None
 
 
+def test_get_kosync_id_downloads_selected_alternative_file(flask_app, mock_container):
+    bl_client = Mock()
+    bl_client.is_configured.return_value = True
+    bl_client.download_book.return_value = b"selected alternative epub"
+    mock_container.mock_ebook_parser.get_kosync_id_from_bytes.return_value = "alternative-hash"
+
+    with flask_app.app_context():
+        from src.blueprints.helpers import get_kosync_id_for_ebook
+
+        result = get_kosync_id_for_ebook(
+            "book.epub",
+            grimmory_id=10,
+            grimmory_file_id=42,
+            bl_client=bl_client,
+        )
+
+    assert result == "alternative-hash"
+    bl_client.download_book.assert_called_once_with(10, file_id=42)
+    mock_container.mock_ebook_parser.get_kosync_id_from_bytes.assert_called_once_with(
+        "book.epub", b"selected alternative epub"
+    )
+
+
 def test_get_kosync_id_abs_download_raises(flask_app, mock_container):
     """When ABS on-demand download raises, should return None gracefully."""
     mock_container.mock_abs_client.is_configured.return_value = True

--- a/tests/test_kosync_service.py
+++ b/tests/test_kosync_service.py
@@ -8,6 +8,7 @@ All tests use mocked database_service and container — no Flask app needed.
 
 import os
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -312,3 +313,50 @@ class TestResolveBestProgress:
 
         result, status = svc.resolve_best_progress("e" * 32, _make_book())
         assert status == 502
+
+
+class TestFindEpubInGrimmory:
+    @staticmethod
+    def _cached_file(*, book_id, file_id, filename, book_type):
+        return SimpleNamespace(
+            server_id="default",
+            remote_book_id=str(book_id),
+            remote_file_id=str(file_id),
+            filename=filename,
+            title=filename,
+            raw_metadata_dict={"bookType": book_type},
+        )
+
+    def test_uses_exact_epub_identity_and_deduplicates_rows(self, tmp_path):
+        db = MagicMock()
+        audio = self._cached_file(book_id=10, file_id=41, filename="book.m4b", book_type="AUDIOBOOK")
+        epub = self._cached_file(book_id=10, file_id=42, filename="book.epub", book_type="EPUB")
+        duplicate = self._cached_file(book_id=10, file_id=42, filename="book.epub", book_type="EPUB")
+        db.get_all_grimmory_books.return_value = [audio, epub, duplicate]
+        db.get_kosync_doc_by_grimmory_id.return_value = None
+        container = MagicMock()
+        group = container.grimmory_client_group.return_value
+        group.is_configured.return_value = True
+        group.download_book.return_value = b"epub bytes"
+        container.ebook_parser.return_value.get_kosync_id_from_bytes.return_value = "target-hash"
+        container.data_dir.return_value = tmp_path
+        service = _make_service(db=db, container=container)
+
+        assert service._find_epub_in_grimmory("target-hash") == "default_book.epub"
+
+        group.download_book.assert_called_once_with("default:10", file_id="42")
+        db.get_kosync_doc_by_grimmory_id.assert_called_once_with("default:10:42")
+
+    def test_rejects_untrusted_remote_filename_before_download(self, tmp_path):
+        db = MagicMock()
+        db.get_all_grimmory_books.return_value = [
+            self._cached_file(book_id=10, file_id=42, filename="../escape.epub", book_type="EPUB")
+        ]
+        container = MagicMock()
+        group = container.grimmory_client_group.return_value
+        group.is_configured.return_value = True
+        container.data_dir.return_value = tmp_path
+        service = _make_service(db=db, container=container)
+
+        assert service._find_epub_in_grimmory("target-hash") is None
+        group.download_book.assert_not_called()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,9 +5,10 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
-from src.db.models import Base, Book, BookAlignment, GrimmoryBook, PendingSuggestion
+from src.db.models import Base, Book, BookAlignment, DetectedBook, GrimmoryBook, PendingSuggestion
 
 
 @pytest.fixture
@@ -41,6 +42,27 @@ def test_grimmory_book_model(session):
     retrieved = session.query(GrimmoryBook).filter_by(filename="test.epub").first()
     assert retrieved.title == "Test Title"
     assert retrieved.last_updated is not None
+
+
+def test_grimmory_audio_identity_is_unique_and_detection_format_is_explicit(session):
+    session.add(Book(title="Audio", grimmory_audio_source_id="default:10:42"))
+    session.add(
+        DetectedBook(
+            source="grimmory",
+            source_id="default:10:42",
+            title="Audio",
+            progress_percentage=0.25,
+            media_format="audiobook",
+        )
+    )
+    session.commit()
+
+    assert session.query(Book).one().grimmory_audio_source_id == "default:10:42"
+    assert session.query(DetectedBook).one().media_format == "audiobook"
+
+    session.add(Book(title="Duplicate", grimmory_audio_source_id="default:10:42"))
+    with pytest.raises(IntegrityError):
+        session.commit()
 
 
 def test_pending_suggestion_matches_corrupt_json(session):


### PR DESCRIPTION
## What changed

- preserves exact Grimmory `instance:book:file` identities for audiobook and EPUB files
- adds dedicated Grimmory audiobook sync clients and companion linking through `BookIntakeService`
- downloads exact alternative files and reconciles the Grimmory cache transactionally
- hardens pagination, KoSync recovery, path containment, and concurrent file ownership

## Why

Grimmory now supports audiobooks, but PageKeeper previously treated it as an ebook-only source. Currently Reading needs a safe format-aware foundation before the UI can surface and link activity across Grimmory, KoSync, and Audiobookshelf.

## Impact

This is the backend foundation for the stacked Currently Reading UX PR. It is intentionally user-interface neutral.

## Validation

- 147 focused backend tests passed
- Ruff and diff checks passed
- Alembic head verified at `bb9c0d1e2f3a`
- full stacked suite: 1,337 passed, 3 skipped

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grimmory audiobook sync support with per-file exact identity tracking
> - Introduces `GrimmoryAudioSyncClient` to sync audiobook progress by exact `grimmory_audio_source_id` (formatted as `instance:bookId:fileId`), including bulk state fetching and progress updates via `update_audiobook_progress`.
> - Shifts `GrimmoryClient` from filename-keyed caches to identity-keyed caches (`_book_identity_cache`, `_book_file_cache`) so multiple BookFiles per book (primary + alternatives + audiobooks) are individually tracked.
> - Extends `download_book` to accept a `file_id` and fetch a specific alternative file via `/api/v1/books/{book_id}/files/{file_id}/download`, rejecting stale identities.
> - Adds `link_grimmory_audiobook_ebook` to `BookIntakeService` to atomically link a Grimmory audiobook to an ebook, enforcing KoSync ownership and detection-claim semantics with conflict detection.
> - Adds `grimmory_audio_source_id` (unique) to `Book` and `media_format` (non-null, default `ebook`) to `DetectedBook` via two new Alembic migrations; existing ABS-sourced `detected_books` rows are backfilled as `audiobook`.
> - Replaces uniqueness on `(server_id, filename)` in `grimmory_books` with a conditional unique index on `(server_id, remote_book_id, remote_file_id)` and adds `reconcile_grimmory_books` for atomic bulk DB reconciliation.
> - Adds `sanitize_filename` and `is_safe_path_within` checks across `epub_resolver.py`, `helpers.py`, and `kosync_service.py` to reject path traversal filenames before any download or cache access.
> - Risk: `grimmory_id` stored on `KosyncDocument` rows now includes the file id (e.g. `server:book:file`), which changes existing stored values on next scan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8aa436. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->